### PR TITLE
[github-actions] Reduce workflow token permissions (#63)

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -23,8 +23,7 @@ on:
         branches: [ "main" ]
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
 
 concurrency:
     group: ${{ github.event_name == 'pull_request' && format('reports-preview-pr-{0}', github.event.pull_request.number) || 'reports-pages' }}
@@ -35,6 +34,8 @@ jobs:
         if: github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && inputs.cleanup-previews) && (github.event_name != 'pull_request' || github.event.action != 'closed')
         name: Generate Reports
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
 
         env:
             PAGES_ARTIFACT_NAME: ${{ github.event_name == 'pull_request' && format('github-pages-pr-{0}', github.event.pull_request.number) || 'github-pages' }}
@@ -120,8 +121,16 @@ jobs:
                 keep_files: false
                 force_orphan: false
 
+    comment_preview:
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        name: Comment Pull Request Preview URLs
+        needs: reports
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+
+        steps:
             - name: Comment preview URLs on pull request
-              if: github.event_name == 'pull_request'
               uses: marocchino/sticky-pull-request-comment@v2
               with:
                 header: pr-preview
@@ -135,6 +144,8 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action == 'closed'
         name: Cleanup Pull Request Preview
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
 
         steps:
             - name: Checkout gh-pages
@@ -162,6 +173,9 @@ jobs:
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.cleanup-previews)
         name: Cleanup Orphaned Pull Request Previews
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: read
 
         steps:
             - name: Checkout gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,7 @@ on:
         branches: [ "main" ]
 
 permissions:
-    contents: write
-    pages: write
-    id-token: write
+    contents: read
 
 concurrency:
     group: "pages"

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -11,8 +11,7 @@ on:
     types: [closed]
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 concurrency:
   group: update-wiki-${{ github.event.pull_request.number || github.ref }}
@@ -23,6 +22,9 @@ jobs:
     name: Update Wiki Preview
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     env:
       WIKI_PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
@@ -117,6 +119,9 @@ jobs:
     name: Publish Wiki Master
     if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     env:
       WIKI_PUBLISH_BRANCH: master
@@ -186,6 +191,8 @@ jobs:
     name: Delete Closed PR Wiki Preview
     if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     env:
       WIKI_PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
@@ -215,6 +222,9 @@ jobs:
     name: Delete Orphaned Wiki Previews
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout main branch

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -92,6 +92,35 @@ write generated preview commits, update pull request comments, and publish Pages
 content. Keep those permissions scoped to the workflow jobs that actually need
 them.
 
+Workflow Permission Scope
+-------------------------
+
+The reusable workflows default to read-only repository access and grant write
+permissions at the job level when generated content must be pushed or pull
+requests must be updated.
+
+``tests.yml`` only needs ``contents: read`` because it checks out code, installs
+dependencies, and runs PHPUnit.
+
+``reports.yml`` keeps ``contents: write`` on jobs that publish or clean
+``gh-pages`` content. The pull request preview comment runs as a separate job
+with ``pull-requests: write`` because it posts or updates the sticky preview
+comment. Scheduled preview cleanup uses ``pull-requests: read`` so it can
+distinguish open pull requests from closed or merged ones before deleting
+``previews/pr-<number>`` directories.
+
+``wiki.yml`` keeps ``contents: write`` on preview, publish, and cleanup jobs
+because the workflow pushes wiki branches, updates the parent repository
+submodule pointer, promotes preview content to wiki ``master``, and deletes
+stale preview branches. Jobs that inspect pull request state keep
+``pull-requests: read``.
+
+The label synchronization workflow declares ``issues: read`` to copy labels from
+the linked issue and ``pull-requests: write`` to apply those labels to the pull
+request. The auto-assign workflow keeps ``issues: write`` and
+``pull-requests: write`` because assignment is a write operation on both event
+types.
+
 Resolving ``.github/wiki`` Pointer Conflicts
 --------------------------------------------
 

--- a/resources/github-actions/label-sync.yml
+++ b/resources/github-actions/label-sync.yml
@@ -9,5 +9,7 @@ on:
 jobs:
   label-sync:
     permissions:
+      contents: read
+      issues: read
       pull-requests: write
     uses: php-fast-forward/dev-tools/.github/workflows/label-sync.yml@main

--- a/resources/github-actions/tests.yml
+++ b/resources/github-actions/tests.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary
- Reduce `tests.yml` workflow and packaged stub to read-only repository contents.
- Move reports/wiki write permissions to the jobs that push generated content or clean previews.
- Split reports preview commenting into its own job with `pull-requests: write`.
- Declare `issues: read` for label sync and document the remaining required write scopes.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/*.yml resources/github-actions/*.yml`
- `git diff --check`

## Notes
- `composer dev-tools docs` and PHP-based hooks could not run locally because this shell does not have `php` on `PATH`.
- Current reports publishing uses the `gh-pages` branch, so publish and cleanup jobs still require `contents: write` instead of `pages: write`/`id-token: write`.

Closes #63
