### PR TITLE
[command] Add README metadata during composer sync (#57)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "ecs",
         "fast-forward"
     ],
+    "readme": "README.md",
     "authors": [
         {
             "name": "Felipe Sayão Lobato Abreu",

--- a/src/Console/Command/UpdateComposerJsonCommand.php
+++ b/src/Console/Command/UpdateComposerJsonCommand.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Console\Command;
 use Composer\Command\BaseCommand;
 use Composer\Factory;
 use Composer\Json\JsonManipulator;
+use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -45,10 +46,12 @@ final class UpdateComposerJsonCommand extends BaseCommand
     /**
      * Creates a new UpdateComposerJsonCommand instance.
      *
+     * @param ComposerJsonInterface $composer the composer.json metadata accessor
      * @param FilesystemInterface $filesystem the filesystem used to read and write composer.json
      * @param FileLocatorInterface $fileLocator the locator used to resolve packaged configuration files
      */
     public function __construct(
+        private readonly ComposerJsonInterface $composer,
         private readonly FilesystemInterface $filesystem,
         private readonly FileLocatorInterface $fileLocator,
     ) {
@@ -93,6 +96,10 @@ final class UpdateComposerJsonCommand extends BaseCommand
 
         foreach ($this->scripts() as $name => $command) {
             $manipulator->addSubNode('scripts', $name, $command);
+        }
+
+        if ('' === $this->composer->getReadme() && $this->filesystem->exists('README.md', \dirname($file))) {
+            $manipulator->addProperty('readme', 'README.md');
         }
 
         $manipulator->addSubNode('extra', 'grumphp', [

--- a/tests/Console/Command/UpdateComposerJsonCommandTest.php
+++ b/tests/Console/Command/UpdateComposerJsonCommandTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Console\Command;
 
+use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\Command\UpdateComposerJsonCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,12 +33,16 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Safe\json_decode;
+
 #[CoversClass(UpdateComposerJsonCommand::class)]
 final class UpdateComposerJsonCommandTest extends TestCase
 {
     use ProphecyTrait;
 
     private ObjectProphecy $filesystem;
+
+    private ObjectProphecy $composer;
 
     private ObjectProphecy $fileLocator;
 
@@ -52,12 +57,17 @@ final class UpdateComposerJsonCommandTest extends TestCase
      */
     protected function setUp(): void
     {
+        $this->composer = $this->prophesize(ComposerJsonInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
 
-        $this->command = new UpdateComposerJsonCommand($this->filesystem->reveal(), $this->fileLocator->reveal());
+        $this->command = new UpdateComposerJsonCommand(
+            $this->composer->reveal(),
+            $this->filesystem->reveal(),
+            $this->fileLocator->reveal(),
+        );
     }
 
     /**
@@ -89,12 +99,106 @@ final class UpdateComposerJsonCommandTest extends TestCase
             ->willReturn(true);
         $this->filesystem->readFile('/app/composer.json')
             ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
         $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
             ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
         $this->filesystem->dumpFile(
             '/app/composer.json',
             Argument::that(static fn(string $contents): bool => str_contains($contents, '"dev-tools"')
                 && str_contains($contents, '"grumphp"')),
+        )->shouldBeCalledOnce();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillAddReadmeMetadataWhenReadmeExistsAndComposerJsonDoesNotDeclareReadme(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(true);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->filesystem->dumpFile(
+            '/app/composer.json',
+            Argument::that(static function (string $contents): bool {
+                $composerJson = json_decode($contents, true);
+
+                return 'README.md' === $composerJson['readme'];
+            }),
+        )->shouldBeCalledOnce();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillPreserveExistingReadmeMetadata(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package","readme":"docs/readme.md"}');
+        $this->composer->getReadme()
+            ->willReturn('docs/readme.md');
+        $this->filesystem->exists('README.md', '/app')
+            ->shouldNotBeCalled();
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->filesystem->dumpFile(
+            '/app/composer.json',
+            Argument::that(static function (string $contents): bool {
+                $composerJson = json_decode($contents, true);
+
+                return 'docs/readme.md' === $composerJson['readme'];
+            }),
+        )->shouldBeCalledOnce();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipReadmeMetadataWhenReadmeDoesNotExist(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->filesystem->dumpFile(
+            '/app/composer.json',
+            Argument::that(static function (string $contents): bool {
+                $composerJson = json_decode($contents, true);
+
+                return ! \array_key_exists('readme', $composerJson);
+            }),
         )->shouldBeCalledOnce();
 
         self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());


### PR DESCRIPTION
## Summary
- Update UpdateComposerJsonCommand to add Composer readme metadata when README.md exists and no readme value is declared.
- Use ComposerJsonInterface for the existing metadata check and preserve existing readme values.
- Add focused tests for adding, preserving, and skipping README metadata, and add the package's own readme field.

## Testing
- composer dev-tools tests -- --filter=UpdateComposerJsonCommandTest
- composer dev-tools code-style
- composer dev-tools tests
- composer normalize --dry-run
- php bin/dev-tools update-composer-json

Note: composer dev-tools was also attempted, but the reports stage failed in this local non-interactive environment with proc_open(/dev/tty): Failed to open stream: Device not configured.

Closes #57