### PR TITLE
[sync] Synchronize funding metadata (#56)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 github: php-fast-forward
 custom:
-  - https://www.paypal.com/donate/?business=JLDAF45XZ8D84
+  - 'https://www.paypal.com/donate/?business=JLDAF45XZ8D84'

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ composer reports --target=.dev-tools --coverage=.dev-tools/coverage
 # Synchronize packaged agent skills into .agents/skills
 composer skills
 
+# Synchronize Composer funding metadata with .github/FUNDING.yml
+composer funding
+composer funding --dry-run
+
 # Merges and synchronizes .gitignore files
 composer gitignore
 
@@ -117,6 +121,10 @@ The `metrics` command ships with `phpmetrics/phpmetrics` as a direct
 dependency of `fast-forward/dev-tools`, so consumer repositories can generate
 metrics reports without extra setup.
 
+The `funding` command keeps supported `composer.json` funding entries aligned
+with `.github/FUNDING.yml`, including GitHub Sponsors handles and `custom`
+URLs, while preserving unsupported providers in place.
+
 The `skills` command keeps `.agents/skills` aligned with the packaged Fast
 Forward skill set. It creates missing links, repairs broken links, and
 preserves existing non-symlink directories. The `dev-tools:sync` command calls
@@ -138,8 +146,9 @@ source of truth.
 | `composer metrics` | Runs PhpMetrics for the current project and generates requested report artifacts. |
 | `composer docs` | Builds the HTML documentation site from PSR-4 code and `docs/`. |
 | `composer skills` | Creates or repairs packaged skill links in `.agents/skills`. |
+| `composer funding` | Synchronizes managed funding metadata between `composer.json` and `.github/FUNDING.yml`. |
 | `composer gitattributes` | Manages export-ignore rules in `.gitattributes`. |
-| `composer dev-tools:sync` | Updates scripts, workflow stubs, `.editorconfig`, `.gitignore`, `.gitattributes`, wiki setup, and packaged skills. |
+| `composer dev-tools:sync` | Updates scripts, funding metadata, workflow stubs, `.editorconfig`, `.gitignore`, `.gitattributes`, wiki setup, and packaged skills. |
 
 ## 🔌 Integration
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ metrics reports without extra setup.
 
 The `funding` command keeps supported `composer.json` funding entries aligned
 with `.github/FUNDING.yml`, including GitHub Sponsors handles and `custom`
-URLs, while preserving unsupported providers in place.
+URLs, while preserving unsupported providers in place and re-running
+`composer normalize` after manifest updates.
 
 The `skills` command keeps `.agents/skills` aligned with the packaged Fast
 Forward skill set. It creates missing links, repairs broken links, and

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "symfony/process": "^7.4 || ^8.0",
         "symfony/var-dumper": "^7.4 || ^8.0",
         "symfony/var-exporter": "^7.4 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0",
         "symplify/easy-coding-standard": "^13.0",
         "thecodingmachine/safe": "^3.4",
         "twig/twig": "^3.24"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,16 @@
         "source": "https://github.com/php-fast-forward/dev-tools",
         "docs": "https://php-fast-forward.github.io/dev-tools/"
     },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/php-fast-forward"
+        },
+        {
+            "type": "custom",
+            "url": "https://www.paypal.com/donate/?business=JLDAF45XZ8D84"
+        }
+    ],
     "require": {
         "php": "^8.3",
         "composer-plugin-api": "^2.0",

--- a/docs/api/commands.rst
+++ b/docs/api/commands.rst
@@ -44,6 +44,9 @@ dependencies through constructor injection. The architecture uses
    * - ``FastForward\DevTools\Console\Command\SkillsCommand``
      - ``skills``
      - Synchronizes packaged agent skills into ``.agents/skills``.
+   * - ``FastForward\DevTools\Console\Command\FundingCommand``
+     - ``funding``
+     - Synchronizes managed funding metadata between Composer and GitHub files.
    * - ``FastForward\DevTools\Console\Command\SyncCommand``
      - ``dev-tools:sync``
      - Synchronizes consumer-facing scripts, automation assets, and packaged

--- a/docs/commands/funding.rst
+++ b/docs/commands/funding.rst
@@ -1,0 +1,105 @@
+funding
+=======
+
+Synchronizes funding metadata between ``composer.json`` and
+``.github/FUNDING.yml``.
+
+Description
+-----------
+
+The ``funding`` command merges supported funding metadata declared in Composer
+and GitHub formats so both files stay aligned:
+
+1. Composer ``funding`` entries with ``type=github`` are normalized to GitHub
+   Sponsors handles in ``.github/FUNDING.yml``.
+2. Composer ``funding`` entries with ``type=custom`` are normalized to
+   ``custom`` URLs in ``.github/FUNDING.yml``.
+3. Existing ``github`` and ``custom`` entries from ``.github/FUNDING.yml`` are
+   mirrored back into ``composer.json``.
+4. Unsupported providers are preserved in their original format.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   composer funding
+   composer funding [options]
+   composer dev-tools funding -- [options]
+   vendor/bin/dev-tools funding [options]
+
+Options
+-------
+
+``--composer-file`` (optional)
+   Path to the Composer manifest to synchronize. Default:
+   ``Factory::getComposerFile()``.
+
+``--funding-file`` (optional)
+   Path to the GitHub funding file to synchronize. Default:
+   ``.github/FUNDING.yml``.
+
+``--dry-run``
+   Preview funding metadata drift without writing files.
+
+``--check``
+   Exit with code ``1`` when synchronized funding metadata would change either
+   file.
+
+``--interactive``
+   Prompt before writing drifted funding metadata files.
+
+Examples
+--------
+
+Synchronize the default files:
+
+.. code-block:: bash
+
+   composer funding
+
+Preview funding drift:
+
+.. code-block:: bash
+
+   composer funding --dry-run
+
+Validate funding metadata in CI:
+
+.. code-block:: bash
+
+   composer funding --check
+
+Use custom paths:
+
+.. code-block:: bash
+
+   composer funding --composer-file=packages/example/composer.json --funding-file=packages/example/.github/FUNDING.yml
+
+Exit Codes
+----------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Code
+     - Meaning
+   * - 0
+     - Success. Funding metadata was already aligned or was updated
+       successfully.
+   * - 1
+     - Failure. ``--check`` detected drift or a write failed.
+
+Behavior
+--------
+
+- Supports GitHub Sponsors handles and ``custom`` URLs as synchronized managed
+  entries.
+- Preserves unsupported Composer funding providers and unsupported GitHub
+  funding YAML keys.
+- Creates ``.github/FUNDING.yml`` when Composer declares supported funding
+  metadata and the file is missing.
+- Skips writing ``.github/FUNDING.yml`` when neither side declares supported
+  funding metadata.
+- Renders a unified diff during ``--dry-run`` and ``--check`` so local runs and
+  CI logs show the managed changes clearly.

--- a/docs/commands/funding.rst
+++ b/docs/commands/funding.rst
@@ -97,6 +97,8 @@ Behavior
   entries.
 - Preserves unsupported Composer funding providers and unsupported GitHub
   funding YAML keys.
+- Normalizes ``composer.json`` with ``composer normalize`` after applying
+  funding metadata updates.
 - Creates ``.github/FUNDING.yml`` when Composer declares supported funding
   metadata and the file is missing.
 - Skips writing ``.github/FUNDING.yml`` when neither side declares supported

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -18,6 +18,7 @@ Detailed documentation for each dev-tools command.
    reports
    skills
    sync
+   funding
    gitignore
    gitattributes
    license

--- a/docs/commands/sync.rst
+++ b/docs/commands/sync.rst
@@ -12,12 +12,13 @@ The ``dev-tools:sync`` command synchronizes consumer-facing automation and defau
 2. ``copy-resource`` - copies GitHub Actions workflows
 3. ``copy-resource`` - copies .editorconfig
 4. ``copy-resource`` - copies dependabot.yml
-5. ``wiki --init`` - initializes wiki as submodule
-6. ``gitignore`` - merges .gitignore files
-7. ``gitattributes`` - manages export-ignore rules
-8. ``skills`` - synchronizes packaged skills
-9. ``license`` - generates LICENSE file
-10. ``git-hooks`` - installs Git hooks
+5. ``funding`` - synchronizes ``composer.json`` funding metadata with ``.github/FUNDING.yml``
+6. ``wiki --init`` - initializes wiki as submodule
+7. ``gitignore`` - merges .gitignore files
+8. ``gitattributes`` - manages export-ignore rules
+9. ``skills`` - synchronizes packaged skills
+10. ``license`` - generates LICENSE file
+11. ``git-hooks`` - installs Git hooks
 
 Usage
 -----
@@ -89,13 +90,16 @@ Exit Codes
 Behavior
 ---------
 
-- Updates ``composer.json`` scripts and extra configuration.
+- Updates ``composer.json`` scripts, extra configuration, and managed funding
+  metadata.
 - Copies missing workflow stubs, ``.editorconfig``, and ``dependabot.yml``.
+- Synchronizes supported funding metadata between ``composer.json`` and
+  ``.github/FUNDING.yml``.
 - When ``--overwrite`` is enabled, replaced text resources emit a unified diff
   so terminal sessions and CI logs show what changed.
 - ``--dry-run`` and ``--check`` verify managed-file drift for ``composer.json``,
-  copied resources, ``.gitignore``, ``.gitattributes``, ``LICENSE``, and Git
-  hooks.
+  funding metadata, copied resources, ``.gitignore``, ``.gitattributes``,
+  ``LICENSE``, and Git hooks.
 - ``--interactive`` prompts before replacing drifted managed files when the
   command is running in an interactive terminal.
 - Creates ``.github/wiki`` as a git submodule when missing.

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -193,6 +193,28 @@ Important details:
 - it creates missing symlinks and repairs broken ones;
 - it preserves an existing non-symlink directory instead of overwriting it.
 
+``funding``
+-----------
+
+Synchronizes supported funding metadata between Composer and GitHub formats.
+
+.. code-block:: bash
+
+   composer funding
+   composer funding --dry-run
+   composer funding --check
+
+Important details:
+
+- it keeps ``composer.json`` ``funding`` entries and ``.github/FUNDING.yml`` in
+  sync for GitHub Sponsors and ``custom`` URLs;
+- it preserves unsupported Composer funding providers and unsupported YAML
+  keys instead of rewriting them;
+- it creates ``.github/FUNDING.yml`` when Composer already declares supported
+  funding metadata;
+- it supports ``--dry-run``, ``--check``, and ``--interactive`` so funding
+  drift can be surfaced in CI and reviewed locally.
+
 ``dev-tools:sync``
 ------------------
 
@@ -206,6 +228,8 @@ Important details:
 
 - it updates ``composer.json`` scripts and
   ``extra.grumphp.config-default-path``;
+- it calls ``funding`` so supported funding metadata stays aligned between
+  ``composer.json`` and ``.github/FUNDING.yml``;
 - it copies missing workflow stubs, ``.editorconfig``, and ``dependabot.yml``;
 - it creates ``.github/wiki`` as a git submodule when the directory is
   missing.

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\Factory;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Funding\ComposerFundingCodec;
+use FastForward\DevTools\Funding\FundingProfileMerger;
+use FastForward\DevTools\Funding\FundingYamlCodec;
+use FastForward\DevTools\Resource\FileDiffer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * Synchronizes funding metadata between composer.json and .github/FUNDING.yml.
+ */
+#[AsCommand(
+    name: 'funding',
+    description: 'Synchronizes funding metadata between composer.json and .github/FUNDING.yml.',
+    help: 'This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.'
+)]
+final class FundingCommand extends BaseCommand
+{
+    /**
+     * Creates a new FundingCommand instance.
+     *
+     * @param FilesystemInterface $filesystem the filesystem used to read and write funding metadata files
+     * @param ComposerFundingCodec $composerFundingCodec the codec used to parse and render Composer funding metadata
+     * @param FundingYamlCodec $fundingYamlCodec the codec used to parse and render GitHub funding YAML metadata
+     * @param FundingProfileMerger $fundingProfileMerger the merger used to synchronize normalized funding profiles
+     * @param FileDiffer $fileDiffer the differ used to summarize managed-file drift
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly ComposerFundingCodec $composerFundingCodec,
+        private readonly FundingYamlCodec $fundingYamlCodec,
+        private readonly FundingProfileMerger $fundingProfileMerger,
+        private readonly FileDiffer $fileDiffer,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures command options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                name: 'composer-file',
+                mode: InputOption::VALUE_OPTIONAL,
+                description: 'Path to the composer.json file to synchronize.',
+                default: Factory::getComposerFile(),
+            )
+            ->addOption(
+                name: 'funding-file',
+                mode: InputOption::VALUE_OPTIONAL,
+                description: 'Path to the .github/FUNDING.yml file to synchronize.',
+                default: '.github/FUNDING.yml',
+            )
+            ->addOption(
+                name: 'dry-run',
+                mode: InputOption::VALUE_NONE,
+                description: 'Preview funding metadata synchronization without writing files.',
+            )
+            ->addOption(
+                name: 'check',
+                mode: InputOption::VALUE_NONE,
+                description: 'Report funding metadata drift and exit non-zero when updates are required.',
+            )
+            ->addOption(
+                name: 'interactive',
+                mode: InputOption::VALUE_NONE,
+                description: 'Prompt before applying funding metadata updates.',
+            );
+    }
+
+    /**
+     * Synchronizes funding metadata across Composer and GitHub files.
+     *
+     * @param InputInterface $input the command input
+     * @param OutputInterface $output the command output
+     *
+     * @return int the command status code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $composerFile = (string) $input->getOption('composer-file');
+        $fundingFile = (string) $input->getOption('funding-file');
+        $dryRun = (bool) $input->getOption('dry-run');
+        $check = (bool) $input->getOption('check');
+        $interactive = (bool) $input->getOption('interactive');
+
+        $output->writeln('<info>Synchronizing funding metadata...</info>');
+
+        if (! $this->filesystem->exists($composerFile)) {
+            $output->writeln(\sprintf('<comment>Composer file %s does not exist. Skipping funding synchronization.</comment>', $composerFile));
+
+            return self::SUCCESS;
+        }
+
+        $composerContents = $this->filesystem->readFile($composerFile);
+        $fundingContents = $this->filesystem->exists($fundingFile) ? $this->filesystem->readFile($fundingFile) : null;
+
+        $mergedProfile = $this->fundingProfileMerger->merge(
+            $this->composerFundingCodec->parse($composerContents),
+            $this->fundingYamlCodec->parse($fundingContents),
+        );
+
+        $updatedComposerContents = $this->composerFundingCodec->dump($composerContents, $mergedProfile);
+        $updatedFundingContents = $mergedProfile->hasYamlContent()
+            ? $this->fundingYamlCodec->dump($mergedProfile)
+            : null;
+
+        $composerStatus = $this->handleComposerFile(
+            $composerFile,
+            $composerContents,
+            $updatedComposerContents,
+            $dryRun,
+            $check,
+            $interactive,
+            $input,
+            $output,
+        );
+
+        $fundingStatus = $this->handleFundingFile(
+            $fundingFile,
+            $fundingContents,
+            $updatedFundingContents,
+            $dryRun,
+            $check,
+            $interactive,
+            $input,
+            $output,
+        );
+
+        return max($composerStatus, $fundingStatus);
+    }
+
+    /**
+     * Handles composer.json synchronization reporting and writes.
+     *
+     * @return int the command status code
+     */
+    private function handleComposerFile(
+        string $composerFile,
+        string $composerContents,
+        string $updatedComposerContents,
+        bool $dryRun,
+        bool $check,
+        bool $interactive,
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $comparison = $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            $composerFile,
+            $updatedComposerContents,
+            $composerContents,
+            \sprintf('Updating managed file %s from generated funding metadata synchronization.', $composerFile),
+        );
+
+        $output->writeln(\sprintf('<comment>%s</comment>', $comparison->getSummary()));
+
+        if ($comparison->isChanged()) {
+            $consoleDiff = $this->fileDiffer->formatForConsole($comparison->getDiff(), $output->isDecorated());
+
+            if (null !== $consoleDiff) {
+                $output->writeln($consoleDiff);
+            }
+        }
+
+        if ($comparison->isUnchanged()) {
+            return self::SUCCESS;
+        }
+
+        if ($check) {
+            return self::FAILURE;
+        }
+
+        if ($dryRun) {
+            return self::SUCCESS;
+        }
+
+        if ($interactive && $input->isInteractive() && ! $this->shouldWriteManagedFile($input, $output, $composerFile)) {
+            $output->writeln(\sprintf('<comment>Skipped updating %s.</comment>', $composerFile));
+
+            return self::SUCCESS;
+        }
+
+        $this->filesystem->dumpFile($composerFile, $updatedComposerContents);
+        $output->writeln(\sprintf('<info>Updated funding metadata in %s.</info>', $composerFile));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Handles .github/FUNDING.yml synchronization reporting and writes.
+     *
+     * @return int the command status code
+     */
+    private function handleFundingFile(
+        string $fundingFile,
+        ?string $currentFundingContents,
+        ?string $updatedFundingContents,
+        bool $dryRun,
+        bool $check,
+        bool $interactive,
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        if (null === $updatedFundingContents && null === $currentFundingContents) {
+            $output->writeln('<comment>No supported funding metadata found. Skipping .github/FUNDING.yml synchronization.</comment>');
+
+            return self::SUCCESS;
+        }
+
+        if (null === $updatedFundingContents) {
+            return self::SUCCESS;
+        }
+
+        $comparison = $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            $fundingFile,
+            $updatedFundingContents,
+            $currentFundingContents,
+            null === $currentFundingContents
+                ? \sprintf('Managed file %s will be created from generated funding metadata synchronization.', $fundingFile)
+                : \sprintf('Updating managed file %s from generated funding metadata synchronization.', $fundingFile),
+        );
+
+        $output->writeln(\sprintf('<comment>%s</comment>', $comparison->getSummary()));
+
+        if ($comparison->isChanged()) {
+            $consoleDiff = $this->fileDiffer->formatForConsole($comparison->getDiff(), $output->isDecorated());
+
+            if (null !== $consoleDiff) {
+                $output->writeln($consoleDiff);
+            }
+        }
+
+        if ($comparison->isUnchanged()) {
+            return self::SUCCESS;
+        }
+
+        if ($check) {
+            return self::FAILURE;
+        }
+
+        if ($dryRun) {
+            return self::SUCCESS;
+        }
+
+        if ($interactive && $input->isInteractive() && ! $this->shouldWriteManagedFile($input, $output, $fundingFile)) {
+            $output->writeln(\sprintf('<comment>Skipped updating %s.</comment>', $fundingFile));
+
+            return self::SUCCESS;
+        }
+
+        $this->filesystem->mkdir($this->filesystem->dirname($fundingFile));
+        $this->filesystem->dumpFile($fundingFile, $updatedFundingContents);
+        $output->writeln(\sprintf('<info>Updated funding metadata in %s.</info>', $fundingFile));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Prompts whether a managed file should be written.
+     *
+     * @return bool true when the write SHOULD proceed
+     */
+    private function shouldWriteManagedFile(InputInterface $input, OutputInterface $output, string $targetFile): bool
+    {
+        $question = new ConfirmationQuestion(\sprintf('Update managed file %s? [y/N] ', $targetFile), false);
+
+        return (bool) $this->getHelper('question')->ask($input, $output, $question);
+    }
+}

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -25,6 +25,8 @@ use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Funding\ComposerFundingCodec;
 use FastForward\DevTools\Funding\FundingProfileMerger;
 use FastForward\DevTools\Funding\FundingYamlCodec;
+use FastForward\DevTools\Process\ProcessBuilderInterface;
+use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Resource\FileDiffer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,6 +52,8 @@ final class FundingCommand extends BaseCommand
      * @param FundingYamlCodec $fundingYamlCodec the codec used to parse and render GitHub funding YAML metadata
      * @param FundingProfileMerger $fundingProfileMerger the merger used to synchronize normalized funding profiles
      * @param FileDiffer $fileDiffer the differ used to summarize managed-file drift
+     * @param ProcessBuilderInterface $processBuilder the process builder used to normalize composer.json after updates
+     * @param ProcessQueueInterface $processQueue the process queue used to execute composer normalize
      */
     public function __construct(
         private readonly FilesystemInterface $filesystem,
@@ -57,6 +61,8 @@ final class FundingCommand extends BaseCommand
         private readonly FundingYamlCodec $fundingYamlCodec,
         private readonly FundingProfileMerger $fundingProfileMerger,
         private readonly FileDiffer $fileDiffer,
+        private readonly ProcessBuilderInterface $processBuilder,
+        private readonly ProcessQueueInterface $processQueue,
     ) {
         parent::__construct();
     }
@@ -210,6 +216,11 @@ final class FundingCommand extends BaseCommand
         }
 
         $this->filesystem->dumpFile($composerFile, $updatedComposerContents);
+
+        if (self::SUCCESS !== $this->normalizeComposerFile($composerFile, $output)) {
+            return self::FAILURE;
+        }
+
         $output->writeln(\sprintf('<info>Updated funding metadata in %s.</info>', $composerFile));
 
         return self::SUCCESS;
@@ -295,5 +306,36 @@ final class FundingCommand extends BaseCommand
         $question = new ConfirmationQuestion(\sprintf('Update managed file %s? [y/N] ', $targetFile), false);
 
         return (bool) $this->getHelper('question')->ask($input, $output, $question);
+    }
+
+    /**
+     * Normalizes a composer manifest after funding metadata changes.
+     *
+     * @param string $composerFile the composer manifest path
+     * @param OutputInterface $output the command output
+     *
+     * @return int the normalization status code
+     */
+    private function normalizeComposerFile(string $composerFile, OutputInterface $output): int
+    {
+        $processBuilder = $this->processBuilder
+            ->withArgument('--ansi')
+            ->withArgument('--no-update-lock');
+
+        $workingDirectory = $this->filesystem->dirname($composerFile);
+
+        if ('.' !== $workingDirectory) {
+            $processBuilder = $processBuilder->withArgument('--working-dir', $workingDirectory);
+        }
+
+        $composerBasename = $this->filesystem->basename($composerFile);
+
+        if ('composer.json' !== $composerBasename) {
+            $processBuilder = $processBuilder->withArgument('--file', $composerBasename);
+        }
+
+        $this->processQueue->add($processBuilder->build('composer normalize'));
+
+        return $this->processQueue->run($output);
     }
 }

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -34,7 +34,7 @@ use Symfony\Component\Filesystem\Path;
 #[AsCommand(
     name: 'dev-tools:sync',
     description: 'Installs and synchronizes dev-tools scripts, GitHub Actions workflows, .editorconfig, and .gitattributes in the root project.',
-    help: 'This command runs the dedicated synchronization commands for composer.json, resources, wiki, Git metadata, skills, license, and Git hooks.'
+    help: 'This command runs the dedicated synchronization commands for composer.json, resources, funding metadata, wiki, Git metadata, skills, license, and Git hooks.'
 )]
 final class SyncCommand extends BaseCommand
 {
@@ -103,6 +103,7 @@ final class SyncCommand extends BaseCommand
         $allowDetached = ! $dryRun && ! $check && ! $interactive;
 
         $this->queueDevToolsCommand(['update-composer-json', ...$modeArguments]);
+        $this->queueDevToolsCommand(['funding', ...$modeArguments]);
         $this->queueDevToolsCommand(
             [
                 'copy-resource',

--- a/src/Funding/ComposerFundingCodec.php
+++ b/src/Funding/ComposerFundingCodec.php
@@ -20,11 +20,10 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Funding;
 
 use Composer\Json\JsonFile;
-use Composer\Json\JsonManipulator;
-
 use function array_values;
 use function is_array;
 use function is_string;
+use function json_encode;
 use function parse_url;
 use function preg_match;
 use function sprintf;
@@ -103,7 +102,6 @@ final readonly class ComposerFundingCodec
      */
     public function dump(string $contents, FundingProfile $profile): string
     {
-        $manipulator = new JsonManipulator($contents);
         $entries = [];
 
         foreach ($profile->getGithubSponsors() as $githubSponsor) {
@@ -124,13 +122,20 @@ final readonly class ComposerFundingCodec
             $entries[] = $unsupportedEntry;
         }
 
-        $manipulator->removeMainKey('funding');
+        $data = JsonFile::parseJson($contents);
+        unset($data['funding']);
 
-        if ([] !== $entries) {
-            $manipulator->addMainKey('funding', $entries);
+        if ([] === $entries) {
+            return json_encode(
+                $data,
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ) . "\n";
         }
 
-        return $manipulator->getContents();
+        return json_encode(
+            $this->insertFundingEntries($data, $entries),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
     }
 
     /**
@@ -158,5 +163,34 @@ final readonly class ComposerFundingCodec
         }
 
         return $matches[1];
+    }
+
+    /**
+     * Inserts funding entries in a stable Composer key order.
+     *
+     * @param array<string, mixed> $data the decoded composer.json payload
+     * @param array<int, array<string, mixed>> $entries the funding entries to insert
+     *
+     * @return array<string, mixed> the composer payload with funding inserted
+     */
+    private function insertFundingEntries(array $data, array $entries): array
+    {
+        $orderedData = [];
+        $inserted = false;
+
+        foreach ($data as $key => $value) {
+            $orderedData[$key] = $value;
+
+            if ('support' === $key) {
+                $orderedData['funding'] = $entries;
+                $inserted = true;
+            }
+        }
+
+        if (! $inserted) {
+            $orderedData['funding'] = $entries;
+        }
+
+        return $orderedData;
     }
 }

--- a/src/Funding/ComposerFundingCodec.php
+++ b/src/Funding/ComposerFundingCodec.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Funding;
+
+use Composer\Json\JsonFile;
+use Composer\Json\JsonManipulator;
+
+use function array_values;
+use function is_array;
+use function is_string;
+use function parse_url;
+use function preg_match;
+use function sprintf;
+use function trim;
+
+/**
+ * Parses and renders Composer funding metadata.
+ */
+final readonly class ComposerFundingCodec
+{
+    /**
+     * Parses Composer funding entries into a normalized funding profile.
+     *
+     * @param string $contents the composer.json contents
+     *
+     * @return FundingProfile the normalized funding profile
+     */
+    public function parse(string $contents): FundingProfile
+    {
+        $data = JsonFile::parseJson($contents);
+        $funding = $data['funding'] ?? [];
+
+        if (! is_array($funding)) {
+            return new FundingProfile();
+        }
+
+        $githubSponsors = [];
+        $customUrls = [];
+        $unsupported = [];
+
+        foreach ($funding as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $type = is_string($entry['type'] ?? null) ? trim($entry['type']) : '';
+            $url = is_string($entry['url'] ?? null) ? trim($entry['url']) : '';
+
+            if ('' === $url) {
+                $unsupported[] = $entry;
+
+                continue;
+            }
+
+            $githubSponsor = $this->extractGithubSponsor($url);
+
+            if ('github' === $type && null !== $githubSponsor) {
+                $githubSponsors[] = $githubSponsor;
+
+                continue;
+            }
+
+            if ('custom' === $type) {
+                $customUrls[] = $url;
+
+                continue;
+            }
+
+            $unsupported[] = $entry;
+        }
+
+        return new FundingProfile(
+            array_values(array_unique($githubSponsors)),
+            array_values(array_unique($customUrls)),
+            unsupportedComposerEntries: $unsupported,
+        );
+    }
+
+    /**
+     * Applies a normalized funding profile to composer.json contents.
+     *
+     * @param string $contents the composer.json contents
+     * @param FundingProfile $profile the merged funding profile
+     *
+     * @return string the updated composer.json contents
+     */
+    public function dump(string $contents, FundingProfile $profile): string
+    {
+        $manipulator = new JsonManipulator($contents);
+        $entries = [];
+
+        foreach ($profile->getGithubSponsors() as $githubSponsor) {
+            $entries[] = [
+                'type' => 'github',
+                'url' => sprintf('https://github.com/sponsors/%s', $githubSponsor),
+            ];
+        }
+
+        foreach ($profile->getCustomUrls() as $customUrl) {
+            $entries[] = [
+                'type' => 'custom',
+                'url' => $customUrl,
+            ];
+        }
+
+        foreach ($profile->getUnsupportedComposerEntries() as $unsupportedEntry) {
+            $entries[] = $unsupportedEntry;
+        }
+
+        $manipulator->removeMainKey('funding');
+
+        if ([] !== $entries) {
+            $manipulator->addMainKey('funding', $entries);
+        }
+
+        return $manipulator->getContents();
+    }
+
+    /**
+     * Extracts a GitHub Sponsors handle from a funding URL.
+     *
+     * @param string $url the funding URL
+     *
+     * @return string|null the sponsor handle, or null when the URL is unsupported
+     */
+    private function extractGithubSponsor(string $url): ?string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (! is_string($host) || ! is_string($path)) {
+            return null;
+        }
+
+        if (! \in_array($host, ['github.com', 'www.github.com'], true)) {
+            return null;
+        }
+
+        if (1 !== preg_match('#^/sponsors/([^/]+)$#', $path, $matches)) {
+            return null;
+        }
+
+        return $matches[1];
+    }
+}

--- a/src/Funding/FundingProfile.php
+++ b/src/Funding/FundingProfile.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Funding;
+
+/**
+ * Carries normalized funding metadata across Composer and GitHub formats.
+ */
+final readonly class FundingProfile
+{
+    /**
+     * Creates a new funding profile.
+     *
+     * @param array<int, string> $githubSponsors the normalized GitHub Sponsors handles
+     * @param array<int, string> $customUrls the normalized custom funding URLs
+     * @param array<string, mixed> $unsupportedYamlEntries the YAML entries preserved without synchronization
+     * @param array<int, array<string, mixed>> $unsupportedComposerEntries the Composer entries preserved without synchronization
+     */
+    public function __construct(
+        private array $githubSponsors = [],
+        private array $customUrls = [],
+        private array $unsupportedYamlEntries = [],
+        private array $unsupportedComposerEntries = [],
+    ) {
+    }
+
+    /**
+     * Returns the normalized GitHub Sponsors handles.
+     *
+     * @return array<int, string> the GitHub Sponsors handles
+     */
+    public function getGithubSponsors(): array
+    {
+        return $this->githubSponsors;
+    }
+
+    /**
+     * Returns the normalized custom funding URLs.
+     *
+     * @return array<int, string> the custom funding URLs
+     */
+    public function getCustomUrls(): array
+    {
+        return $this->customUrls;
+    }
+
+    /**
+     * Returns the unsupported YAML entries that MUST be preserved.
+     *
+     * @return array<string, mixed> the YAML entries kept without transformation
+     */
+    public function getUnsupportedYamlEntries(): array
+    {
+        return $this->unsupportedYamlEntries;
+    }
+
+    /**
+     * Returns the unsupported Composer funding entries that MUST be preserved.
+     *
+     * @return array<int, array<string, mixed>> the Composer funding entries kept without transformation
+     */
+    public function getUnsupportedComposerEntries(): array
+    {
+        return $this->unsupportedComposerEntries;
+    }
+
+    /**
+     * Reports whether the profile contains any YAML-serializable content.
+     *
+     * @return bool true when the YAML file SHOULD exist
+     */
+    public function hasYamlContent(): bool
+    {
+        return [] !== $this->githubSponsors
+            || [] !== $this->customUrls
+            || [] !== $this->unsupportedYamlEntries;
+    }
+}

--- a/src/Funding/FundingProfileMerger.php
+++ b/src/Funding/FundingProfileMerger.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Funding;
+
+use function array_merge;
+use function array_unique;
+use function sort;
+
+/**
+ * Merges normalized funding profiles into a deterministic synchronized view.
+ */
+final readonly class FundingProfileMerger
+{
+    /**
+     * Merges funding metadata from Composer and GitHub sources.
+     *
+     * @param FundingProfile $composerProfile the funding metadata sourced from composer.json
+     * @param FundingProfile $yamlProfile the funding metadata sourced from .github/FUNDING.yml
+     *
+     * @return FundingProfile the merged synchronized funding metadata
+     */
+    public function merge(FundingProfile $composerProfile, FundingProfile $yamlProfile): FundingProfile
+    {
+        return new FundingProfile(
+            $this->sortedUnique([...$composerProfile->getGithubSponsors(), ...$yamlProfile->getGithubSponsors()]),
+            $this->sortedUnique([...$composerProfile->getCustomUrls(), ...$yamlProfile->getCustomUrls()]),
+            $yamlProfile->getUnsupportedYamlEntries(),
+            $composerProfile->getUnsupportedComposerEntries(),
+        );
+    }
+
+    /**
+     * Returns a sorted unique list of scalar values.
+     *
+     * @param array<int, string> $values the values to normalize
+     *
+     * @return array<int, string> the sorted unique values
+     */
+    private function sortedUnique(array $values): array
+    {
+        $values = array_values(array_unique($values));
+        sort($values);
+
+        return $values;
+    }
+}

--- a/src/Funding/FundingYamlCodec.php
+++ b/src/Funding/FundingYamlCodec.php
@@ -81,7 +81,7 @@ final readonly class FundingYamlCodec
         }
 
         if ([] !== $profile->getCustomUrls()) {
-            $data['custom'] = $this->denormalizeList($profile->getCustomUrls());
+            $data['custom'] = $profile->getCustomUrls();
         }
 
         return Yaml::dump($data, 4, 2);

--- a/src/Funding/FundingYamlCodec.php
+++ b/src/Funding/FundingYamlCodec.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Funding;
+
+use Symfony\Component\Yaml\Yaml;
+
+use function array_filter;
+use function array_values;
+use function count;
+use function is_array;
+use function is_string;
+use function trim;
+
+/**
+ * Parses and renders GitHub funding YAML metadata.
+ */
+final readonly class FundingYamlCodec
+{
+    /**
+     * Parses a GitHub funding YAML payload into a normalized profile.
+     *
+     * @param string|null $contents the YAML contents, or null when the file does not exist
+     *
+     * @return FundingProfile the normalized funding profile
+     */
+    public function parse(?string $contents): FundingProfile
+    {
+        if (null === $contents || '' === trim($contents)) {
+            return new FundingProfile();
+        }
+
+        $data = Yaml::parse($contents);
+
+        if (! is_array($data)) {
+            return new FundingProfile();
+        }
+
+        $unsupported = array_filter(
+            $data,
+            static fn(string $key): bool => ! \in_array($key, ['github', 'custom'], true),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        return new FundingProfile(
+            $this->normalizeList($data['github'] ?? []),
+            $this->normalizeList($data['custom'] ?? []),
+            $unsupported,
+        );
+    }
+
+    /**
+     * Renders a normalized funding profile into GitHub funding YAML.
+     *
+     * @param FundingProfile $profile the profile to render
+     *
+     * @return string the YAML document contents
+     */
+    public function dump(FundingProfile $profile): string
+    {
+        $data = $profile->getUnsupportedYamlEntries();
+
+        if ([] !== $profile->getGithubSponsors()) {
+            $data['github'] = $this->denormalizeList($profile->getGithubSponsors());
+        }
+
+        if ([] !== $profile->getCustomUrls()) {
+            $data['custom'] = $this->denormalizeList($profile->getCustomUrls());
+        }
+
+        return Yaml::dump($data, 4, 2);
+    }
+
+    /**
+     * Normalizes a scalar-or-list YAML node into a string list.
+     *
+     * @param mixed $value the YAML node to normalize
+     *
+     * @return array<int, string> the normalized string list
+     */
+    private function normalizeList(mixed $value): array
+    {
+        if (is_string($value) && '' !== trim($value)) {
+            return [trim($value)];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(
+                static fn(mixed $entry): ?string => is_string($entry) && '' !== trim($entry) ? trim($entry) : null,
+                $value,
+            ),
+        ));
+    }
+
+    /**
+     * Converts a normalized list into the compact YAML representation.
+     *
+     * @param array<int, string> $values the normalized values
+     *
+     * @return string|array<int, string> the scalar-or-list YAML node
+     */
+    private function denormalizeList(array $values): string|array
+    {
+        return 1 === count($values) ? $values[0] : $values;
+    }
+}

--- a/tests/Console/Command/FundingCommandTest.php
+++ b/tests/Console/Command/FundingCommandTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Console\Command;
+
+use FastForward\DevTools\Console\Command\FundingCommand;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Funding\ComposerFundingCodec;
+use FastForward\DevTools\Funding\FundingProfile;
+use FastForward\DevTools\Funding\FundingProfileMerger;
+use FastForward\DevTools\Funding\FundingYamlCodec;
+use FastForward\DevTools\Resource\FileDiff;
+use FastForward\DevTools\Resource\FileDiffer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+use function Safe\json_decode;
+
+#[CoversClass(FundingCommand::class)]
+#[UsesClass(FileDiff::class)]
+#[UsesClass(ComposerFundingCodec::class)]
+#[UsesClass(FundingProfile::class)]
+#[UsesClass(FundingProfileMerger::class)]
+#[UsesClass(FundingYamlCodec::class)]
+final class FundingCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy $filesystem;
+
+    private ObjectProphecy $input;
+
+    private ObjectProphecy $output;
+
+    private ObjectProphecy $fileDiffer;
+
+    private FundingCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+        $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->output->isDecorated()->willReturn(false);
+        $this->output->writeln(Argument::any());
+        $this->fileDiffer->formatForConsole(Argument::cetera())->willReturn(null);
+        $this->input->getOption('composer-file')->willReturn('composer.json');
+        $this->input->getOption('funding-file')->willReturn('.github/FUNDING.yml');
+        $this->input->getOption('dry-run')->willReturn(false);
+        $this->input->getOption('check')->willReturn(false);
+        $this->input->getOption('interactive')->willReturn(false);
+        $this->filesystem->dirname('.github/FUNDING.yml')->willReturn('.github');
+
+        $this->command = new FundingCommand(
+            $this->filesystem->reveal(),
+            new ComposerFundingCodec(),
+            new FundingYamlCodec(),
+            new FundingProfileMerger(),
+            $this->fileDiffer->reveal(),
+        );
+    }
+
+    #[Test]
+    public function executeWillCreateComposerFundingFromFundingYaml(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\ncustom: https://example.com/support\n";
+
+        $this->filesystem->exists('composer.json')->willReturn(true);
+        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::that(static function (string $contents): bool {
+                $decoded = json_decode($contents, true);
+
+                return [
+                    ['type' => 'github', 'url' => 'https://github.com/sponsors/foo'],
+                    ['type' => 'custom', 'url' => 'https://example.com/support'],
+                ] === $decoded['funding'];
+            }),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(
+            'composer.json',
+            Argument::that(static fn(string $contents): bool => str_contains($contents, '"funding"')),
+        )->shouldBeCalledOnce();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    #[Test]
+    public function executeWillCreateFundingYamlFromComposerFunding(): void
+    {
+        $composerContents = <<<'JSON'
+{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
+JSON;
+
+        $this->filesystem->exists('composer.json')->willReturn(true);
+        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(false);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Composer unchanged'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::that(static function (string $contents): bool {
+                $decoded = Yaml::parse($contents);
+
+                return 'foo' === $decoded['github']
+                    && 'https://example.com/support' === $decoded['custom'];
+            }),
+            null,
+            'Managed file .github/FUNDING.yml will be created from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Funding changed'))->shouldBeCalledOnce();
+        $this->filesystem->mkdir('.github')->shouldBeCalledOnce();
+        $this->filesystem->dumpFile('.github/FUNDING.yml', Argument::type('string'))->shouldBeCalledOnce();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    #[Test]
+    public function executeWillMergeBothSourcesWithoutDuplicatingEntries(): void
+    {
+        $composerContents = <<<'JSON'
+{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"}]}
+JSON;
+        $fundingYaml = "custom: https://example.com/support\n";
+
+        $this->filesystem->exists('composer.json')->willReturn(true);
+        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::that(static function (string $contents): bool {
+                $decoded = json_decode($contents, true);
+
+                return [
+                    ['type' => 'github', 'url' => 'https://github.com/sponsors/foo'],
+                    ['type' => 'custom', 'url' => 'https://example.com/support'],
+                ] === $decoded['funding'];
+            }),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::that(static function (string $contents): bool {
+                $decoded = Yaml::parse($contents);
+
+                return 'foo' === $decoded['github']
+                    && 'https://example.com/support' === $decoded['custom'];
+            }),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Funding changed'))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile('composer.json', Argument::type('string'))->shouldBeCalledOnce();
+        $this->filesystem->mkdir('.github')->shouldBeCalledOnce();
+        $this->filesystem->dumpFile('.github/FUNDING.yml', Argument::type('string'))->shouldBeCalledOnce();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    #[Test]
+    public function executeWillBeIdempotentWhenFundingMetadataAlreadyMatches(): void
+    {
+        $composerContents = <<<'JSON'
+{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
+JSON;
+        $fundingYaml = "github: foo\ncustom: https://example.com/support\n";
+
+        $this->filesystem->exists('composer.json')->willReturn(true);
+        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Composer unchanged'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    #[Test]
+    public function commandWillSetExpectedNameDescriptionAndHelp(): void
+    {
+        self::assertSame('funding', $this->command->getName());
+        self::assertSame(
+            'Synchronizes funding metadata between composer.json and .github/FUNDING.yml.',
+            $this->command->getDescription(),
+        );
+        self::assertSame(
+            'This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.',
+            $this->command->getHelp(),
+        );
+    }
+
+    private function executeCommand(): int
+    {
+        $reflectionMethod = new ReflectionMethod($this->command, 'execute');
+
+        return $reflectionMethod->invoke($this->command, $this->input->reveal(), $this->output->reveal());
+    }
+}

--- a/tests/Console/Command/FundingCommandTest.php
+++ b/tests/Console/Command/FundingCommandTest.php
@@ -25,6 +25,8 @@ use FastForward\DevTools\Funding\ComposerFundingCodec;
 use FastForward\DevTools\Funding\FundingProfile;
 use FastForward\DevTools\Funding\FundingProfileMerger;
 use FastForward\DevTools\Funding\FundingYamlCodec;
+use FastForward\DevTools\Process\ProcessBuilderInterface;
+use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Resource\FileDiff;
 use FastForward\DevTools\Resource\FileDiffer;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,6 +39,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 
 use function Safe\json_decode;
@@ -59,6 +62,12 @@ final class FundingCommandTest extends TestCase
 
     private ObjectProphecy $fileDiffer;
 
+    private ObjectProphecy $processBuilder;
+
+    private ObjectProphecy $processQueue;
+
+    private ObjectProphecy $normalizeProcess;
+
     private FundingCommand $command;
 
     protected function setUp(): void
@@ -67,6 +76,9 @@ final class FundingCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
+        $this->normalizeProcess = $this->prophesize(Process::class);
         $this->output->isDecorated()->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())->willReturn(null);
@@ -76,6 +88,11 @@ final class FundingCommandTest extends TestCase
         $this->input->getOption('check')->willReturn(false);
         $this->input->getOption('interactive')->willReturn(false);
         $this->filesystem->dirname('.github/FUNDING.yml')->willReturn('.github');
+        $this->filesystem->dirname('composer.json')->willReturn('.');
+        $this->filesystem->basename('composer.json')->willReturn('composer.json');
+        $this->processBuilder->withArgument(Argument::any())->willReturn($this->processBuilder->reveal());
+        $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn($this->processBuilder->reveal());
+        $this->processBuilder->build('composer normalize')->willReturn($this->normalizeProcess->reveal());
 
         $this->command = new FundingCommand(
             $this->filesystem->reveal(),
@@ -83,6 +100,8 @@ final class FundingCommandTest extends TestCase
             new FundingYamlCodec(),
             new FundingProfileMerger(),
             $this->fileDiffer->reveal(),
+            $this->processBuilder->reveal(),
+            $this->processQueue->reveal(),
         );
     }
 
@@ -117,6 +136,8 @@ final class FundingCommandTest extends TestCase
             $fundingYaml,
             'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
         $this->filesystem->dumpFile(
             'composer.json',
             Argument::that(static fn(string $contents): bool => str_contains($contents, '"funding"')),
@@ -149,7 +170,7 @@ JSON;
                 $decoded = Yaml::parse($contents);
 
                 return 'foo' === $decoded['github']
-                    && 'https://example.com/support' === $decoded['custom'];
+                    && ['https://example.com/support'] === $decoded['custom'];
             }),
             null,
             'Managed file .github/FUNDING.yml will be created from generated funding metadata synchronization.',
@@ -193,11 +214,13 @@ JSON;
                 $decoded = Yaml::parse($contents);
 
                 return 'foo' === $decoded['github']
-                    && 'https://example.com/support' === $decoded['custom'];
+                    && ['https://example.com/support'] === $decoded['custom'];
             }),
             $fundingYaml,
             'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Funding changed'))->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
         $this->filesystem->dumpFile('composer.json', Argument::type('string'))->shouldBeCalledOnce();
         $this->filesystem->mkdir('.github')->shouldBeCalledOnce();
         $this->filesystem->dumpFile('.github/FUNDING.yml', Argument::type('string'))->shouldBeCalledOnce();
@@ -232,6 +255,7 @@ JSON;
             'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
         $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/SyncCommandTest.php
+++ b/tests/Console/Command/SyncCommandTest.php
@@ -73,7 +73,7 @@ final class SyncCommandTest extends TestCase
             $this->command->getDescription()
         );
         self::assertSame(
-            'This command runs the dedicated synchronization commands for composer.json, resources, wiki, Git metadata, skills, license, and Git hooks.',
+            'This command runs the dedicated synchronization commands for composer.json, resources, funding metadata, wiki, Git metadata, skills, license, and Git hooks.',
             $this->command->getHelp()
         );
     }
@@ -85,7 +85,7 @@ final class SyncCommandTest extends TestCase
     public function executeWillQueueDedicatedSynchronizationCommands(): void
     {
         $this->processQueue->add(Argument::type(Process::class), false, false)
-            ->shouldBeCalledOnce();
+            ->shouldBeCalledTimes(2);
         $this->processQueue->add(Argument::type(Process::class), false, true)
             ->shouldBeCalledTimes(9);
         $this->processQueue->run($this->output->reveal())
@@ -105,7 +105,7 @@ final class SyncCommandTest extends TestCase
             ->willReturn(true);
 
         $this->processQueue->add(Argument::type(Process::class), false, false)
-            ->shouldBeCalledTimes(8);
+            ->shouldBeCalledTimes(9);
         $this->processQueue->add(Argument::type(Process::class), false, true)
             ->shouldNotBeCalled();
         $this->processQueue->run($this->output->reveal())

--- a/tests/Funding/ComposerFundingCodecTest.php
+++ b/tests/Funding/ComposerFundingCodecTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Funding;
+
+use FastForward\DevTools\Funding\ComposerFundingCodec;
+use FastForward\DevTools\Funding\FundingProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+use function Safe\json_decode;
+
+#[CoversClass(ComposerFundingCodec::class)]
+#[UsesClass(FundingProfile::class)]
+final class ComposerFundingCodecTest extends TestCase
+{
+    #[Test]
+    public function parseWillNormalizeSupportedAndUnsupportedFundingEntries(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $profile = $codec->parse(<<<'JSON'
+{
+  "name": "example/package",
+  "funding": [
+    {"type": "github", "url": "https://github.com/sponsors/foo"},
+    {"type": "custom", "url": "https://example.com/support"},
+    {"type": "patreon", "url": "https://patreon.com/example"}
+  ]
+}
+JSON);
+
+        self::assertSame(['foo'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+        self::assertSame(
+            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            $profile->getUnsupportedComposerEntries(),
+        );
+    }
+
+    #[Test]
+    public function dumpWillWriteSupportedFundingAndPreserveUnsupportedEntries(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $contents = $codec->dump(
+            '{"name":"example/package"}',
+            new FundingProfile(
+                ['bar'],
+                ['https://example.com/support'],
+                unsupportedComposerEntries: [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            ),
+        );
+
+        $decoded = json_decode($contents, true);
+
+        self::assertSame(
+            [
+                ['type' => 'github', 'url' => 'https://github.com/sponsors/bar'],
+                ['type' => 'custom', 'url' => 'https://example.com/support'],
+                ['type' => 'patreon', 'url' => 'https://patreon.com/example'],
+            ],
+            $decoded['funding'],
+        );
+    }
+}

--- a/tests/Funding/FundingProfileMergerTest.php
+++ b/tests/Funding/FundingProfileMergerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Funding;
+
+use FastForward\DevTools\Funding\FundingProfile;
+use FastForward\DevTools\Funding\FundingProfileMerger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FundingProfileMerger::class)]
+#[UsesClass(FundingProfile::class)]
+final class FundingProfileMergerTest extends TestCase
+{
+    #[Test]
+    public function mergeWillCombineSupportedFundingAndPreserveUnsupportedEntries(): void
+    {
+        $merger = new FundingProfileMerger();
+
+        $merged = $merger->merge(
+            new FundingProfile(
+                ['foo'],
+                ['https://example.com/a'],
+                unsupportedComposerEntries: [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            ),
+            new FundingProfile(
+                ['bar', 'foo'],
+                ['https://example.com/b'],
+                ['ko_fi' => 'example'],
+            ),
+        );
+
+        self::assertSame(['bar', 'foo'], $merged->getGithubSponsors());
+        self::assertSame(['https://example.com/a', 'https://example.com/b'], $merged->getCustomUrls());
+        self::assertSame(['ko_fi' => 'example'], $merged->getUnsupportedYamlEntries());
+        self::assertSame(
+            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            $merged->getUnsupportedComposerEntries(),
+        );
+    }
+}

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Funding;
+
+use FastForward\DevTools\Funding\FundingProfile;
+use FastForward\DevTools\Funding\FundingYamlCodec;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversClass(FundingYamlCodec::class)]
+#[UsesClass(FundingProfile::class)]
+final class FundingYamlCodecTest extends TestCase
+{
+    #[Test]
+    public function parseWillNormalizeSupportedAndUnsupportedYamlEntries(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $profile = $codec->parse(<<<'YAML'
+github:
+  - foo
+custom: https://example.com/support
+patreon: example
+YAML);
+
+        self::assertSame(['foo'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+        self::assertSame(['patreon' => 'example'], $profile->getUnsupportedYamlEntries());
+    }
+
+    #[Test]
+    public function dumpWillRenderScalarAndListFundingKeys(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $contents = $codec->dump(new FundingProfile(
+            ['foo'],
+            ['https://example.com/support', 'https://example.com/other'],
+            ['patreon' => 'example'],
+        ));
+
+        self::assertSame(
+            [
+                'patreon' => 'example',
+                'github' => 'foo',
+                'custom' => ['https://example.com/support', 'https://example.com/other'],
+            ],
+            Yaml::parse($contents),
+        );
+    }
+}

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -68,4 +68,23 @@ YAML);
             Yaml::parse($contents),
         );
     }
+
+    #[Test]
+    public function dumpWillRenderSingleCustomUrlAsList(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $contents = $codec->dump(new FundingProfile(
+            ['foo'],
+            ['https://example.com/support'],
+        ));
+
+        self::assertSame(
+            [
+                'github' => 'foo',
+                'custom' => ['https://example.com/support'],
+            ],
+            Yaml::parse($contents),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `funding` command that keeps `composer.json` funding entries and `.github/FUNDING.yml` aligned
- wire funding synchronization into `dev-tools:sync` and preserve unsupported providers while managing GitHub Sponsors and custom URLs
- document the new command and sync behavior in README and Sphinx docs

## Testing
- `./vendor/bin/phpunit tests/Funding tests/Console/Command/FundingCommandTest.php tests/Console/Command/SyncCommandTest.php --coverage-filter src --coverage-text`
- `git diff --check`

Closes #56