### PR TITLE
[github-actions] Preserve git history for metrics reports (#103)

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -43,6 +43,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+              with:
+                fetch-depth: 0
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary
- fetch the full repository history before running `composer dev-tools reports`
- keep the metrics generation fix scoped to the reusable reports workflow
- preserve the existing preview and Pages deployment flow

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reports.yml"); YAML.load_file("resources/github-actions/reports.yml")'

Closes #103