### PR TITLE
[wiki] Push publish branch explicitly (#48)

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -142,14 +142,9 @@ jobs:
           git reset --hard "origin/${WIKI_PREVIEW_BRANCH}"
           git clean -fd
 
-      - name: Commit & push wiki publish branch
-        uses: EndBug/add-and-commit@v10
-        with:
-          cwd: .github/wiki
-          add: .
-          message: "Publish wiki docs from PR #${{ github.event.pull_request.number }}"
-          default_author: github_actions
-          push: origin HEAD:${{ env.WIKI_PUBLISH_BRANCH }}
+      - name: Push wiki publish branch
+        working-directory: .github/wiki
+        run: git push --force-with-lease origin HEAD:"${WIKI_PUBLISH_BRANCH}"
 
       - name: Delete wiki preview branch
         working-directory: .github/wiki


### PR DESCRIPTION
## Summary
Fixes the publish step uncovered after PR #50. The publish job reset the local wiki branch to the PR preview commit, but `EndBug/add-and-commit` skipped pushing because the working tree was clean. This changes the publish step to push the selected wiki commit explicitly before deleting the preview branch.

## Changes
- Replaces the publish `EndBug/add-and-commit` step with `git push --force-with-lease origin HEAD:${WIKI_PUBLISH_BRANCH}`.
- Keeps preview branch deletion after the publish push, so failed publish attempts preserve the PR wiki branch for investigation.

## Testing
- `git diff --check` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/wiki.yml"); puts "YAML OK"'` passed.
- Commit hooks passed: GrumPHP composer_script, composer, phplint, jsonlint, and yamllint.
- Verified from the previous publish log that `EndBug/add-and-commit` reported `pushed: false` when the working tree was clean.

Closes #48