### PR TITLE
[sync] Show diffs for overwritten resources (#66)

### DIFF
--- a/docs/commands/copy-resource.rst
+++ b/docs/commands/copy-resource.rst
@@ -36,7 +36,9 @@ Options
 
 ``--overwrite, -o``
    Overwrite existing target files. Without this option, existing files
-   are skipped.
+   are skipped. When a text file changes, the command shows a unified diff
+   before copying. Unchanged targets are reported as skipped, and binary or
+   unreadable files fall back to a clear non-diff message.
 
 Examples
 --------

--- a/docs/commands/sync.rst
+++ b/docs/commands/sync.rst
@@ -32,7 +32,9 @@ Options
 -------
 
 ``--overwrite, -o``
-   Overwrite existing target files.
+   Overwrite existing target files. Text resources copied through
+   ``copy-resource`` show a readable diff in the sync output before they are
+   replaced.
 
 Examples
 --------
@@ -67,5 +69,7 @@ Behavior
 
 - Updates ``composer.json`` scripts and extra configuration.
 - Copies missing workflow stubs, ``.editorconfig``, and ``dependabot.yml``.
+- When ``--overwrite`` is enabled, replaced text resources emit a unified diff
+  so terminal sessions and CI logs show what changed.
 - Creates ``.github/wiki`` as a git submodule when missing.
 - Calls other commands in sequence.

--- a/src/Console/Command/CopyResourceCommand.php
+++ b/src/Console/Command/CopyResourceCommand.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Console\Command;
 use Composer\Command\BaseCommand;
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Resource\OverwriteDiffRenderer;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,11 +46,13 @@ final class CopyResourceCommand extends BaseCommand
      * @param FilesystemInterface $filesystem the filesystem used for copy operations
      * @param FileLocatorInterface $fileLocator the locator used to resolve source resources
      * @param FinderFactoryInterface $finderFactory the factory used to create finders for directory resources
+     * @param OverwriteDiffRenderer $overwriteDiffRenderer the renderer used to summarize overwrite changes
      */
     public function __construct(
         private readonly FilesystemInterface $filesystem,
         private readonly FileLocatorInterface $fileLocator,
         private readonly FinderFactoryInterface $finderFactory,
+        private readonly OverwriteDiffRenderer $overwriteDiffRenderer,
     ) {
         parent::__construct();
     }
@@ -155,6 +158,20 @@ final class CopyResourceCommand extends BaseCommand
             $output->writeln(\sprintf('<comment>Skipped existing resource %s.</comment>', $targetPath));
 
             return self::SUCCESS;
+        }
+
+        if ($overwrite && $this->filesystem->exists($targetPath)) {
+            $comparison = $this->overwriteDiffRenderer->render($sourcePath, $targetPath);
+
+            $output->writeln(\sprintf('<comment>%s</comment>', $comparison->summary()));
+
+            if ($comparison->isChanged() && null !== $comparison->diff()) {
+                $output->writeln($comparison->diff());
+            }
+
+            if ($comparison->isUnchanged()) {
+                return self::SUCCESS;
+            }
         }
 
         $this->filesystem->copy($sourcePath, $targetPath, $overwrite);

--- a/src/Resource/OverwriteDiffRenderer.php
+++ b/src/Resource/OverwriteDiffRenderer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Resource;
+
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+use Throwable;
+
+use function sprintf;
+use function str_contains;
+use function trim;
+
+/**
+ * Renders deterministic overwrite summaries and unified diffs for copied files.
+ */
+final readonly class OverwriteDiffRenderer
+{
+    /**
+     * Creates a new overwrite diff renderer.
+     *
+     * @param FilesystemInterface $filesystem the filesystem used to read compared file contents
+     */
+    public function __construct(private FilesystemInterface $filesystem)
+    {
+    }
+
+    /**
+     * Compares a source file against the target file that would be overwritten.
+     *
+     * @param string $sourcePath the source file path that would replace the target
+     * @param string $targetPath the existing target file path
+     *
+     * @return OverwriteDiffResult the rendered comparison result
+     */
+    public function render(string $sourcePath, string $targetPath): OverwriteDiffResult
+    {
+        try {
+            $sourceContent = $this->filesystem->readFile($sourcePath);
+            $targetContent = $this->filesystem->readFile($targetPath);
+        } catch (Throwable) {
+            return new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_UNREADABLE,
+                sprintf(
+                    'Target %s will be overwritten from %s, but the existing or source content could not be read.',
+                    $targetPath,
+                    $sourcePath,
+                ),
+            );
+        }
+
+        if ($sourceContent === $targetContent) {
+            return new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_UNCHANGED,
+                sprintf('Target %s already matches source %s; overwrite skipped.', $targetPath, $sourcePath),
+            );
+        }
+
+        if ($this->isBinary($sourceContent) || $this->isBinary($targetContent)) {
+            return new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_BINARY,
+                sprintf(
+                    'Target %s will be overwritten from %s, but a text diff is unavailable for binary content.',
+                    $targetPath,
+                    $sourcePath,
+                ),
+            );
+        }
+
+        $header = sprintf("--- Current: %s\n+++ Source: %s\n", $targetPath, $sourcePath);
+        $differ = new Differ(new UnifiedDiffOutputBuilder($header));
+
+        return new OverwriteDiffResult(
+            OverwriteDiffResult::STATUS_CHANGED,
+            sprintf('Overwriting resource %s from %s.', $targetPath, $sourcePath),
+            trim($differ->diff($targetContent, $sourceContent)),
+        );
+    }
+
+    /**
+     * Reports whether the given content should be treated as binary.
+     *
+     * @param string $content the content to inspect
+     *
+     * @return bool true when the content should not receive a text diff
+     */
+    private function isBinary(string $content): bool
+    {
+        return str_contains($content, "\0");
+    }
+}

--- a/src/Resource/OverwriteDiffResult.php
+++ b/src/Resource/OverwriteDiffResult.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Resource;
+
+/**
+ * Carries the result of comparing an overwrite source and target pair.
+ */
+final readonly class OverwriteDiffResult
+{
+    /**
+     * @var string indicates that the source and target differ and a text diff is available
+     */
+    public const string STATUS_CHANGED = 'changed';
+
+    /**
+     * @var string indicates that the source and target already match
+     */
+    public const string STATUS_UNCHANGED = 'unchanged';
+
+    /**
+     * @var string indicates that a text diff should not be rendered for the compared files
+     */
+    public const string STATUS_BINARY = 'binary';
+
+    /**
+     * @var string indicates that the compared files could not be read safely
+     */
+    public const string STATUS_UNREADABLE = 'unreadable';
+
+    /**
+     * Creates a new overwrite diff result.
+     *
+     * @param string $status the comparison status for the source and target files
+     * @param string $summary the human-readable summary for console output
+     * @param string|null $diff the optional unified diff payload
+     */
+    public function __construct(
+        private string $status,
+        private string $summary,
+        private ?string $diff = null,
+    ) {
+    }
+
+    /**
+     * Returns the comparison status.
+     *
+     * @return string the comparison status value
+     */
+    public function status(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Returns the human-readable summary.
+     *
+     * @return string the summary for console output
+     */
+    public function summary(): string
+    {
+        return $this->summary;
+    }
+
+    /**
+     * Returns the optional unified diff payload.
+     *
+     * @return string|null the diff payload, or null when no text diff is available
+     */
+    public function diff(): ?string
+    {
+        return $this->diff;
+    }
+
+    /**
+     * Reports whether the compared files already match.
+     *
+     * @return bool true when the source and target contents are identical
+     */
+    public function isUnchanged(): bool
+    {
+        return self::STATUS_UNCHANGED === $this->status;
+    }
+
+    /**
+     * Reports whether the compared files produced a text diff.
+     *
+     * @return bool true when a text diff is available
+     */
+    public function isChanged(): bool
+    {
+        return self::STATUS_CHANGED === $this->status;
+    }
+}

--- a/tests/Console/Command/CopyResourceCommandTest.php
+++ b/tests/Console/Command/CopyResourceCommandTest.php
@@ -22,8 +22,11 @@ namespace FastForward\DevTools\Tests\Console\Command;
 use FastForward\DevTools\Console\Command\CopyResourceCommand;
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Resource\OverwriteDiffRenderer;
+use FastForward\DevTools\Resource\OverwriteDiffResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -40,6 +43,7 @@ use function Safe\unlink;
 use function Safe\rmdir;
 
 #[CoversClass(CopyResourceCommand::class)]
+#[UsesClass(OverwriteDiffResult::class)]
 final class CopyResourceCommandTest extends TestCase
 {
     use ProphecyTrait;
@@ -53,6 +57,8 @@ final class CopyResourceCommandTest extends TestCase
     private ObjectProphecy $input;
 
     private ObjectProphecy $output;
+
+    private ObjectProphecy $overwriteDiffRenderer;
 
     private CopyResourceCommand $command;
 
@@ -72,11 +78,13 @@ final class CopyResourceCommandTest extends TestCase
         $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
+        $this->overwriteDiffRenderer = $this->prophesize(OverwriteDiffRenderer::class);
 
         $this->command = new CopyResourceCommand(
             $this->filesystem->reveal(),
             $this->fileLocator->reveal(),
             $this->finderFactory->reveal(),
+            $this->overwriteDiffRenderer->reveal(),
         );
     }
 
@@ -138,6 +146,120 @@ final class CopyResourceCommandTest extends TestCase
         )->shouldBeCalledOnce();
         $this->output->writeln(Argument::containingString('Copied resource'))
             ->shouldBeCalled();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillShowDiffBeforeOverwritingChangedFile(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+
+        $this->overwriteDiffRenderer->render('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_CHANGED,
+                'Overwriting resource /project/.editorconfig from /package/.editorconfig.',
+                "--- Current: /project/.editorconfig\n+++ Source: /package/.editorconfig\n@@ -1 +1 @@\n-old\n+new"
+            ))
+            ->shouldBeCalledOnce();
+
+        $this->output->writeln('<comment>Overwriting resource /project/.editorconfig from /package/.editorconfig.</comment>')
+            ->shouldBeCalledOnce();
+        $this->output->writeln("--- Current: /project/.editorconfig\n+++ Source: /package/.editorconfig\n@@ -1 +1 @@\n-old\n+new")
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy('/package/.editorconfig', '/project/.editorconfig', true)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<info>Copied resource /project/.editorconfig.</info>')
+            ->shouldBeCalledOnce();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReportUnchangedOverwriteAsNoOp(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+
+        $this->overwriteDiffRenderer->render('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_UNCHANGED,
+                'Target /project/.editorconfig already matches source /package/.editorconfig; overwrite skipped.',
+            ))
+            ->shouldBeCalledOnce();
+
+        $this->output->writeln('<comment>Target /project/.editorconfig already matches source /package/.editorconfig; overwrite skipped.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::any(), Argument::any(), Argument::any())
+            ->shouldNotBeCalled();
+        $this->output->writeln('<info>Copied resource /project/.editorconfig.</info>')
+            ->shouldNotBeCalled();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillHandleBinaryOverwriteGracefully(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+
+        $this->overwriteDiffRenderer->render('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new OverwriteDiffResult(
+                OverwriteDiffResult::STATUS_BINARY,
+                'Target /project/.editorconfig will be overwritten from /package/.editorconfig, but a text diff is unavailable for binary content.',
+            ))
+            ->shouldBeCalledOnce();
+
+        $this->output->writeln('<comment>Target /project/.editorconfig will be overwritten from /package/.editorconfig, but a text diff is unavailable for binary content.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy('/package/.editorconfig', '/project/.editorconfig', true)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<info>Copied resource /project/.editorconfig.</info>')
+            ->shouldBeCalledOnce();
 
         self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Resource/OverwriteDiffRendererTest.php
+++ b/tests/Resource/OverwriteDiffRendererTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Resource;
+
+use FastForward\DevTools\Filesystem\Filesystem;
+use FastForward\DevTools\Resource\OverwriteDiffRenderer;
+use FastForward\DevTools\Resource\OverwriteDiffResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+use function Safe\file_put_contents;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
+use function sprintf;
+use function sys_get_temp_dir;
+
+#[CoversClass(OverwriteDiffRenderer::class)]
+#[UsesClass(OverwriteDiffResult::class)]
+#[UsesClass(Filesystem::class)]
+final class OverwriteDiffRendererTest extends TestCase
+{
+    private string $tempDirectory;
+
+    private OverwriteDiffRenderer $renderer;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->tempDirectory = sys_get_temp_dir() . '/overwrite-diff-renderer-' . bin2hex(random_bytes(4));
+        mkdir($this->tempDirectory);
+        $this->renderer = new OverwriteDiffRenderer(new Filesystem());
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        foreach (['source.txt', 'target.txt', 'binary.bin'] as $filename) {
+            $path = $this->tempDirectory . '/' . $filename;
+
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        if (is_dir($this->tempDirectory)) {
+            rmdir($this->tempDirectory);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillReturnChangedResultWithUnifiedDiff(): void
+    {
+        $sourcePath = $this->tempDirectory . '/source.txt';
+        $targetPath = $this->tempDirectory . '/target.txt';
+
+        file_put_contents($sourcePath, "new\n");
+        file_put_contents($targetPath, "old\n");
+
+        $result = $this->renderer->render($sourcePath, $targetPath);
+
+        self::assertSame(OverwriteDiffResult::STATUS_CHANGED, $result->status());
+        self::assertSame(sprintf('Overwriting resource %s from %s.', $targetPath, $sourcePath), $result->summary());
+        self::assertNotNull($result->diff());
+        self::assertStringContainsString('--- Current: ' . $targetPath, $result->diff());
+        self::assertStringContainsString('+++ Source: ' . $sourcePath, $result->diff());
+        self::assertStringContainsString('-old', $result->diff());
+        self::assertStringContainsString('+new', $result->diff());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillReturnUnchangedResultWhenContentsMatch(): void
+    {
+        $sourcePath = $this->tempDirectory . '/source.txt';
+        $targetPath = $this->tempDirectory . '/target.txt';
+
+        file_put_contents($sourcePath, "same\n");
+        file_put_contents($targetPath, "same\n");
+
+        $result = $this->renderer->render($sourcePath, $targetPath);
+
+        self::assertSame(OverwriteDiffResult::STATUS_UNCHANGED, $result->status());
+        self::assertSame(
+            sprintf('Target %s already matches source %s; overwrite skipped.', $targetPath, $sourcePath),
+            $result->summary(),
+        );
+        self::assertNull($result->diff());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillReturnBinaryResultWhenNullBytesAreDetected(): void
+    {
+        $sourcePath = $this->tempDirectory . '/binary.bin';
+        $targetPath = $this->tempDirectory . '/target.txt';
+
+        file_put_contents($sourcePath, "bin\0ary");
+        file_put_contents($targetPath, "text\n");
+
+        $result = $this->renderer->render($sourcePath, $targetPath);
+
+        self::assertSame(OverwriteDiffResult::STATUS_BINARY, $result->status());
+        self::assertSame(
+            sprintf(
+                'Target %s will be overwritten from %s, but a text diff is unavailable for binary content.',
+                $targetPath,
+                $sourcePath,
+            ),
+            $result->summary(),
+        );
+        self::assertNull($result->diff());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillReturnUnreadableResultWhenContentsCannotBeRead(): void
+    {
+        $sourcePath = $this->tempDirectory . '/source.txt';
+        $targetPath = $this->tempDirectory . '/missing.txt';
+
+        file_put_contents($sourcePath, "new\n");
+
+        $result = $this->renderer->render($sourcePath, $targetPath);
+
+        self::assertSame(OverwriteDiffResult::STATUS_UNREADABLE, $result->status());
+        self::assertSame(
+            sprintf(
+                'Target %s will be overwritten from %s, but the existing or source content could not be read.',
+                $targetPath,
+                $sourcePath,
+            ),
+            $result->summary(),
+        );
+        self::assertNull($result->diff());
+    }
+}


### PR DESCRIPTION
## Summary
- add a small overwrite diff helper so `copy-resource --overwrite` can classify replacements as changed, unchanged, binary, or unreadable
- show unified diffs for changed text files, skip no-op overwrites when contents already match, and keep binary/unreadable fallbacks readable in terminal and CI logs
- document the new overwrite reporting in the `copy-resource` and `dev-tools:sync` command pages

## Testing
- `./vendor/bin/phpunit tests/Console/Command/CopyResourceCommandTest.php tests/Resource/OverwriteDiffRendererTest.php`
- `./vendor/bin/phpunit tests/Console/Command tests/Console/CommandLoader tests/Composer/Capability tests/Console/DevToolsTest.php`
- `git diff --check`

## Notes
- `composer dev-tools` was also run, but it still fails in this environment because Rector/PHP CS Fixer parallel workers cannot bind `tcp://127.0.0.1:0` (`EPERM`) and Composer cannot reach Packagist (`curl error 6`).
- The PHPUnit command suite still emits the existing JoliNotif third-party subscriber warning at shutdown in this environment.

Closes #66