### PR TITLE
[ci] Fix GitHub Actions workflow caching and auto-assign/label-sync configuration (#36)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,9 +4,8 @@ on:
   issues:
     types: [ opened, reopened ]
   pull_request_target:
-    types: [ opened, reopened ]
+    types: [ opened, reopened, synchronize ]
   workflow_call:
-  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -6,6 +6,7 @@ on:
   pull_request_target:
     types: [ opened, reopened ]
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,21 @@
+name: Auto assign PR author
+
+on:
+  issues:
+    types: [ opened, reopened ]
+  pull_request_target:
+    types: [ opened, reopened ]
+  workflow_call:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto assign PR author
+        uses: toshimaru/auto-author-assign@v3.0.1
+        with:
+          repo-token: ${{ github.token }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -38,13 +38,12 @@ jobs:
       - name: Copy labels from issue to PR
         if: steps.extract-issue.outputs.issue_number != ''
         run: |
-          ISSUE_NUM=${{ steps.extract-issue.outputs.issue_number }}
-          PR_NUM=${{ github.event.pull_request.number }}
-
           LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
 
           for label in $LABELS; do
             gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
           done
         env:
+          ISSUE_NUM: ${{ steps.extract-issue.outputs.issue_number }}
+          PR_NUM: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,50 @@
+name: PR Label Sync
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_call:
+    inputs:
+      copy_issue_labels:
+        type: boolean
+        default: true
+        description: "Copy labels from linked issue"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  copy-issue-labels:
+    if: inputs.copy_issue_labels == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from PR
+        id: extract-issue
+        run: |
+          BODY='${{ github.event.pull_request.body }}'
+          TITLE='${{ github.event.pull_request.title }}'
+          
+          ISSUE=$(echo "$BODY $TITLE" | \
+            grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
+            grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
+          
+          if [ -n "$ISSUE" ]; then
+            echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Copy labels from issue to PR
+        if: steps.extract-issue.outputs.issue_number != ''
+        run: |
+          ISSUE_NUM=${{ steps.extract-issue.outputs.issue_number }}
+          PR_NUM=${{ github.event.pull_request.number }}
+          
+          LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
+          
+          for label in $LABELS; do
+            gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -21,6 +21,9 @@ jobs:
     if: inputs.copy_issue_labels == true || github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Extract issue number from PR
         id: extract-issue
         env:
@@ -38,12 +41,13 @@ jobs:
       - name: Copy labels from issue to PR
         if: steps.extract-issue.outputs.issue_number != ''
         run: |
-          LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
+          LABELS=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels --jq '.labels[].name')
 
           for label in $LABELS; do
-            gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
+            gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$label" 2>/dev/null || true
           done
         env:
           ISSUE_NUM: ${{ steps.extract-issue.outputs.issue_number }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   copy-issue-labels:
-    if: inputs.copy_issue_labels == true
+    if: inputs.copy_issue_labels == true || github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - name: Extract issue number from PR
@@ -26,11 +26,11 @@ jobs:
         run: |
           BODY='${{ github.event.pull_request.body }}'
           TITLE='${{ github.event.pull_request.title }}'
-          
+
           ISSUE=$(echo "$BODY $TITLE" | \
             grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
             grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
-          
+
           if [ -n "$ISSUE" ]; then
             echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
           fi
@@ -40,9 +40,9 @@ jobs:
         run: |
           ISSUE_NUM=${{ steps.extract-issue.outputs.issue_number }}
           PR_NUM=${{ github.event.pull_request.number }}
-          
+
           LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
-          
+
           for label in $LABELS; do
             gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
           done

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -27,7 +27,9 @@ jobs:
           BODY: ${{ github.event.pull_request.body }}
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          ISSUE=$(echo "$TITLE $BODY" | grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+')
+          ISSUE=$(echo "$TITLE $BODY" | \
+            grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
+            grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
 
           if [ -n "$ISSUE" ]; then
             echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -27,9 +27,7 @@ jobs:
           BODY: ${{ github.event.pull_request.body }}
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          ISSUE=$(echo "$BODY $TITLE" | \
-            grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
-            grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
+          ISSUE=$(echo "$TITLE $BODY" | grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+')
 
           if [ -n "$ISSUE" ]; then
             echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,4 +1,4 @@
-name: PR Label Sync
+name: Pull Request Label Sync
 
 on:
   pull_request_target:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: Extract issue number from PR
         id: extract-issue
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          BODY='${{ github.event.pull_request.body }}'
-          TITLE='${{ github.event.pull_request.title }}'
-
           ISSUE=$(echo "$BODY $TITLE" | \
             grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
             grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -22,23 +22,18 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Get Composer Cache Directory
-              id: composer-cache
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
             - name: Cache Composer dependencies
               uses: actions/cache@v5
               with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-
-
+                path: /tmp/composer-cache
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-composer-
             - name: Install dependencies
               uses: php-actions/composer@v6
               env:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+                  COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: '8.3'
 

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -37,7 +37,7 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: '8.3'
-                  args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
+                  args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
             - name: Generate reports
               uses: php-actions/composer@v6

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -37,7 +37,8 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: '8.3'
-                  args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
+                  command: 'install'
+                  args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
             - name: Generate reports
               uses: php-actions/composer@v6

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -29,6 +29,7 @@ jobs:
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                 restore-keys: |
                   ${{ runner.os }}-composer-
+
             - name: Install dependencies
               uses: php-actions/composer@v6
               env:
@@ -36,6 +37,7 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: '8.3'
+                  args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
 
             - name: Generate reports
               uses: php-actions/composer@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: ${{ matrix.php-version }}
+                  args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
 
             - name: Resolve minimum coverage
               id: minimum-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,8 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: ${{ matrix.php-version }}
-                  args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
+                  command: 'install'
+                  args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
             - name: Resolve minimum coverage
               id: minimum-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,12 @@ jobs:
                   command: 'install'
                   args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
+            - name: Composer Audit
+              uses: php-actions/composer@v6
+              with:
+                  php_version: ${{ matrix.php-version }}
+                  command: 'audit'
+
             - name: Resolve minimum coverage
               id: minimum-coverage
               run: echo "value=${INPUT_MIN_COVERAGE:-80}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,23 +38,19 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Get Composer Cache Directory
-              id: composer-cache
-              run: |
-                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
             - name: Cache Composer dependencies
               uses: actions/cache@v5
               with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-composer-
+                path: /tmp/composer-cache
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-composer-
 
             - name: Install dependencies
               uses: php-actions/composer@v6
               env:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+                  COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: ${{ matrix.php-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
               with:
                   php_version: ${{ matrix.php-version }}
-                  args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
+                  args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
             - name: Resolve minimum coverage
               id: minimum-coverage

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -41,7 +41,7 @@ jobs:
           COMPOSER_CACHE_DIR: /tmp/composer-cache
         with:
           php_version: '8.3'
-          args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
+          args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
       - name: Create Docs Markdown
         uses: php-actions/composer@v6

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -41,6 +41,7 @@ jobs:
           COMPOSER_CACHE_DIR: /tmp/composer-cache
         with:
           php_version: '8.3'
+          args: 'install --prefer-dist --no-progress --no-suggest --no-interaction --no-plugins --no-scripts'
 
       - name: Create Docs Markdown
         uses: php-actions/composer@v6

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -41,7 +41,8 @@ jobs:
           COMPOSER_CACHE_DIR: /tmp/composer-cache
         with:
           php_version: '8.3'
-          args: 'install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
+          command: 'install'
+          args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
 
       - name: Create Docs Markdown
         uses: php-actions/composer@v6

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -26,15 +26,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
       - name: Cache Composer dependencies
         uses: actions/cache@v5
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
 
@@ -42,6 +38,7 @@ jobs:
         uses: php-actions/composer@v6
         env:
           COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+          COMPOSER_CACHE_DIR: /tmp/composer-cache
         with:
           php_version: '8.3'
 

--- a/resources/github-actions/auto-assign.yml
+++ b/resources/github-actions/auto-assign.yml
@@ -1,0 +1,14 @@
+name: Auto assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  auto-assign:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: php-fast-forward/dev-tools/.github/workflows/auto-assign.yml@main

--- a/resources/github-actions/auto-assign.yml
+++ b/resources/github-actions/auto-assign.yml
@@ -2,7 +2,7 @@ name: Auto assign
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   issues:
     types: [opened, reopened]
 

--- a/resources/github-actions/label-sync.yml
+++ b/resources/github-actions/label-sync.yml
@@ -1,0 +1,50 @@
+name: PR Label Sync
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_call:
+    inputs:
+      copy_issue_labels:
+        type: boolean
+        default: true
+        description: "Copy labels from linked issue"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  copy-issue-labels:
+    if: inputs.copy_issue_labels == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from PR
+        id: extract-issue
+        run: |
+          BODY='${{ github.event.pull_request.body }}'
+          TITLE='${{ github.event.pull_request.title }}'
+          
+          ISSUE=$(echo "$BODY $TITLE" | \
+            grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
+            grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
+          
+          if [ -n "$ISSUE" ]; then
+            echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Copy labels from issue to PR
+        if: steps.extract-issue.outputs.issue_number != ''
+        run: |
+          ISSUE_NUM=${{ steps.extract-issue.outputs.issue_number }}
+          PR_NUM=${{ github.event.pull_request.number }}
+          
+          LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
+          
+          for label in $LABELS; do
+            gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/resources/github-actions/label-sync.yml
+++ b/resources/github-actions/label-sync.yml
@@ -1,50 +1,13 @@
-name: PR Label Sync
+name: Label sync
 
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
-  pull_request:
-    types: [opened, reopened, synchronize]
-  workflow_call:
-    inputs:
-      copy_issue_labels:
-        type: boolean
-        default: true
-        description: "Copy labels from linked issue"
-
-permissions:
-  contents: read
-  pull-requests: write
+  issues:
+    types: [opened, reopened]
 
 jobs:
-  copy-issue-labels:
-    if: inputs.copy_issue_labels == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Extract issue number from PR
-        id: extract-issue
-        run: |
-          BODY='${{ github.event.pull_request.body }}'
-          TITLE='${{ github.event.pull_request.title }}'
-          
-          ISSUE=$(echo "$BODY $TITLE" | \
-            grep -oE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' | \
-            grep -oE '#[[:digit:]]+' | head -1 | tr -d '#')
-          
-          if [ -n "$ISSUE" ]; then
-            echo "issue_number=$ISSUE" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Copy labels from issue to PR
-        if: steps.extract-issue.outputs.issue_number != ''
-        run: |
-          ISSUE_NUM=${{ steps.extract-issue.outputs.issue_number }}
-          PR_NUM=${{ github.event.pull_request.number }}
-          
-          LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '.labels[].name')
-          
-          for label in $LABELS; do
-            gh pr edit "$PR_NUM" --add-label "$label" 2>/dev/null || true
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
+  label-sync:
+    permissions:
+      pull-requests: write
+    uses: php-fast-forward/dev-tools/.github/workflows/label-sync.yml@main


### PR DESCRIPTION
## Summary
Fixes GitHub Actions workflow configuration issues by standardizing composer cache paths, adding explicit command parameters, and introducing auto-assign and label-sync workflows.

## Changes
- Replace dynamic composer cache directory (`composer config cache-files-dir`) with fixed `/tmp/composer-cache`
- Change cache keys from `composer.json` to `composer.lock` for reliable invalidation
- Add explicit `COMPOSER_CACHE_DIR` environment variable to composer action
- Add explicit `command` and `args` to `php-actions/composer` actions
- Add new auto-assign workflow using `toshimaru/auto-author-assign`
- Add reusable workflow in `resources/github-actions/auto-assign.yml`
- Add new label-sync workflow that copies issue labels to PRs
- Add reusable workflow in `resources/github-actions/label-sync.yml`

## Testing
- Verified all workflows maintain correct structure
- Composer cache now uses consistent paths across all jobs
- Auto-assign workflow properly configured for PRs and issues
- Label-sync copies labels from linked issue to PR (e.g., `Closes #36`)

Closes #36