### PR TITLE
[github-actions] Add reports deployment health checks (#70)

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -123,10 +123,106 @@ jobs:
                 keep_files: false
                 force_orphan: false
 
+    verify_main_reports:
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && !(github.event_name == 'workflow_dispatch' && inputs.cleanup-previews)
+        name: Verify Main Reports Deployment
+        needs: reports
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Health check deployed reports
+              env:
+                BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+              run: |
+                check_url() {
+                    url="$1"
+                    label="$2"
+                    attempts=6
+                    delay=5
+
+                    for attempt in $(seq 1 "${attempts}"); do
+                        echo "Checking ${label}: ${url} (attempt ${attempt}/${attempts})"
+
+                        http_status="$(curl --silent --show-error --output /dev/null --location --write-out '%{http_code}' "${url}" 2>/tmp/curl-error.log || true)"
+
+                        if [ "${http_status}" -ge 200 ] && [ "${http_status}" -lt 400 ]; then
+                            echo "${label} is reachable (${http_status})."
+                            return 0
+                        fi
+
+                        curl_error="$(cat /tmp/curl-error.log)"
+
+                        if [ -n "${curl_error}" ]; then
+                            echo "Attempt ${attempt} failed for ${label}: ${url} (curl error: ${curl_error})"
+                        else
+                            echo "Attempt ${attempt} failed for ${label}: ${url} (HTTP ${http_status})"
+                        fi
+
+                        if [ "${attempt}" -lt "${attempts}" ]; then
+                            sleep "${delay}"
+                        fi
+                    done
+
+                    echo "::error title=Reports health check failed::${label} is not reachable at ${url}. Last HTTP status: ${http_status}${curl_error:+; curl error: ${curl_error}}"
+                    return 1
+                }
+
+                check_url "${BASE_URL}/" "Reports index"
+                check_url "${BASE_URL}/coverage/" "Coverage report"
+
+    verify_preview_reports:
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        name: Verify Pull Request Reports Preview
+        needs: reports
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Health check deployed preview
+              env:
+                BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}
+              run: |
+                check_url() {
+                    url="$1"
+                    label="$2"
+                    attempts=6
+                    delay=5
+
+                    for attempt in $(seq 1 "${attempts}"); do
+                        echo "Checking ${label}: ${url} (attempt ${attempt}/${attempts})"
+
+                        http_status="$(curl --silent --show-error --output /dev/null --location --write-out '%{http_code}' "${url}" 2>/tmp/curl-error.log || true)"
+
+                        if [ "${http_status}" -ge 200 ] && [ "${http_status}" -lt 400 ]; then
+                            echo "${label} is reachable (${http_status})."
+                            return 0
+                        fi
+
+                        curl_error="$(cat /tmp/curl-error.log)"
+
+                        if [ -n "${curl_error}" ]; then
+                            echo "Attempt ${attempt} failed for ${label}: ${url} (curl error: ${curl_error})"
+                        else
+                            echo "Attempt ${attempt} failed for ${label}: ${url} (HTTP ${http_status})"
+                        fi
+
+                        if [ "${attempt}" -lt "${attempts}" ]; then
+                            sleep "${delay}"
+                        fi
+                    done
+
+                    echo "::error title=Preview health check failed::${label} is not reachable at ${url}. Last HTTP status: ${http_status}${curl_error:+; curl error: ${curl_error}}"
+                    return 1
+                }
+
+                check_url "${BASE_URL}/" "Preview reports index"
+                check_url "${BASE_URL}/coverage/" "Preview coverage report"
+
     comment_preview:
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
         name: Comment Pull Request Preview URLs
-        needs: reports
+        needs:
+            - reports
+            - verify_preview_reports
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -33,9 +33,11 @@ The ``reports.yml`` workflow is responsible for generating technical documentati
 
 **Behavior:**
 *   **Main Branch**: Runs all checks and deploys the final reports to the root of the ``gh-pages`` branch.
+    *   Runs a post-deploy health check against the published reports index and coverage URLs with retry/backoff to account for Pages propagation.
 *   **Pull Requests**:
     *   Generates a **Preview** of the documentation, coverage, and metrics.
     *   Deploys the preview to ``gh-pages`` under ``previews/pr-{number}/``.
+    *   Verifies the preview index and coverage URLs after deployment before posting preview links.
     *   Posts a **Sticky Comment** on the PR with links to the live preview, coverage report, and metrics site.
     *   **Cleanup**: When a PR is closed, the workflow automatically removes the preview directory from the ``gh-pages`` branch to keep the repository clean.
     *   **Concurrency**: New pushes to the same PR cancel older in-progress preview runs without affecting other PRs.


### PR DESCRIPTION
## Summary
- add post-deploy health check jobs for main and pull request reports deployments
- verify the published index and coverage URLs with retry/backoff and clearer diagnostics
- document the health-check behavior in the GitHub Actions guide

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reports.yml")'
- git diff --check

Closes #70