### PR TITLE
[ci] Fix --no-plugins flag in reports and wiki workflows (#38)

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -38,7 +38,7 @@ jobs:
               with:
                   php_version: '8.3'
                   command: 'install'
-                  args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
+                  args: '--prefer-dist --no-progress --no-interaction --no-scripts'
 
             - name: Generate reports
               uses: php-actions/composer@v6

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           php_version: '8.3'
           command: 'install'
-          args: '--prefer-dist --no-progress --no-interaction --no-plugins --no-scripts'
+          args: '--prefer-dist --no-progress --no-interaction --no-scripts'
 
       - name: Create Docs Markdown
         uses: php-actions/composer@v6


### PR DESCRIPTION
## Summary
Remove the `--no-plugins` flag from composer install args in reports and wiki workflows, allowing the dev-tools Composer plugin to be active during workflow execution.

## Changes
- Remove `--no-plugins` from `.github/workflows/reports.yml`
- Remove `--no-plugins` from `.github/workflows/wiki.yml`

## Testing
- Verified composer install runs without --no-plugins flag
- dev-tools plugin will now be available for `dev-tools reports` and `dev-tools wiki` commands

Closes #38