### PR TITLE
[command] Fix SyncCommand InputOption import (#52)

### DIFF
--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -20,11 +20,11 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Console\Command;
 
 use Composer\Command\BaseCommand;
-use ECSPrefix202601\Symfony\Component\Console\Input\InputOption;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
 


### PR DESCRIPTION
## Summary
Fixes `SyncCommand` so it imports Symfony Console's real `InputOption` class instead of the ECS-prefixed implementation detail.

## Changes
- Replaced `ECSPrefix202601\Symfony\Component\Console\Input\InputOption` with `Symfony\Component\Console\Input\InputOption` in `src/Console/Command/SyncCommand.php`.
- Verified no `ECSPrefix202601` references remain in `src` or `tests`.

## Testing
- `rg -n -F 'ECSPrefix202601' src tests` found no matches.
- `php -l src/Console/Command/SyncCommand.php` passed.
- `git diff --check` passed.
- `composer dev-tools tests -- --filter=SyncCommandTest` passed: 2 tests, 7 assertions.
- Commit hooks passed: GrumPHP composer_script, composer, phplint, jsonlint, and yamllint.
- `composer dev-tools` completed with exit code 0, but emitted local non-TTY `proc_open(/dev/tty)` errors while invoking the `tests` and `docs` subcommands in this desktop shell.

Closes #52