### PR TITLE
[filesystem] Isolate Finder creation behind a factory (#90)

### DIFF
--- a/src/Agent/Skills/SkillsSynchronizer.php
+++ b/src/Agent/Skills/SkillsSynchronizer.php
@@ -19,10 +19,10 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Agent\Skills;
 
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -35,15 +35,15 @@ use Symfony\Component\Filesystem\Path;
 final class SkillsSynchronizer implements LoggerAwareInterface
 {
     /**
-     * Initializes the synchronizer with a filesystem and finder instance.
+     * Initializes the synchronizer with a filesystem and finder factory.
      *
      * @param Filesystem $filesystem Filesystem instance for file operations
-     * @param Finder $finder Finder instance for locating skill directories in the package
+     * @param FinderFactoryInterface $finderFactory Factory for locating skill directories in the package
      * @param LoggerInterface $logger Logger for recording synchronization actions and decisions
      */
     public function __construct(
         private readonly Filesystem $filesystem,
-        private readonly Finder $finder,
+        private readonly FinderFactoryInterface $finderFactory,
         private LoggerInterface $logger,
     ) {}
 
@@ -103,7 +103,8 @@ final class SkillsSynchronizer implements LoggerAwareInterface
         string $packageSkillsPath,
         SynchronizeResult $result,
     ): void {
-        $finder = $this->finder
+        $finder = $this->finderFactory
+            ->create()
             ->directories()
             ->in($packageSkillsPath)
             ->depth('== 0');

--- a/src/Agent/Skills/SkillsSynchronizer.php
+++ b/src/Agent/Skills/SkillsSynchronizer.php
@@ -20,9 +20,9 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Agent\Skills;
 
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -37,12 +37,12 @@ final class SkillsSynchronizer implements LoggerAwareInterface
     /**
      * Initializes the synchronizer with a filesystem and finder factory.
      *
-     * @param Filesystem $filesystem Filesystem instance for file operations
+     * @param FilesystemInterface $filesystem Filesystem instance for file operations
      * @param FinderFactoryInterface $finderFactory Factory for locating skill directories in the package
      * @param LoggerInterface $logger Logger for recording synchronization actions and decisions
      */
     public function __construct(
-        private readonly Filesystem $filesystem,
+        private readonly FilesystemInterface $filesystem,
         private readonly FinderFactoryInterface $finderFactory,
         private LoggerInterface $logger,
     ) {}

--- a/src/Console/Command/CopyResourceCommand.php
+++ b/src/Console/Command/CopyResourceCommand.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Console\Command;
 
 use Composer\Command\BaseCommand;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -27,7 +28,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\Finder\Finder;
 
 /**
  * Copies packaged or local resources into the consumer repository.
@@ -44,12 +44,12 @@ final class CopyResourceCommand extends BaseCommand
      *
      * @param FilesystemInterface $filesystem the filesystem used for copy operations
      * @param FileLocatorInterface $fileLocator the locator used to resolve source resources
-     * @param Finder $finder the finder used to iterate directory resources
+     * @param FinderFactoryInterface $finderFactory the factory used to create finders for directory resources
      */
     public function __construct(
         private readonly FilesystemInterface $filesystem,
         private readonly FileLocatorInterface $fileLocator,
-        private readonly Finder $finder,
+        private readonly FinderFactoryInterface $finderFactory,
     ) {
         parent::__construct();
     }
@@ -126,7 +126,8 @@ final class CopyResourceCommand extends BaseCommand
         bool $overwrite,
         OutputInterface $output
     ): int {
-        $files = $this->finder
+        $files = $this->finderFactory
+            ->create()
             ->files()
             ->in($sourcePath);
 

--- a/src/Console/Command/GitAttributesCommand.php
+++ b/src/Console/Command/GitAttributesCommand.php
@@ -19,9 +19,9 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Console\Command;
 
+use Composer\Command\BaseCommand;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
-use Composer\Command\BaseCommand;
 use FastForward\DevTools\GitAttributes\CandidateProviderInterface;
 use FastForward\DevTools\GitAttributes\ExistenceCheckerInterface;
 use FastForward\DevTools\GitAttributes\ExportIgnoreFilterInterface;
@@ -31,7 +31,6 @@ use FastForward\DevTools\GitAttributes\WriterInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 use function Safe\getcwd;
 
@@ -66,7 +65,7 @@ final class GitAttributesCommand extends BaseCommand
      * @param MergerInterface $merger the merger component
      * @param ReaderInterface $reader the reader component
      * @param WriterInterface $writer the writer component
-     * @param Filesystem $filesystem the filesystem component
+     * @param FilesystemInterface $filesystem the filesystem component
      * @param ComposerJsonInterface $composer the composer.json accessor
      */
     public function __construct(

--- a/src/Console/Command/GitHooksCommand.php
+++ b/src/Console/Command/GitHooksCommand.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Console\Command;
 
 use Composer\Command\BaseCommand;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -29,7 +30,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\Finder\Finder;
 
 /**
  * Installs Git hooks and initializes GrumPHP hooks for the consumer repository.
@@ -48,14 +48,14 @@ final class GitHooksCommand extends BaseCommand
      * @param FileLocatorInterface $fileLocator the locator used to find packaged hooks
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble GrumPHP processes
      * @param ProcessQueueInterface $processQueue the queue used to execute GrumPHP initialization
-     * @param Finder $finder the finder used to iterate hook files
+     * @param FinderFactoryInterface $finderFactory the factory used to create finders for hook files
      */
     public function __construct(
         private readonly FilesystemInterface $filesystem,
         private readonly FileLocatorInterface $fileLocator,
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
-        private readonly Finder $finder,
+        private readonly FinderFactoryInterface $finderFactory,
     ) {
         parent::__construct();
     }
@@ -118,7 +118,8 @@ final class GitHooksCommand extends BaseCommand
         $targetPath = (string) $this->filesystem->getAbsolutePath((string) $input->getOption('target'));
         $overwrite = ! $input->getOption('no-overwrite');
 
-        $files = $this->finder
+        $files = $this->finderFactory
+            ->create()
             ->files()
             ->in($sourcePath);
 

--- a/src/Console/CommandLoader/DevToolsCommandLoader.php
+++ b/src/Console/CommandLoader/DevToolsCommandLoader.php
@@ -19,12 +19,12 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Console\CommandLoader;
 
-use ReflectionClass;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use Psr\Container\ContainerInterface;
+use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
-use Symfony\Component\Finder\Finder;
 
 /**
  * Responsible for dynamically discovering and loading Symfony Console commands
@@ -50,26 +50,27 @@ final class DevToolsCommandLoader extends ContainerCommandLoader
      * instantiable and have the AsCommand attribute.
      * It builds a command map associating command names with their respective classes.
      *
-     * @param Finder $finder
+     * @param FinderFactoryInterface $finderFactory
      * @param ContainerInterface $container
      */
-    public function __construct(Finder $finder, ContainerInterface $container)
+    public function __construct(FinderFactoryInterface $finderFactory, ContainerInterface $container)
     {
-        parent::__construct($container, $this->getCommandMap($finder));
+        parent::__construct($container, $this->getCommandMap($finderFactory));
     }
 
     /**
      * Builds a command map by scanning the Command directory for classes that are instantiable and have the AsCommand attribute.
      *
-     * @param Finder $finder
+     * @param FinderFactoryInterface $finderFactory
      *
      * @return array
      */
-    private function getCommandMap(Finder $finder): array
+    private function getCommandMap(FinderFactoryInterface $finderFactory): array
     {
         $commandMap = [];
 
-        $commandsDirectory = $finder
+        $commandsDirectory = $finderFactory
+            ->create()
             ->files()
             ->in(__DIR__ . '/../Command')
             ->name('*.php');

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -103,6 +103,44 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
     }
 
     /**
+     * Removes files, symbolic links, or directories.
+     *
+     * @param iterable<string>|string $files the file(s), link(s), or directory(ies) to remove
+     */
+    #[Override]
+    public function remove(string|iterable $files): void
+    {
+        parent::remove($this->getAbsolutePath($files));
+    }
+
+    /**
+     * Creates a symbolic link.
+     *
+     * @param string $originDir the origin path the link MUST point to
+     * @param string $targetDir the link path to create
+     * @param bool $copyOnWindows whether directories SHOULD be copied on Windows instead of linked
+     */
+    #[Override]
+    public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
+    {
+        parent::symlink($this->getAbsolutePath($originDir), $this->getAbsolutePath($targetDir), $copyOnWindows);
+    }
+
+    /**
+     * Reads a symbolic link target.
+     *
+     * @param string $path the symbolic link path
+     * @param bool $canonicalize whether the returned path SHOULD be canonicalized
+     *
+     * @return string|null the link target, or null when the path is not a symbolic link
+     */
+    #[Override]
+    public function readlink(string $path, bool $canonicalize = false): ?string
+    {
+        return parent::readlink($this->getAbsolutePath($path), $canonicalize);
+    }
+
+    /**
      * Resolves a path or iterable of paths into their absolute path representation.
      *
      * @param iterable<string>|string $files the path(s) to resolve

--- a/src/Filesystem/FilesystemInterface.php
+++ b/src/Filesystem/FilesystemInterface.php
@@ -76,6 +76,32 @@ interface FilesystemInterface
     public function chmod(string|iterable $files, int $mode, int $umask = 0o000, bool $recursive = false): void;
 
     /**
+     * Removes files, symbolic links, or directories.
+     *
+     * @param iterable<string>|string $files the file(s), link(s), or directory(ies) to remove
+     */
+    public function remove(string|iterable $files): void;
+
+    /**
+     * Creates a symbolic link.
+     *
+     * @param string $originDir the origin path the link MUST point to
+     * @param string $targetDir the link path to create
+     * @param bool $copyOnWindows whether directories SHOULD be copied on Windows instead of linked
+     */
+    public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void;
+
+    /**
+     * Reads a symbolic link target.
+     *
+     * @param string $path the symbolic link path
+     * @param bool $canonicalize whether the returned path SHOULD be canonicalized
+     *
+     * @return string|null the link target, or null when the path is not a symbolic link
+     */
+    public function readlink(string $path, bool $canonicalize = false): ?string;
+
+    /**
      * Resolves a path or iterable of paths into their absolute path representation.
      *
      * If a relative path is provided, it SHALL be evaluated against the current

--- a/src/Filesystem/FinderFactory.php
+++ b/src/Filesystem/FinderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Filesystem;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Default factory for Symfony Finder instances.
+ */
+final class FinderFactory implements FinderFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function create(): Finder
+    {
+        return new Finder();
+    }
+}

--- a/src/Filesystem/FinderFactoryInterface.php
+++ b/src/Filesystem/FinderFactoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Filesystem;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Creates fresh Symfony Finder instances for each filesystem scan.
+ */
+interface FinderFactoryInterface
+{
+    /**
+     * Creates a new mutable Finder instance.
+     *
+     * @return Finder a Finder instance that callers MAY configure for one scan
+     */
+    public function create(): Finder;
+}

--- a/src/GitAttributes/ExistenceChecker.php
+++ b/src/GitAttributes/ExistenceChecker.php
@@ -19,7 +19,8 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\GitAttributes;
 
-use Symfony\Component\Filesystem\Filesystem;
+use FastForward\DevTools\Filesystem\Filesystem;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 
 /**
  * Checks the existence of files and directories in a given base path.
@@ -30,10 +31,10 @@ use Symfony\Component\Filesystem\Filesystem;
 final readonly class ExistenceChecker implements ExistenceCheckerInterface
 {
     /**
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      */
     public function __construct(
-        private Filesystem $filesystem = new Filesystem()
+        private FilesystemInterface $filesystem = new Filesystem()
     ) {}
 
     /**

--- a/src/GitAttributes/Writer.php
+++ b/src/GitAttributes/Writer.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\GitAttributes;
 
-use Symfony\Component\Filesystem\Filesystem;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 
 use function Safe\preg_split;
 
@@ -33,10 +33,10 @@ use function Safe\preg_split;
 final readonly class Writer implements WriterInterface
 {
     /**
-     * @param Filesystem $filesystem the filesystem service responsible for writing the file
+     * @param FilesystemInterface $filesystem the filesystem service responsible for writing the file
      */
     public function __construct(
-        private Filesystem $filesystem
+        private FilesystemInterface $filesystem
     ) {}
 
     /**

--- a/src/GitIgnore/Writer.php
+++ b/src/GitIgnore/Writer.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\GitIgnore;
 
-use Symfony\Component\Filesystem\Filesystem;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 
 /**
  * Renders and persists normalized .gitignore content.
@@ -37,11 +37,11 @@ final readonly class Writer implements WriterInterface
      * The provided filesystem implementation MUST support writing file contents
      * to the target path returned by a GitIgnoreInterface instance.
      *
-     * @param Filesystem $filesystem The filesystem service responsible for
-     *                               writing the rendered .gitignore content.
+     * @param FilesystemInterface $filesystem The filesystem service responsible for
+     *                                        writing the rendered .gitignore content.
      */
     public function __construct(
-        private Filesystem $filesystem
+        private FilesystemInterface $filesystem
     ) {}
 
     /**

--- a/src/License/Generator.php
+++ b/src/License/Generator.php
@@ -21,8 +21,8 @@ namespace FastForward\DevTools\License;
 
 use Throwable;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use Psr\Clock\ClockInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Twig\Environment;
 
 /**
@@ -44,7 +44,7 @@ final readonly class Generator implements GeneratorInterface
      *
      * @param ResolverInterface $resolver The resolver for mapping license identifiers to templates
      * @param ComposerJsonInterface $composer
-     * @param Filesystem $filesystem The filesystem component for file operations
+     * @param FilesystemInterface $filesystem The filesystem component for file operations
      * @param ClockInterface $clock
      * @param Environment $renderer
      */
@@ -53,7 +53,7 @@ final readonly class Generator implements GeneratorInterface
         private ComposerJsonInterface $composer,
         private ClockInterface $clock,
         private Environment $renderer,
-        private Filesystem $filesystem,
+        private FilesystemInterface $filesystem,
     ) {}
 
     /**

--- a/src/ServiceProvider/DevToolsServiceProvider.php
+++ b/src/ServiceProvider/DevToolsServiceProvider.php
@@ -24,6 +24,8 @@ use FastForward\DevTools\Composer\Capability\DevToolsCommandProvider;
 use FastForward\DevTools\Composer\Json\ComposerJson;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\CommandLoader\DevToolsCommandLoader;
+use FastForward\DevTools\Filesystem\FinderFactory;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\Filesystem;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\GitAttributes\CandidateProvider;
@@ -62,7 +64,6 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
-use Symfony\Component\Finder\Finder;
 use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
 
@@ -89,13 +90,13 @@ final class DevToolsServiceProvider implements ServiceProviderInterface
             ProcessQueueInterface::class => get(ProcessQueue::class),
 
             // Filesystem
+            FinderFactoryInterface::class => get(FinderFactory::class),
             FilesystemInterface::class => get(Filesystem::class),
 
             // Composer
             ComposerJsonInterface::class => get(ComposerJson::class),
 
             // Symfony Components
-            Finder::class => create(Finder::class),
             FileLocatorInterface::class => create(FileLocator::class)->constructor([getcwd(), \dirname(__DIR__, 2)]),
 
             // PSR

--- a/tests/Agent/Skills/SkillsSynchronizerTest.php
+++ b/tests/Agent/Skills/SkillsSynchronizerTest.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Tests\Agent\Skills;
 use ArrayIterator;
 use FastForward\DevTools\Agent\Skills\SkillsSynchronizer;
 use FastForward\DevTools\Agent\Skills\SynchronizeResult;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -49,6 +50,11 @@ final class SkillsSynchronizerTest extends TestCase
     private ObjectProphecy $filesystem;
 
     /**
+     * @var ObjectProphecy<FinderFactoryInterface>
+     */
+    private ObjectProphecy $finderFactory;
+
+    /**
      * @var ObjectProphecy<Finder>
      */
     private ObjectProphecy $finder;
@@ -64,6 +70,7 @@ final class SkillsSynchronizerTest extends TestCase
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $this->finder = $this->prophesize(Finder::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
     }
@@ -230,6 +237,9 @@ final class SkillsSynchronizerTest extends TestCase
     {
         $finder = $this->finder->reveal();
 
+        $this->finderFactory->create()
+            ->willReturn($finder)
+            ->shouldBeCalledOnce();
         $this->finder->directories()
             ->willReturn($finder)
             ->shouldBeCalledOnce();
@@ -265,7 +275,7 @@ final class SkillsSynchronizerTest extends TestCase
     {
         return new SkillsSynchronizer(
             $this->filesystem->reveal(),
-            $this->finder->reveal(),
+            $this->finderFactory->reveal(),
             $this->logger->reveal(),
         );
     }

--- a/tests/Agent/Skills/SkillsSynchronizerTest.php
+++ b/tests/Agent/Skills/SkillsSynchronizerTest.php
@@ -23,6 +23,7 @@ use ArrayIterator;
 use FastForward\DevTools\Agent\Skills\SkillsSynchronizer;
 use FastForward\DevTools\Agent\Skills\SynchronizeResult;
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -30,7 +31,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -45,7 +45,7 @@ final class SkillsSynchronizerTest extends TestCase
     private const string CONSUMER_SKILLS_PATH = '/consumer/.agents/skills';
 
     /**
-     * @var ObjectProphecy<Filesystem>
+     * @var ObjectProphecy<FilesystemInterface>
      */
     private ObjectProphecy $filesystem;
 
@@ -69,7 +69,7 @@ final class SkillsSynchronizerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $this->finder = $this->prophesize(Finder::class);
         $this->logger = $this->prophesize(LoggerInterface::class);

--- a/tests/Console/Command/CopyResourceCommandTest.php
+++ b/tests/Console/Command/CopyResourceCommandTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\CopyResourceCommand;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -47,6 +48,8 @@ final class CopyResourceCommandTest extends TestCase
 
     private ObjectProphecy $fileLocator;
 
+    private ObjectProphecy $finderFactory;
+
     private ObjectProphecy $input;
 
     private ObjectProphecy $output;
@@ -66,13 +69,14 @@ final class CopyResourceCommandTest extends TestCase
 
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
+        $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
 
         $this->command = new CopyResourceCommand(
             $this->filesystem->reveal(),
             $this->fileLocator->reveal(),
-            new Finder(),
+            $this->finderFactory->reveal(),
         );
     }
 
@@ -120,6 +124,9 @@ final class CopyResourceCommandTest extends TestCase
 
         $this->fileLocator->locate('resources/github-actions')
             ->willReturn($this->sourceDirectory);
+        $this->finderFactory->create()
+            ->willReturn(new Finder())
+            ->shouldBeCalledOnce();
         $this->filesystem->getAbsolutePath('.github/workflows')
             ->willReturn('/app/.github/workflows');
         $this->filesystem->exists('/app/.github/workflows/nested/example.yml')

--- a/tests/Console/Command/GitHooksCommandTest.php
+++ b/tests/Console/Command/GitHooksCommandTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\GitHooksCommand;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -52,6 +53,8 @@ final class GitHooksCommandTest extends TestCase
 
     private ObjectProphecy $fileLocator;
 
+    private ObjectProphecy $finderFactory;
+
     private ObjectProphecy $processQueue;
 
     private ObjectProphecy $input;
@@ -73,6 +76,7 @@ final class GitHooksCommandTest extends TestCase
 
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
+        $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -82,7 +86,7 @@ final class GitHooksCommandTest extends TestCase
             $this->fileLocator->reveal(),
             new ProcessBuilder(),
             $this->processQueue->reveal(),
-            new Finder(),
+            $this->finderFactory->reveal(),
         );
     }
 
@@ -134,6 +138,9 @@ final class GitHooksCommandTest extends TestCase
 
         $this->fileLocator->locate('resources/git-hooks')
             ->willReturn($this->sourceDirectory);
+        $this->finderFactory->create()
+            ->willReturn(new Finder())
+            ->shouldBeCalledOnce();
         $this->filesystem->getAbsolutePath('.git/hooks')
             ->willReturn('/app/.git/hooks');
         $this->filesystem->copy(Argument::containingString('/post-merge'), '/app/.git/hooks/post-merge', true)

--- a/tests/Console/CommandLoader/DevToolsCommandLoaderTest.php
+++ b/tests/Console/CommandLoader/DevToolsCommandLoaderTest.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Tests\Console\CommandLoader;
 use ArrayIterator;
 use FastForward\DevTools\Console\Command\CodeStyleCommand;
 use FastForward\DevTools\Console\CommandLoader\DevToolsCommandLoader;
+use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -48,7 +49,11 @@ final class DevToolsCommandLoaderTest extends TestCase
         $commandDirectory = \dirname(__DIR__, 3) . '/src/Console/Command';
         $command = $this->prophesize(Command::class);
 
+        $finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $finder = $this->prophesize(Finder::class);
+        $finderFactory->create()
+            ->willReturn($finder->reveal())
+            ->shouldBeCalledOnce();
         $finder->files()
             ->willReturn($finder->reveal())
             ->shouldBeCalled();
@@ -65,7 +70,7 @@ final class DevToolsCommandLoaderTest extends TestCase
         $container->has(CodeStyleCommand::class)->willReturn(true)->shouldBeCalled();
         $container->get(CodeStyleCommand::class)->willReturn($command->reveal())->shouldBeCalled();
 
-        $loader = new DevToolsCommandLoader($finder->reveal(), $container->reveal());
+        $loader = new DevToolsCommandLoader($finderFactory->reveal(), $container->reveal());
 
         self::assertTrue($loader->has('code-style'));
         self::assertSame($command->reveal(), $loader->get('code-style'));

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -21,6 +21,7 @@ namespace FastForward\DevTools\Tests\Console;
 
 use FastForward\DevTools\Console\CommandLoader\DevToolsCommandLoader;
 use FastForward\DevTools\Console\DevTools;
+use FastForward\DevTools\Filesystem\FinderFactory;
 use FastForward\DevTools\ServiceProvider\DevToolsServiceProvider;
 use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -40,6 +41,7 @@ use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
 #[CoversClass(DevTools::class)]
 #[UsesClass(DevToolsCommandLoader::class)]
+#[UsesClass(FinderFactory::class)]
 #[UsesClass(DevToolsServiceProvider::class)]
 final class DevToolsTest extends TestCase
 {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Path;
 
+use function Safe\file_put_contents;
 use function Safe\getcwd;
 
 #[CoversClass(Filesystem::class)]
@@ -151,5 +152,34 @@ final class FilesystemTest extends TestCase
 
         self::assertTrue($this->filesystem->exists($dirName, $this->tempDir));
         self::assertDirectoryExists($this->tempDir . '/' . $dirName);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function removeWillDeleteRelativePathAgainstCurrentWorkingDirectory(): void
+    {
+        $filename = $this->tempDir . '/remove-me.txt';
+        file_put_contents($filename, 'temporary');
+
+        $this->filesystem->remove($filename);
+
+        self::assertFileDoesNotExist($filename);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function symlinkAndReadlinkWillUseAbsolutePaths(): void
+    {
+        $origin = $this->tempDir . '/origin';
+        $target = $this->tempDir . '/target';
+
+        $this->filesystem->mkdir($origin);
+        $this->filesystem->symlink($origin, $target);
+
+        self::assertSame($origin, $this->filesystem->readlink($target, true));
     }
 }

--- a/tests/Filesystem/FinderFactoryTest.php
+++ b/tests/Filesystem/FinderFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Filesystem;
+
+use FastForward\DevTools\Filesystem\FinderFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+#[CoversClass(FinderFactory::class)]
+final class FinderFactoryTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function createWillReturnFreshFinderInstances(): void
+    {
+        $factory = new FinderFactory();
+
+        $firstFinder = $factory->create();
+        $secondFinder = $factory->create();
+
+        self::assertInstanceOf(Finder::class, $firstFinder);
+        self::assertInstanceOf(Finder::class, $secondFinder);
+        self::assertNotSame($firstFinder, $secondFinder);
+    }
+}

--- a/tests/GitAttributes/ExistenceCheckerTest.php
+++ b/tests/GitAttributes/ExistenceCheckerTest.php
@@ -19,13 +19,13 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\GitAttributes;
 
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\GitAttributes\ExistenceChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[CoversClass(ExistenceChecker::class)]
 final class ExistenceCheckerTest extends TestCase
@@ -33,7 +33,7 @@ final class ExistenceCheckerTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @property ObjectProphecy<Filesystem> $filesystem
+     * @property ObjectProphecy<FilesystemInterface> $filesystem
      */
     private readonly ObjectProphecy $filesystem;
 
@@ -44,7 +44,7 @@ final class ExistenceCheckerTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->checker = new ExistenceChecker($this->filesystem->reveal());
     }
 

--- a/tests/GitAttributes/WriterTest.php
+++ b/tests/GitAttributes/WriterTest.php
@@ -19,13 +19,13 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\GitAttributes;
 
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\GitAttributes\Writer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[CoversClass(Writer::class)]
 final class WriterTest extends TestCase
@@ -33,7 +33,7 @@ final class WriterTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy<Filesystem>
+     * @var ObjectProphecy<FilesystemInterface>
      */
     private ObjectProphecy $filesystem;
 
@@ -44,7 +44,7 @@ final class WriterTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->writer = new Writer($this->filesystem->reveal());
     }
 

--- a/tests/GitIgnore/WriterTest.php
+++ b/tests/GitIgnore/WriterTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\GitIgnore;
 
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\GitIgnore\GitIgnore;
 use FastForward\DevTools\GitIgnore\Writer;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -27,7 +28,6 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Symfony\Component\Filesystem\Filesystem;
 
 #[CoversClass(Writer::class)]
 #[UsesClass(GitIgnore::class)]
@@ -41,7 +41,7 @@ final class WriterTest extends TestCase
     #[Test]
     public function writeDumpsContentToFile(): void
     {
-        $filesystem = $this->prophesize(Filesystem::class);
+        $filesystem = $this->prophesize(FilesystemInterface::class);
         $gitignore = new GitIgnore('/project/.gitignore', ['vendor/', '*.log']);
 
         $writer = new Writer($filesystem->reveal());
@@ -57,7 +57,7 @@ final class WriterTest extends TestCase
     #[Test]
     public function writeWithEmptyEntriesDumpsEmptyString(): void
     {
-        $filesystem = $this->prophesize(Filesystem::class);
+        $filesystem = $this->prophesize(FilesystemInterface::class);
         $gitignore = new GitIgnore('/project/.gitignore', []);
 
         $writer = new Writer($filesystem->reveal());
@@ -73,7 +73,7 @@ final class WriterTest extends TestCase
     #[Test]
     public function writeWithMultipleEntriesJoinsWithNewline(): void
     {
-        $filesystem = $this->prophesize(Filesystem::class);
+        $filesystem = $this->prophesize(FilesystemInterface::class);
         $gitignore = new GitIgnore('/project/.gitignore', ['vendor/', 'node_modules/', '*.log']);
 
         $writer = new Writer($filesystem->reveal());

--- a/tests/License/GeneratorTest.php
+++ b/tests/License/GeneratorTest.php
@@ -23,6 +23,7 @@ use Exception;
 use DateTimeImmutable;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Composer\Json\Schema\AuthorInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\License\Generator;
 use FastForward\DevTools\License\ResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,7 +33,6 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Clock\ClockInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Twig\Environment;
 
 #[CoversClass(Generator::class)]
@@ -61,7 +61,7 @@ final class GeneratorTest extends TestCase
     private ObjectProphecy $renderer;
 
     /**
-     * @var ObjectProphecy<Filesystem>
+     * @var ObjectProphecy<FilesystemInterface>
      */
     private ObjectProphecy $filesystem;
 
@@ -78,7 +78,7 @@ final class GeneratorTest extends TestCase
         $this->composer = $this->prophesize(ComposerJsonInterface::class);
         $this->clock = $this->prophesize(ClockInterface::class);
         $this->renderer = $this->prophesize(Environment::class);
-        $this->filesystem = $this->prophesize(Filesystem::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
 
         $this->generator = new Generator(
             $this->resolver->reveal(),


### PR DESCRIPTION
## Summary
- Add `FinderFactoryInterface` and `FinderFactory` so every mutable Symfony Finder scan starts from a fresh instance.
- Replace injected shared Finder usage in resource copy, git hook sync, command loading, and skill synchronization.
- Register the factory in the service provider and remove the direct `Finder::class` service mapping.
- Move services that consumed `Symfony\Component\Filesystem\Filesystem` directly to the local `FilesystemInterface` abstraction.
- Extend the local filesystem wrapper with `remove`, `symlink`, and `readlink` so skill synchronization and other services do not depend on Symfony Filesystem directly.
- Update tests to mock local factories/interfaces and add coverage proving fresh Finder instances and local filesystem link operations.

## Verification
- `git diff --check`
- `rg -n -F "Symfony\\Component\\Filesystem\\Filesystem" src tests` *(only `src/Filesystem/Filesystem.php` remains as the adapter around Symfony)*
- `rg -n "Finder \\$|Finder \\$finder|Finder::class|Finder::create|new Finder\\(" src tests`
- `./vendor/bin/phpunit --filter 'FilesystemTest|FinderFactoryTest|CopyResourceCommandTest|GitHooksCommandTest|DevToolsCommandLoaderTest|SkillsSynchronizerTest|GitIgnore\\WriterTest|GitAttributes\\WriterTest|ExistenceCheckerTest|GeneratorTest|DevToolsTest'` *(blocked: `env: php: No such file or directory`)*
- `./vendor/bin/composer dev-tools tests -- --filter='FinderFactoryTest|CopyResourceCommandTest|GitHooksCommandTest|DevToolsCommandLoaderTest|SkillsSynchronizerTest|DevToolsTest'` *(blocked: `env: php: No such file or directory`)*

## Notes
- No production `Finder::create()` calls were present. The only remaining production `new Finder()` is inside the dedicated `FinderFactory`.
- Direct Symfony Filesystem usage now remains only inside the local filesystem adapter.

Closes #90
