### PR TITLE
[refactor] Integrate Type Perfect into the refactor workflow (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ composer dev-tools code-style
 
 # Refactor code using Rector
 composer dev-tools refactor
+composer dev-tools refactor -- --type-perfect
+composer dev-tools refactor -- --type-perfect-groups=null_over_false,no_mixed
 
 # Check and fix PHPDoc comments
 composer dev-tools phpdoc
@@ -112,6 +114,14 @@ installation in the consumer project.
 The `metrics` command ships with `phpmetrics/phpmetrics` as a direct
 dependency of `fast-forward/dev-tools`, so consumer repositories can generate
 metrics reports without extra setup.
+
+Type Perfect support is opt-in on top of the `refactor` command. To enable the
+Fast Forward integration path in a consumer repository, install the companion
+packages first:
+
+```bash
+composer require --dev rector/type-perfect phpstan/extension-installer
+```
 
 The `skills` command keeps `.agents/skills` aligned with the packaged Fast
 Forward skill set. It creates missing links, repairs broken links, and

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,10 @@
         "thecodingmachine/safe": "^3.4",
         "twig/twig": "^3.0"
     },
+    "suggest": {
+        "phpstan/extension-installer": "Recommended when enabling Type Perfect through `composer dev-tools refactor -- --type-perfect` so PHPStan extension wiring is loaded automatically.",
+        "rector/type-perfect": "Optional companion package for running Type Perfect checks through `composer dev-tools refactor -- --type-perfect`."
+    },
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {

--- a/docs/advanced/rector-and-phpdoc.rst
+++ b/docs/advanced/rector-and-phpdoc.rst
@@ -42,6 +42,23 @@ The default ``rector.php`` also loads shared Rector sets, imports names,
 removes unused imports, skips generated directories, and enables Safe migration
 rules when ``thecodingmachine/safe`` is installed.
 
+Type Perfect in the Refactor Workflow
+-------------------------------------
+
+The ``refactor`` command can optionally run Type Perfect immediately after the
+Rector pass:
+
+.. code-block:: bash
+
+   composer dev-tools refactor -- --type-perfect
+
+The Fast Forward integration path is intentionally opt-in. It expects
+``rector/type-perfect`` and ``phpstan/extension-installer`` to be installed in
+the consumer project. When the consumer already has ``phpstan.neon`` or
+``phpstan.neon.dist``, DevTools includes that file automatically in the
+generated ``tmp/cache/phpstan/type-perfect.neon`` and then enables the selected
+Type Perfect groups there.
+
 Why ``.docheader`` Appears Automatically
 ----------------------------------------
 

--- a/docs/commands/refactor.rst
+++ b/docs/commands/refactor.rst
@@ -7,7 +7,9 @@ Description
 -----------
 
 The ``refactor`` command (alias: ``rector``) runs Rector to automatically
-refactor PHP code. Without ``--fix``, it runs in dry-run mode.
+refactor PHP code. Without ``--fix``, it runs in dry-run mode. It can also run
+`Type Perfect <https://getrector.com/blog/introducing-type-perfect-for-extra-safety>`_
+as a follow-up PHPStan safety pass when the companion packages are installed.
 
 Usage
 -----
@@ -29,6 +31,16 @@ Options
 ``--config, -c`` (optional)
    Path to the Rector configuration file. Default: ``rector.php``.
 
+``--type-perfect``
+   Runs Type Perfect after Rector using a generated PHPStan config in
+   ``tmp/cache/phpstan/type-perfect.neon``.
+
+``--type-perfect-groups=<groups>`` (optional)
+   Comma-separated Type Perfect groups to enable. Supported groups:
+   ``null_over_false``, ``no_mixed``, and ``narrow_param``.
+
+   Default: ``null_over_false,no_mixed,narrow_param``.
+
 Examples
 --------
 
@@ -43,6 +55,18 @@ Apply fixes automatically:
 .. code-block:: bash
 
    composer refactor --fix
+
+Run Rector and Type Perfect together:
+
+.. code-block:: bash
+
+   composer dev-tools refactor -- --type-perfect
+
+Limit Type Perfect to selected groups:
+
+.. code-block:: bash
+
+   composer dev-tools refactor -- --type-perfect --type-perfect-groups=null_over_false,no_mixed
 
 Exit Codes
 ---------
@@ -63,3 +87,8 @@ Behavior
 - Local ``rector.php`` is preferred when present.
 - Packaged default includes Fast Forward custom Rector rules plus shared Rector sets.
 - Uses ``--dry-run`` mode unless ``--fix`` is specified.
+- ``--type-perfect`` requires ``rector/type-perfect`` and
+  ``phpstan/extension-installer`` in the consumer project.
+- When the consumer already has ``phpstan.neon`` or ``phpstan.neon.dist``,
+  the generated Type Perfect config includes it automatically before enabling
+  the requested Type Perfect groups.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -128,6 +128,24 @@ Use the ``RectorConfig`` class to extend instead of replace:
 
 This approach automatically receives upstream updates while allowing additive customization.
 
+How do I enable Type Perfect together with ``refactor``?
+--------------------------------------------------------
+
+Install the companion packages in the consumer project:
+
+.. code-block:: bash
+
+   composer require --dev rector/type-perfect phpstan/extension-installer
+
+Then run:
+
+.. code-block:: bash
+
+   composer dev-tools refactor -- --type-perfect
+
+You can narrow the rollout by selecting groups with
+``--type-perfect-groups=null_over_false,no_mixed``.
+
 Can I generate coverage without running the full ``standards`` pipeline?
 ------------------------------------------------------------------------
 

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -89,13 +89,18 @@ Runs Rector against the current project.
 .. code-block:: bash
 
    composer refactor --fix
+   composer dev-tools refactor -- --type-perfect
 
 Important details:
 
 - without ``--fix``, Rector runs in dry-run mode;
 - local ``rector.php`` is preferred when present;
 - the packaged default includes Fast Forward custom Rector rules plus shared
-  Rector sets.
+  Rector sets;
+- ``--type-perfect`` adds a PHPStan Type Perfect pass after Rector using a
+  generated config in ``tmp/cache/phpstan/type-perfect.neon``;
+- the Fast Forward Type Perfect path expects ``rector/type-perfect`` and
+  ``phpstan/extension-installer`` to be installed in the consumer project.
 
 ``phpdoc``
 ----------

--- a/src/Console/Command/RefactorCommand.php
+++ b/src/Console/Command/RefactorCommand.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Console\Command;
 
 use Composer\Command\BaseCommand;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -46,14 +47,30 @@ final class RefactorCommand extends BaseCommand
     public const string CONFIG = 'rector.php';
 
     /**
+     * @var string the generated PHPStan config used to run Type Perfect checks
+     */
+    private const string TYPE_PERFECT_CONFIG = 'tmp/cache/phpstan/type-perfect.neon';
+
+    /**
+     * @var list<string> the supported Type Perfect rule groups
+     */
+    private const array TYPE_PERFECT_GROUPS = [
+        'null_over_false',
+        'no_mixed',
+        'narrow_param',
+    ];
+
+    /**
      * Creates a new RefactorCommand instance.
      *
      * @param FileLocatorInterface $fileLocator the file locator
+     * @param FilesystemInterface $filesystem the filesystem used for Type Perfect configuration generation
      * @param ProcessBuilderInterface $processBuilder the process builder
      * @param ProcessQueueInterface $processQueue the process queue
      */
     public function __construct(
         private readonly FileLocatorInterface $fileLocator,
+        private readonly FilesystemInterface $filesystem,
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
     ) {
@@ -83,6 +100,17 @@ final class RefactorCommand extends BaseCommand
                 mode: InputOption::VALUE_OPTIONAL,
                 description: 'The path to the Rector configuration file.',
                 default: self::CONFIG
+            )
+            ->addOption(
+                name: 'type-perfect',
+                mode: InputOption::VALUE_NONE,
+                description: 'Run PHPStan Type Perfect checks after Rector using the supported Fast Forward preset.'
+            )
+            ->addOption(
+                name: 'type-perfect-groups',
+                mode: InputOption::VALUE_OPTIONAL,
+                description: 'Comma-separated Type Perfect groups to enable.',
+                default: implode(',', self::TYPE_PERFECT_GROUPS)
             );
     }
 
@@ -101,10 +129,11 @@ final class RefactorCommand extends BaseCommand
     {
         $output->writeln('<info>Running Rector for code refactoring...</info>');
 
+        $config = (string) $input->getOption('config');
         $processBuilder = $this->processBuilder
             ->withArgument('process')
             ->withArgument('--config')
-            ->withArgument($this->fileLocator->locate(self::CONFIG));
+            ->withArgument($this->fileLocator->locate($config));
 
         if (! $input->getOption('fix')) {
             $processBuilder = $processBuilder->withArgument('--dry-run');
@@ -112,6 +141,112 @@ final class RefactorCommand extends BaseCommand
 
         $this->processQueue->add($processBuilder->build('vendor/bin/rector'));
 
+        if ($input->getOption('type-perfect')) {
+            $typePerfectGroups = $this->resolveTypePerfectGroups((string) $input->getOption('type-perfect-groups'));
+
+            if ([] === $typePerfectGroups) {
+                $output->writeln(
+                    '<error>No valid Type Perfect groups were provided. Supported groups: '
+                    . implode(', ', self::TYPE_PERFECT_GROUPS)
+                    . '.</error>'
+                );
+
+                return self::FAILURE;
+            }
+
+            if (! $this->filesystem->exists('vendor/rector/type-perfect')) {
+                $output->writeln(
+                    '<error>Type Perfect support requires rector/type-perfect. Install it with '
+                    . '"composer require rector/type-perfect --dev" before using --type-perfect.</error>'
+                );
+
+                return self::FAILURE;
+            }
+
+            if (! $this->filesystem->exists('vendor/phpstan/extension-installer')) {
+                $output->writeln(
+                    '<error>Type Perfect support requires phpstan/extension-installer for the Fast Forward integration path. '
+                    . 'Install it with "composer require phpstan/extension-installer --dev" before using --type-perfect.</error>'
+                );
+
+                return self::FAILURE;
+            }
+
+            $output->writeln('<info>Running Type Perfect safety checks...</info>');
+
+            $typePerfectConfig = $this->writeTypePerfectConfig($typePerfectGroups);
+            $typePerfect = $this->processBuilder
+                ->withArgument('analyse')
+                ->withArgument('--configuration', $typePerfectConfig)
+                ->build('vendor/bin/phpstan');
+
+            $this->processQueue->add($typePerfect);
+        }
+
         return $this->processQueue->run($output);
+    }
+
+    /**
+     * Filters the requested Type Perfect groups down to the supported subset.
+     *
+     * @param string $groups the raw comma-separated option value
+     *
+     * @return list<string> the valid requested groups in declaration order
+     */
+    private function resolveTypePerfectGroups(string $groups): array
+    {
+        $requestedGroups = array_map('trim', explode(',', $groups));
+        $requestedGroups = array_filter($requestedGroups, static fn(string $group): bool => '' !== $group);
+
+        return array_values(array_intersect(self::TYPE_PERFECT_GROUPS, $requestedGroups));
+    }
+
+    /**
+     * Writes the temporary PHPStan config used to run Type Perfect.
+     *
+     * @param list<string> $groups the enabled Type Perfect groups
+     *
+     * @return string the generated config path
+     */
+    private function writeTypePerfectConfig(array $groups): string
+    {
+        $configPath = (string) $this->filesystem->getAbsolutePath(self::TYPE_PERFECT_CONFIG);
+        $this->filesystem->mkdir($this->filesystem->dirname($configPath));
+
+        $lines = [];
+        $projectPhpStanConfig = $this->resolveProjectPhpStanConfig();
+
+        if (null !== $projectPhpStanConfig) {
+            $lines[] = 'includes:';
+            $lines[] = sprintf("    - '%s'", str_replace("'", "''", $projectPhpStanConfig));
+            $lines[] = '';
+        }
+
+        $lines[] = 'parameters:';
+        $lines[] = '    type_perfect:';
+
+        foreach ($groups as $group) {
+            $lines[] = sprintf('        %s: true', $group);
+        }
+
+        $this->filesystem->dumpFile($configPath, implode("\n", $lines) . "\n");
+
+        return $configPath;
+    }
+
+    /**
+     * Resolves the consumer PHPStan config to include in the generated Type Perfect file.
+     *
+     * @return string|null the absolute PHPStan config path, or null when the consumer has no PHPStan config yet
+     */
+    private function resolveProjectPhpStanConfig(): ?string
+    {
+        foreach (['phpstan.neon', 'phpstan.neon.dist'] as $candidate) {
+            if ($this->filesystem->exists($candidate)) {
+                return (string) $this->filesystem->getAbsolutePath($candidate);
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Console/Command/RefactorCommandTest.php
+++ b/tests/Console/Command/RefactorCommandTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\RefactorCommand;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -43,6 +44,11 @@ final class RefactorCommandTest extends TestCase
      * @var ObjectProphecy<FileLocatorInterface>
      */
     private ObjectProphecy $fileLocator;
+
+    /**
+     * @var ObjectProphecy<FilesystemInterface>
+     */
+    private ObjectProphecy $filesystem;
 
     /**
      * @var ObjectProphecy<ProcessBuilderInterface>
@@ -73,12 +79,15 @@ final class RefactorCommandTest extends TestCase
 
     private const string CONFIG_PATH = '/path/to/rector.php';
 
+    private const string TYPE_PERFECT_CONFIG_PATH = '/app/tmp/cache/phpstan/type-perfect.neon';
+
     /**
      * @return void
      */
     protected function setUp(): void
     {
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
@@ -90,6 +99,12 @@ final class RefactorCommandTest extends TestCase
 
         $this->input->getOption('fix')
             ->willReturn(false);
+        $this->input->getOption('config')
+            ->willReturn(RefactorCommand::CONFIG);
+        $this->input->getOption('type-perfect')
+            ->willReturn(false);
+        $this->input->getOption('type-perfect-groups')
+            ->willReturn('null_over_false,no_mixed,narrow_param');
 
         $this->processBuilder->withArgument(Argument::cetera())
             ->willReturn($this->processBuilder->reveal());
@@ -102,6 +117,7 @@ final class RefactorCommandTest extends TestCase
 
         $this->command = new RefactorCommand(
             $this->fileLocator->reveal(),
+            $this->filesystem->reveal(),
             $this->processBuilder->reveal(),
             $this->processQueue->reveal()
         );
@@ -129,6 +145,8 @@ final class RefactorCommandTest extends TestCase
 
         self::assertTrue($definition->hasOption('fix'));
         self::assertTrue($definition->hasOption('config'));
+        self::assertTrue($definition->hasOption('type-perfect'));
+        self::assertTrue($definition->hasOption('type-perfect-groups'));
     }
 
     /**
@@ -179,6 +197,86 @@ final class RefactorCommandTest extends TestCase
         $result = $this->executeCommand();
 
         self::assertSame(RefactorCommand::SUCCESS, $result);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillRunTypePerfectAfterRectorWhenRequested(): void
+    {
+        $typePerfectProcess = $this->prophesize(Process::class);
+
+        $this->input->getOption('type-perfect')
+            ->willReturn(true);
+        $this->output->writeln('<info>Running Rector for code refactoring...</info>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->exists('vendor/rector/type-perfect')
+            ->willReturn(true);
+        $this->filesystem->exists('vendor/phpstan/extension-installer')
+            ->willReturn(true);
+        $this->filesystem->exists('phpstan.neon')
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('phpstan.neon')
+            ->willReturn('/app/phpstan.neon');
+        $this->filesystem->getAbsolutePath('tmp/cache/phpstan/type-perfect.neon')
+            ->willReturn(self::TYPE_PERFECT_CONFIG_PATH);
+        $this->filesystem->dirname(self::TYPE_PERFECT_CONFIG_PATH)
+            ->willReturn('/app/tmp/cache/phpstan');
+        $this->filesystem->mkdir('/app/tmp/cache/phpstan')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(
+            self::TYPE_PERFECT_CONFIG_PATH,
+            Argument::that(static fn(string $contents): bool => str_contains($contents, "includes:\n    - '/app/phpstan.neon'")
+                && str_contains($contents, 'null_over_false: true')
+                && str_contains($contents, 'no_mixed: true')
+                && str_contains($contents, 'narrow_param: true')),
+        )->shouldBeCalledOnce();
+
+        $this->output->writeln('<info>Running Type Perfect safety checks...</info>')
+            ->shouldBeCalledOnce();
+
+        $this->processBuilder->withArgument('analyse')
+            ->shouldBeCalledOnce()
+            ->willReturn($this->processBuilder->reveal());
+        $this->processBuilder->withArgument('--configuration', self::TYPE_PERFECT_CONFIG_PATH)
+            ->shouldBeCalledOnce()
+            ->willReturn($this->processBuilder->reveal());
+        $this->processBuilder->build('vendor/bin/phpstan')
+            ->willReturn($typePerfectProcess->reveal())
+            ->shouldBeCalledOnce();
+
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($typePerfectProcess->reveal())
+            ->shouldBeCalledOnce();
+
+        self::assertSame(RefactorCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillFailWhenTypePerfectPackageIsMissing(): void
+    {
+        $this->input->getOption('type-perfect')
+            ->willReturn(true);
+        $this->output->writeln('<info>Running Rector for code refactoring...</info>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->exists('vendor/rector/type-perfect')
+            ->willReturn(false);
+
+        $this->output->writeln(
+            '<error>Type Perfect support requires rector/type-perfect. Install it with "composer require rector/type-perfect --dev" before using --type-perfect.</error>'
+        )->shouldBeCalledOnce();
+
+        $this->processQueue->add(Argument::type(Process::class))
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->shouldNotBeCalled();
+
+        self::assertSame(RefactorCommand::FAILURE, $this->executeCommand());
     }
 
     /**


### PR DESCRIPTION
## Summary
Adds an opt-in Type Perfect pass to `composer dev-tools refactor` so consumer projects can run Rector and Type Perfect as part of the same refactoring workflow without hand-building a dedicated PHPStan config.

## Changes
- add `--type-perfect` and `--type-perfect-groups` to `RefactorCommand`
- generate `tmp/cache/phpstan/type-perfect.neon`, automatically including local `phpstan.neon` or `phpstan.neon.dist` when present
- validate the supported Fast Forward installation path by checking for `rector/type-perfect` and `phpstan/extension-installer`
- document the new opt-in flow in the README, refactor command docs, FAQ, and Rector/PHPDoc advanced guide
- add PHPUnit coverage for the new Type Perfect command behavior and missing-package failure path

## Testing
- `./vendor/bin/phpunit tests/Console/Command/RefactorCommandTest.php` - passed
- `./vendor/bin/phpunit tests/Console/Command` - passed (78 tests, 291 assertions); the known JoliNotif runner warning still appears at the end
- `git diff --check` - passed
- `composer dev-tools` - not reliable in this environment because parallel tool steps hit local socket restrictions (`Failed to listen on tcp://127.0.0.1:0: EPERM`) and Composer network resolution failed for Packagist (`curl error 6`)

Closes #9