### PR TITLE
[tests] Add PHPUnit output options (#84)

### DIFF
--- a/docs/commands/reports.rst
+++ b/docs/commands/reports.rst
@@ -66,5 +66,7 @@ Behavior
 ---------
 
 - Runs ``docs`` and ``tests --coverage`` in parallel.
+- Runs tests with ``--no-progress`` and ``--coverage-summary`` so report builds
+  keep PHPUnit output concise.
 - Used by the ``standards`` command as the final phase.
 - This is the reporting stage used by GitHub Pages.

--- a/docs/commands/tests.rst
+++ b/docs/commands/tests.rst
@@ -14,6 +14,7 @@ It supports:
 - Enforcing minimum coverage thresholds
 - Filtering tests by pattern
 - Cache management
+- Optional progress and coverage-text verbosity control
 
 Usage
 -----
@@ -43,9 +44,15 @@ Options
 ``--no-cache``
    Disable PHPUnit caching.
 
+``--no-progress``
+   Disable PHPUnit progress output.
+
 ``--coverage, -c`` (optional)
    Generate code coverage reports. If a path is provided, reports are saved there.
    Without a path, reports are saved to the cache directory.
+
+``--coverage-summary``
+   When coverage text is generated, show only the summary table.
 
 ``--filter, -f`` (optional)
    Filter which tests to run based on a pattern (regex supported).
@@ -74,6 +81,12 @@ Run with coverage report:
 
    composer tests --coverage=public/coverage
 
+Run with concise coverage text output:
+
+.. code-block:: bash
+
+   composer tests --coverage=public/coverage --coverage-summary
+
 Run tests matching a pattern:
 
 .. code-block:: bash
@@ -91,6 +104,12 @@ Run without cache:
 .. code-block:: bash
 
    composer tests --no-cache
+
+Run without PHPUnit progress output:
+
+.. code-block:: bash
+
+   composer tests --no-progress
 
 Exit Codes
 ---------
@@ -113,5 +132,7 @@ Behavior
 - Local ``phpunit.xml`` is preferred over the packaged default.
 - Coverage filters are automatically applied to all PSR-4 paths from composer.json.
 - Multiple coverage formats are generated: HTML, Testdox HTML, Clover XML, and PHP.
+- ``--coverage-summary`` forwards PHPUnit's ``--only-summary-for-coverage-text``
+  only when coverage text output is generated.
 - The command fails if minimum coverage is not met (when ``--min-coverage`` is set).
 - The packaged configuration registers the DevTools PHPUnit extension.

--- a/docs/running/reports.rst
+++ b/docs/running/reports.rst
@@ -11,7 +11,7 @@ What the Command Runs
 ``reports`` executes the following steps:
 
 1. ``docs --target public``
-2. ``tests --coverage public/coverage``
+2. ``tests --coverage public/coverage --no-progress --coverage-summary``
 
 Outputs
 -------

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -18,6 +18,8 @@ Important details:
 
 - local ``phpunit.xml`` is preferred over the packaged default;
 - ``--coverage=<path>`` creates HTML, Testdox, Clover, and raw coverage output;
+- ``--coverage-summary`` keeps coverage text output to PHPUnit's summary;
+- ``--no-progress`` disables PHPUnit progress output;
 - ``--no-cache`` disables ``tmp/cache/phpunit``;
 - the packaged configuration registers the DevTools PHPUnit extension.
 
@@ -136,7 +138,7 @@ Runs the documentation and test-report pipeline used by GitHub Pages.
 Important details:
 
 - it calls ``docs --target public``;
-- it calls ``tests --coverage public/coverage``;
+- it calls ``tests --coverage public/coverage --no-progress --coverage-summary``;
 - it is the reporting stage used by ``standards``.
 
 ``skills``

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -94,6 +94,8 @@ final class ReportsCommand extends BaseCommand
 
         $coverage = $this->processBuilder
             ->withArgument('--ansi')
+            ->withArgument('--no-progress')
+            ->withArgument('--coverage-summary')
             ->withArgument('--coverage', $input->getOption('coverage'))
             ->build('composer dev-tools tests --');
 

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -113,6 +113,11 @@ final class TestsCommand extends BaseCommand
                 description: 'Whether to generate code coverage reports.',
             )
             ->addOption(
+                name: 'coverage-summary',
+                mode: InputOption::VALUE_NONE,
+                description: 'Whether to show only the summary for text coverage output.',
+            )
+            ->addOption(
                 name: 'filter',
                 shortcut: 'f',
                 mode: InputOption::VALUE_OPTIONAL,
@@ -122,6 +127,11 @@ final class TestsCommand extends BaseCommand
                 name: 'min-coverage',
                 mode: InputOption::VALUE_REQUIRED,
                 description: 'Minimum line coverage percentage required for a successful run.',
+            )
+            ->addOption(
+                name: 'no-progress',
+                mode: InputOption::VALUE_NONE,
+                description: 'Whether to disable progress output from PHPUnit.',
             );
     }
 
@@ -155,6 +165,10 @@ final class TestsCommand extends BaseCommand
             ->withArgument('--display-phpunit-deprecations')
             ->withArgument('--display-incomplete')
             ->withArgument('--display-skipped');
+
+        if ($input->getOption('no-progress')) {
+            $processBuilder = $processBuilder->withArgument('--no-progress');
+        }
 
         if (! $input->getOption('no-cache')) {
             $processBuilder = $processBuilder->withArgument(
@@ -265,6 +279,10 @@ final class TestsCommand extends BaseCommand
                 ->withArgument('--coverage-html', $coveragePath)
                 ->withArgument('--testdox-html', $coveragePath . '/testdox.html')
                 ->withArgument('--coverage-clover', $coveragePath . '/clover.xml');
+
+            if ($input->getOption('coverage-summary')) {
+                $processBuilder = $processBuilder->withArgument('--only-summary-for-coverage-text');
+            }
         }
 
         $coverageReportPath = $coveragePath . '/coverage.php';

--- a/tests/Console/Command/ReportsCommandTest.php
+++ b/tests/Console/Command/ReportsCommandTest.php
@@ -149,6 +149,14 @@ final class ReportsCommandTest extends TestCase
             ->shouldBeCalledOnce()
             ->willReturn($this->processBuilder->reveal());
 
+        $this->processBuilder->withArgument('--no-progress')
+            ->shouldBeCalledOnce()
+            ->willReturn($this->processBuilder->reveal());
+
+        $this->processBuilder->withArgument('--coverage-summary')
+            ->shouldBeCalledOnce()
+            ->willReturn($this->processBuilder->reveal());
+
         $this->processQueue->add($this->docsProcess->reveal(), false, true)
             ->shouldBeCalledOnce();
 

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -150,6 +150,18 @@ final class TestsCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function commandWillHaveExpectedOutputOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        self::assertTrue($definition->hasOption('no-progress'));
+        self::assertTrue($definition->hasOption('coverage-summary'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWillRunPhpUnitProcessWithConfigFile(): void
     {
         $this->willQueueProcessMatching(function (Process $process): bool {
@@ -172,11 +184,69 @@ final class TestsCommandTest extends TestCase
             $commandLine = $process->getCommandLine();
 
             return str_contains($commandLine, '--coverage-text')
+                && ! str_contains($commandLine, '--only-summary-for-coverage-text')
                 && str_contains($commandLine, '--coverage-html=' . getcwd() . '/public/coverage');
         });
 
         $this->input->getOption('coverage')
             ->willReturn('public/coverage');
+
+        $this->invokeExecute();
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWithNoProgressWillForwardNoProgressToPhpUnit(): void
+    {
+        $this->willQueueProcessMatching(static fn(Process $process): bool => str_contains(
+            $process->getCommandLine(),
+            '--no-progress',
+        ));
+
+        $this->input->getOption('no-progress')
+            ->willReturn(true);
+
+        $this->invokeExecute();
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWithCoverageSummaryWillIncludeCoverageTextSummaryArgument(): void
+    {
+        $this->willQueueProcessMatching(function (Process $process): bool {
+            $commandLine = $process->getCommandLine();
+
+            return str_contains($commandLine, '--coverage-text')
+                && str_contains($commandLine, '--only-summary-for-coverage-text');
+        });
+
+        $this->input->getOption('coverage')
+            ->willReturn('public/coverage');
+        $this->input->getOption('coverage-summary')
+            ->willReturn(true);
+
+        $this->invokeExecute();
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWithCoverageSummaryWithoutCoverageWillNotGenerateCoverageTextSummary(): void
+    {
+        $this->willQueueProcessMatching(static function (Process $process): bool {
+            $commandLine = $process->getCommandLine();
+
+            return ! str_contains($commandLine, '--coverage-text')
+                && ! str_contains($commandLine, '--only-summary-for-coverage-text');
+        });
+
+        $this->input->getOption('coverage-summary')
+            ->willReturn(true);
 
         $this->invokeExecute();
     }


### PR DESCRIPTION
## Summary
- Add tests command options for PHPUnit progress suppression and concise coverage text output.
- Forward --no-progress to PHPUnit only when requested, and forward --only-summary-for-coverage-text behind the DevTools --coverage-summary option.
- Update reports to delegate tests with --no-progress and --coverage-summary, and document the new CLI behavior.

## Testing
- composer dev-tools tests -- --filter='TestsCommandTest|ReportsCommandTest'
- composer dev-tools code-style
- composer dev-tools tests
- composer dev-tools docs
- git diff --check

Closes #84