### PR TITLE
[changelog] Add Keep a Changelog automation (#28)

### DIFF
--- a/.agents/agents/changelog-maintainer.md
+++ b/.agents/agents/changelog-maintainer.md
@@ -21,6 +21,9 @@ automation using the local changelog workflow.
   changelog yet or has undocumented published versions.
 - Capture each documented tag's creation date and persist it as the release
   date while backfilling historical versions.
+- Order documented releases by semantic version, not by lexical string
+  comparison, so versions like `1.10.0` and `1.11.0` remain above `1.9.0` and
+  `1.1.0`.
 - Validate whether a branch or pull request added meaningful changelog content.
 - Infer the next semantic version from changelog content when preparing a
   release.

--- a/.agents/agents/changelog-maintainer.md
+++ b/.agents/agents/changelog-maintainer.md
@@ -1,0 +1,58 @@
+---
+name: changelog-maintainer
+description: Maintain Keep a Changelog entries, release promotions, and release-note exports for Fast Forward repositories.
+primary-skill: changelog-generator
+supporting-skills:
+  - github-issues
+---
+
+# changelog-maintainer
+
+## Purpose
+
+Keep repository changelog files accurate, human-readable, and ready for release
+automation using the local changelog workflow.
+
+## Responsibilities
+
+- Add or adjust categorized changelog entries in `Unreleased` or a published
+  release.
+- Reconstruct missing release history from Git tags when a repository has no
+  changelog yet or has undocumented published versions.
+- Capture each documented tag's creation date and persist it as the release
+  date while backfilling historical versions.
+- Validate whether a branch or pull request added meaningful changelog content.
+- Infer the next semantic version from changelog content when preparing a
+  release.
+- Promote `Unreleased` entries into a published version and export release
+  notes for publishing flows.
+- Respect alternate changelog file paths when a repository does not use the
+  default `CHANGELOG.md`.
+
+## Use When
+
+- A request asks to add changelog notes for a bug fix, feature, workflow, or
+  release preparation.
+- A pull request or workflow needs changelog validation before merge.
+- A release flow needs version inference, release promotion, or release-note
+  export.
+- A repository adopting DevTools may need its first managed changelog file.
+- A repository has tags or releases that exist in Git but are not yet present
+  in the changelog.
+
+## Boundaries
+
+- Do not invent release automation beyond the commands and workflows already
+  supported by the repository.
+- Do not replace the procedural guidance in the skill; this agent defines role
+  behavior, not command syntax.
+- Do not assume the changelog file always uses the default filename or lives in
+  the repository root.
+
+## Primary Skill
+
+- `changelog-generator`
+
+## Supporting Skills
+
+- `github-issues`

--- a/.agents/skills/changelog-generator/SKILL.md
+++ b/.agents/skills/changelog-generator/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: changelog-generator
+description: Create, maintain, and validate human-readable changelog files that follow Keep a Changelog 1.1.0 using the local dev-tools changelog commands. Use when an agent needs to bootstrap a repository's first changelog, add categorized entries to Unreleased or a published version, check whether a branch added changelog content, infer the next version from Unreleased, promote Unreleased into a released version, or export release notes for publishing workflows.
+---
+
+# Changelog Generator
+
+Maintain changelog files for humans first while keeping them deterministic enough for release automation.
+
+## Workflow
+
+1. Establish current state.
+- Resolve the target file path first. Default to `CHANGELOG.md`, but respect any caller-provided `--file` path.
+- Check whether the changelog file exists.
+- Record whether `Unreleased` already has entries and whether any published releases already exist.
+- If the file does not exist yet, or if Git tags exist that are not documented yet, treat the task as a historical backfill before switching to incremental maintenance.
+
+2. Backfill missing release history when needed.
+- If the repository has no changelog, or if some Git tags are still undocumented, walk the Git tags until the changelog is complete.
+- Inspect tags in chronological order so each documented version can be derived from the diff against the previous tag.
+- Capture the creation date for each tag and use it as the release date recorded in the changelog.
+- For each missing released version:
+  1. compare the previous tag to the current tag;
+  2. record the current tag date;
+  3. extract the notable user-facing, maintainer-facing, or automation-facing changes from that diff;
+  4. resolve any associated pull request numbers from merge commits, squash commit titles, or release history;
+  5. classify them with the standard Keep a Changelog categories;
+  6. add them to the matching released section with `changelog:entry --release=<version> --date=<YYYY-MM-DD>`.
+- Only after all historical tags are represented should new work continue in `Unreleased`.
+- If a tag exists but the diff does not justify a notable entry, keep the release section minimal rather than inventing noise.
+
+3. Choose the right local command.
+- To add one new entry to `Unreleased`:
+
+```bash
+composer dev-tools changelog:entry -- --type=added "Add example workflow"
+composer dev-tools changelog:entry -- --type=fixed "Fix release note validation"
+```
+
+- To add or amend an entry in a published section:
+
+```bash
+composer dev-tools changelog:entry -- --type=changed --release=1.2.0 "Adjust published note"
+composer dev-tools changelog:entry -- --type=fixed --release=1.1.0 --date=2026-04-09 "Correct release metadata handling"
+```
+
+- To validate that a branch added changelog content:
+
+```bash
+composer dev-tools changelog:check
+composer dev-tools changelog:check -- --against=refs/remotes/origin/main
+composer dev-tools changelog:check -- --file=docs/CHANGELOG.md --against=origin/main
+```
+
+- To infer the next semantic version from `Unreleased`:
+
+```bash
+composer dev-tools changelog:next-version
+composer dev-tools changelog:next-version -- --file=docs/CHANGELOG.md
+```
+
+- To promote `Unreleased` into a release:
+
+```bash
+composer dev-tools changelog:promote 1.2.0 -- --date=2026-04-19
+composer dev-tools changelog:promote 1.2.0 -- --file=docs/CHANGELOG.md
+```
+
+- To export release notes from one published section:
+
+```bash
+composer dev-tools changelog:show 1.2.0
+composer dev-tools changelog:show 1.2.0 -- --file=docs/CHANGELOG.md
+```
+
+4. Write human-readable entries.
+- Keep each entry to one line.
+- Prefer the user-visible effect over the implementation detail.
+- Name the concrete surface when that helps: command, option, workflow, configuration, integration, or output.
+- Avoid vague filler such as `misc improvements`, `cleanup`, or `refactorings`.
+- When a change can be tied to a specific pull request, append that PR reference like `(#123)` to the entry.
+- During tag backfill, actively look for PR numbers in merge commits, squash merge titles, or related release metadata before writing the final message.
+
+5. Respect the managed format.
+- Keep `Unreleased` first.
+- Keep released versions in reverse chronological order.
+- Keep section order as:
+  1. `Added`
+  2. `Changed`
+  3. `Deprecated`
+  4. `Removed`
+  5. `Fixed`
+  6. `Security`
+- Omit empty sections.
+- Preserve the official introduction and footer-reference style from Keep a Changelog 1.1.0.
+
+6. Verify the result.
+- For branch validation, prefer running:
+
+```bash
+composer dev-tools changelog:check -- --against=refs/remotes/origin/main
+```
+
+- For release preparation, also inspect:
+
+```bash
+composer dev-tools changelog:next-version
+composer dev-tools changelog:show -- <version>
+```
+
+## Output Contract
+
+- When the task is to add a changelog record, produce one or more command invocations that create the exact entries needed.
+- When the repository has no changelog yet, or has undocumented tags, reconstruct the missing release history from Git tags before treating the work as ordinary `Unreleased` maintenance.
+- When a changelog entry can be traced to a specific pull request, include that PR reference in the rendered entry.
+- When the task is to validate a PR or branch, use `changelog:check` and report whether the branch has meaningful unreleased changes.
+- When the task is to prepare a release, use `changelog:next-version`, `changelog:promote`, and `changelog:show` in that order unless the caller asks for only one step.
+- When a repository has no changelog yet, bootstrap it through `changelog:entry` rather than hand-writing the initial file.
+
+## Consumer Repository Notes
+
+- Repositories using Fast Forward DevTools may not have a changelog yet. In that case, the first `changelog:entry` call SHOULD create the managed file automatically.
+- Do not assume a consumer repository already has historical sections.
+- Do not assume published Git tags are already documented. Compare the tags to the changelog and backfill any missing released sections.
+- When a consumer repository has no previous release, `changelog:next-version` may infer `0.1.0` from the first meaningful `Unreleased` section.
+- Do not assume the managed file lives at `CHANGELOG.md`; respect alternate paths when the caller or repository uses them.
+
+## Reference Files
+
+- Read [references/keep-a-changelog-format.md](references/keep-a-changelog-format.md) for the expected file structure.
+- Read [references/official-example-template.md](references/official-example-template.md) for a concrete template.
+- Read [references/change-categories.md](references/change-categories.md) when classifying entries.
+- Read [references/description-patterns.md](references/description-patterns.md) when polishing wording.

--- a/.agents/skills/changelog-generator/SKILL.md
+++ b/.agents/skills/changelog-generator/SKILL.md
@@ -18,6 +18,7 @@ Maintain changelog files for humans first while keeping them deterministic enoug
 2. Backfill missing release history when needed.
 - If the repository has no changelog, or if some Git tags are still undocumented, walk the Git tags until the changelog is complete.
 - Inspect tags in chronological order so each documented version can be derived from the diff against the previous tag.
+- Treat version ordering as semantic version ordering, never plain string ordering. For example, `1.11.0` MUST sort after `1.10.0`, and `1.10.0` MUST sort after `1.9.0`.
 - Capture the creation date for each tag and use it as the release date recorded in the changelog.
 - For each missing released version:
   1. compare the previous tag to the current tag;
@@ -83,7 +84,8 @@ composer dev-tools changelog:show 1.2.0 -- --file=docs/CHANGELOG.md
 
 5. Respect the managed format.
 - Keep `Unreleased` first.
-- Keep released versions in reverse chronological order.
+- Keep released versions in reverse semantic version order unless the repository has an explicit non-semver release policy.
+- Do not use lexical ordering for versions. `1.10.0` and `1.11.0` MUST remain above `1.9.0`, `1.8.0`, and `1.1.0`.
 - Keep section order as:
   1. `Added`
   2. `Changed`
@@ -93,6 +95,7 @@ composer dev-tools changelog:show 1.2.0 -- --file=docs/CHANGELOG.md
   6. `Security`
 - Omit empty sections.
 - Preserve the official introduction and footer-reference style from Keep a Changelog 1.1.0.
+- Build compare links from the semantically previous published version, not from the previous string-sorted heading.
 
 6. Verify the result.
 - For branch validation, prefer running:

--- a/.agents/skills/changelog-generator/agents/openai.yaml
+++ b/.agents/skills/changelog-generator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fast Forward Changelog"
+  short_description: "Manage Keep a Changelog release notes"
+  default_prompt: "Use $changelog-generator to add, validate, promote, or export changelog entries for this repository."

--- a/.agents/skills/changelog-generator/references/change-categories.md
+++ b/.agents/skills/changelog-generator/references/change-categories.md
@@ -1,0 +1,49 @@
+# Change Categories
+
+Classify entries by user-visible impact, not by commit prefix alone.
+
+## Added
+
+- New commands
+- New options
+- New public workflows
+- New visible integrations
+- New user-facing documentation pages that introduce a capability
+
+## Changed
+
+- Behavior changes
+- Default changes
+- Published workflow changes
+- Release-process changes that affect contributors
+
+## Deprecated
+
+- Surfaces that still exist but now have a migration path
+
+## Removed
+
+- Surfaces that were actually deleted
+
+## Fixed
+
+- Bug fixes
+- Validation fixes
+- Broken automation repairs
+
+## Security
+
+- Hardening
+- Vulnerability fixes
+- Secret-handling or permission fixes
+
+## Tie-breakers
+
+Prefer the most specific outcome:
+
+1. `Security`
+2. `Removed`
+3. `Deprecated`
+4. `Fixed`
+5. `Added`
+6. `Changed`

--- a/.agents/skills/changelog-generator/references/description-patterns.md
+++ b/.agents/skills/changelog-generator/references/description-patterns.md
@@ -1,0 +1,34 @@
+# Description Patterns
+
+Describe the impact, not the internal implementation.
+
+When a changelog entry maps to a specific pull request, append the pull request
+reference at the end of the line, for example `(#123)`.
+
+## Good patterns
+
+```markdown
+- Added `<surface>` to `<do what>` for `<benefit>`
+- Changed `<surface>` to `<new behavior>`
+- Fixed `<failure mode>` in `<surface>`
+- Removed deprecated `<surface>`
+- Deprecated `<surface>`; use `<replacement>`
+- Added `<surface>` to `<do what>` for `<benefit>` `(#123)`
+```
+
+## Examples
+
+```markdown
+- Added changelog automation that bootstraps a managed `CHANGELOG.md` on first entry
+- Added `changelog:entry` to append categorized notes to `Unreleased`
+- Changed release preparation to read release notes directly from `CHANGELOG.md`
+- Fixed changelog validation against the base branch
+- Added pull request Pages previews for reports `(#55)`
+```
+
+## Avoid
+
+- `misc improvements`
+- `cleanup`
+- `refactorings`
+- implementation-only statements that say nothing about user-visible effect

--- a/.agents/skills/changelog-generator/references/keep-a-changelog-format.md
+++ b/.agents/skills/changelog-generator/references/keep-a-changelog-format.md
@@ -1,0 +1,76 @@
+# Keep a Changelog 1.1.0 Format
+
+Use the official Keep a Changelog 1.1.0 structure as the default target format:
+
+- Official guidance: `https://keepachangelog.com/en/1.1.0/`
+- Official example: `https://keepachangelog.com/en/1.1.0/#how`
+
+## Required introduction
+
+Mirror the managed introduction exactly:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+```
+
+## Required heading shape
+
+Use bracketed headings and footer references in the managed style:
+
+```markdown
+## [Unreleased]
+
+### Added
+- ...
+
+## [1.4.0] - 2026-04-11
+
+### Changed
+- ...
+```
+
+## Footer references
+
+Versions and `Unreleased` SHOULD be linkable through footer references:
+
+```markdown
+[unreleased]: https://github.com/<owner>/<repo>/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/<owner>/<repo>/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/<owner>/<repo>/compare/v1.2.0...v1.3.0
+[1.0.0]: https://github.com/<owner>/<repo>/releases/tag/v1.0.0
+```
+
+Rules:
+
+- `Unreleased` compares the latest documented tag to `HEAD`.
+- Each released version compares the previous documented release tag to the current tag.
+- The oldest documented release links to its release page when no older release exists in the changelog.
+- When bootstrapping or backfilling a changelog, document released versions in chronological order from the oldest missing tag to the newest missing tag, then render the final file in reverse chronological order.
+
+## Section order
+
+Keep change types grouped in this order:
+
+1. `Added`
+2. `Changed`
+3. `Deprecated`
+4. `Removed`
+5. `Fixed`
+6. `Security`
+
+## Local command mapping
+
+Use the local dev-tools commands instead of any external changelog CLI:
+
+```bash
+composer dev-tools changelog:entry -- --type=added "..."
+composer dev-tools changelog:check
+composer dev-tools changelog:next-version
+composer dev-tools changelog:promote -- 1.2.0 --date=2026-04-19
+composer dev-tools changelog:show -- 1.2.0
+```

--- a/.agents/skills/changelog-generator/references/official-example-template.md
+++ b/.agents/skills/changelog-generator/references/official-example-template.md
@@ -1,0 +1,28 @@
+# Official Example Template
+
+This is a repository-adapted template that mirrors the managed Keep a Changelog structure.
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added `changelog:entry` to create one categorized changelog entry
+
+### Changed
+- Changed release preparation to rely on managed changelog commands
+
+## [1.0.0] - 2026-04-08
+
+### Added
+- Initial public release of the package
+
+[unreleased]: https://github.com/<owner>/<repo>/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/<owner>/<repo>/releases/tag/v1.0.0
+```

--- a/.agents/skills/github-pull-request/SKILL.md
+++ b/.agents/skills/github-pull-request/SKILL.md
@@ -11,7 +11,7 @@ Use this skill to take a Fast Forward issue from "ready to implement" to an open
 
 1. Resolve repository, branch, issue, and PR context. Read [references/context-routing.md](references/context-routing.md).
 2. Select the next ready issue, or decide to skip or stop. Read [references/issue-selection.md](references/issue-selection.md).
-3. Implement the issue on an isolated branch and keep the write scope focused. Read [references/implementation-loop.md](references/implementation-loop.md).
+3. Implement the issue on an isolated branch, keep the write scope focused, and add a notable changelog entry when the delivered behavior, workflow, or release surface deserves one. Read [references/implementation-loop.md](references/implementation-loop.md).
 4. Draft or update the PR using repository templates when present, otherwise use the fallback structure. Read [references/pr-drafting.md](references/pr-drafting.md).
 5. Run the final gate in [references/review-checklist.md](references/review-checklist.md) before handing results to the user.
 
@@ -22,6 +22,7 @@ Use this skill to take a Fast Forward issue from "ready to implement" to an open
 - Prefer local `git` for checkout, commit, and push.
 - Prefer connector-backed GitHub data for issue and PR context when available.
 - Use `phpunit-tests`, `package-readme`, and `sphinx-docs` when the change clearly affects tests or documentation.
+- Use `changelog-generator` when the implementation introduces a notable user-facing or automation-facing change that SHOULD appear in release notes.
 - Never manually close an issue; rely on `Closes #123` style text in the PR body.
 - Do not block waiting for merge. Open or update the PR, then report status and the next action.
 
@@ -40,5 +41,6 @@ Use this skill to take a Fast Forward issue from "ready to implement" to an open
 - Do not batch unrelated issues into one branch or PR.
 - Do not create a duplicate PR if the current branch already has one.
 - Do not open a PR before running the relevant verification commands.
+- Do not skip a notable changelog update when the implementation changes public behavior, release automation, or repository workflows in a way users or maintainers would expect to see called out.
 - Do not proceed to the next issue if the repository is dirty from unfinished work.
 - Do not let a vague issue body force broad implementation guesses; stop and clarify when the acceptance criteria are not actionable.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -70,6 +70,7 @@ jobs:
         env:
             CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
             CHANGELOG_ROOT_VERSION: ${{ github.event.pull_request.head.ref && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
+            FORCE_COLOR: '1'
 
         steps:
             - uses: actions/checkout@v6
@@ -103,12 +104,12 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Verify changelog update
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-              run: composer --ansi dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
+              run: composer dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
 
     prepare_release_pull_request:
         name: Prepare Release Pull Request
@@ -119,6 +120,7 @@ jobs:
             CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
             RELEASE_BRANCH_PREFIX: ${{ inputs.release-branch-prefix || 'release/v' }}
             CHANGELOG_ROOT_VERSION: ${{ format('dev-{0}', github.event.repository.default_branch) }}
+            FORCE_COLOR: '1'
 
         steps:
             - uses: actions/checkout@v6
@@ -149,7 +151,7 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Resolve release version
               id: version
@@ -160,7 +162,7 @@ jobs:
                     version="${INPUT_VERSION}"
                     source="input"
                   else
-                    version="$(composer --ansi dev-tools changelog:next-version -- --file="${CHANGELOG_FILE}")"
+                    version="$(composer dev-tools changelog:next-version -- --file="${CHANGELOG_FILE}")"
                     source="inferred"
                   fi
 
@@ -172,14 +174,14 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   release_date="$(date -u +%F)"
-                  composer --ansi dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
+                  composer dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
 
             - name: Render release notes preview
               env:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  composer --ansi dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Create release preparation pull request
               id: create_pr
@@ -218,6 +220,7 @@ jobs:
             CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
             RELEASE_BRANCH_PREFIX: ${{ inputs.release-branch-prefix || 'release/v' }}
             CHANGELOG_ROOT_VERSION: ${{ format('dev-{0}', github.event.repository.default_branch) }}
+            FORCE_COLOR: '1'
 
         steps:
             - uses: actions/checkout@v6
@@ -248,7 +251,7 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Resolve merged release version
               id: version
@@ -269,7 +272,7 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  composer --ansi dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Publish GitHub release
               env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -103,12 +103,12 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Verify changelog update
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-              run: composer dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
+              run: composer --ansi dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
 
     prepare_release_pull_request:
         name: Prepare Release Pull Request
@@ -149,7 +149,7 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Resolve release version
               id: version
@@ -160,7 +160,7 @@ jobs:
                     version="${INPUT_VERSION}"
                     source="input"
                   else
-                    version="$(composer dev-tools changelog:next-version -- --file="${CHANGELOG_FILE}")"
+                    version="$(composer --ansi dev-tools changelog:next-version -- --file="${CHANGELOG_FILE}")"
                     source="inferred"
                   fi
 
@@ -172,14 +172,14 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   release_date="$(date -u +%F)"
-                  composer dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
+                  composer --ansi dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
 
             - name: Render release notes preview
               env:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer --ansi dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Create release preparation pull request
               id: create_pr
@@ -248,7 +248,7 @@ jobs:
                   COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
                   COMPOSER_CACHE_DIR: /tmp/composer-cache
                   COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
-              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+              run: composer --ansi install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Resolve merged release version
               id: version
@@ -269,7 +269,7 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer --ansi dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Publish GitHub release
               env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -108,7 +108,7 @@ jobs:
             - name: Verify changelog update
               env:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
-              run: vendor/bin/dev-tools changelog:check --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
+              run: composer dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
 
     prepare_release_pull_request:
         name: Prepare Release Pull Request
@@ -160,7 +160,7 @@ jobs:
                     version="${INPUT_VERSION}"
                     source="input"
                   else
-                    version="$(vendor/bin/dev-tools changelog:next-version --file="${CHANGELOG_FILE}")"
+                    version="$(composer dev-tools changelog:next-version -- --file="${CHANGELOG_FILE}")"
                     source="inferred"
                   fi
 
@@ -172,14 +172,14 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   release_date="$(date -u +%F)"
-                  vendor/bin/dev-tools changelog:promote "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
+                  composer dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
 
             - name: Render release notes preview
               env:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  vendor/bin/dev-tools changelog:show "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Create release preparation pull request
               id: create_pr
@@ -269,7 +269,7 @@ jobs:
                   RELEASE_VERSION: ${{ steps.version.outputs.value }}
               run: |
                   mkdir -p .dev-tools
-                  vendor/bin/dev-tools changelog:show "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+                  composer dev-tools changelog:show -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
 
             - name: Publish GitHub release
               env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,292 @@
+name: Changelog Automation
+
+on:
+    workflow_call:
+        inputs:
+            changelog-file:
+                description: Path to the managed changelog file.
+                required: false
+                type: string
+                default: CHANGELOG.md
+            version:
+                description: Optional version to promote during manual release preparation.
+                required: false
+                type: string
+                default: ''
+            release-branch-prefix:
+                description: Prefix used for release-preparation branches.
+                required: false
+                type: string
+                default: release/v
+    workflow_dispatch:
+        inputs:
+            changelog-file:
+                description: Path to the managed changelog file.
+                required: false
+                type: string
+                default: CHANGELOG.md
+            version:
+                description: Optional version to promote. Leave empty to infer from Unreleased.
+                required: false
+                type: string
+                default: ''
+            release-branch-prefix:
+                description: Prefix used for release-preparation branches.
+                required: false
+                type: string
+                default: release/v
+    pull_request:
+        types: [opened, reopened, synchronize]
+    pull_request_target:
+        types: [closed]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+concurrency:
+    group: ${{ github.event.pull_request.number && format('changelog-pr-{0}', github.event.pull_request.number) || format('changelog-{0}', github.ref) }}
+    cancel-in-progress: ${{ github.event.pull_request.merged != true }}
+
+jobs:
+    resolve_php:
+        name: Resolve PHP Version
+        runs-on: ubuntu-latest
+        outputs:
+            php-version: ${{ steps.resolve.outputs.php-version }}
+
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Resolve workflow PHP version
+              id: resolve
+              uses: php-fast-forward/dev-tools/resources/resolve-php-version@main
+
+    validate_pull_request:
+        name: Validate PR Changelog
+        needs: resolve_php
+        if: ${{ github.event.pull_request.number && github.event.pull_request.merged != true }}
+        runs-on: ubuntu-latest
+        env:
+            CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
+            CHANGELOG_ROOT_VERSION: ${{ github.event.pull_request.head.ref && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
+
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ needs.resolve_php.outputs.php-version }}
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: /tmp/composer-cache
+                  key: ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-
+                      ${{ runner.os }}-composer-
+
+            - name: Mark workspace as safe for git
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Fetch base branch reference
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: git fetch --no-tags --depth=1 origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+            - name: Install dependencies
+              env:
+                  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+                  COMPOSER_CACHE_DIR: /tmp/composer-cache
+                  COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+
+            - name: Verify changelog update
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: vendor/bin/dev-tools changelog:check --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
+
+    prepare_release_pull_request:
+        name: Prepare Release Pull Request
+        needs: resolve_php
+        if: ${{ !github.event.pull_request.number }}
+        runs-on: ubuntu-latest
+        env:
+            CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
+            RELEASE_BRANCH_PREFIX: ${{ inputs.release-branch-prefix || 'release/v' }}
+            CHANGELOG_ROOT_VERSION: ${{ format('dev-{0}', github.event.repository.default_branch) }}
+
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  token: ${{ github.token }}
+                  ref: ${{ github.event.repository.default_branch }}
+                  fetch-depth: 0
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ needs.resolve_php.outputs.php-version }}
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: /tmp/composer-cache
+                  key: ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-
+                      ${{ runner.os }}-composer-
+
+            - name: Mark workspace as safe for git
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Install dependencies
+              env:
+                  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+                  COMPOSER_CACHE_DIR: /tmp/composer-cache
+                  COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+
+            - name: Resolve release version
+              id: version
+              env:
+                  INPUT_VERSION: ${{ inputs.version || '' }}
+              run: |
+                  if [ -n "${INPUT_VERSION}" ]; then
+                    version="${INPUT_VERSION}"
+                    source="input"
+                  else
+                    version="$(vendor/bin/dev-tools changelog:next-version --file="${CHANGELOG_FILE}")"
+                    source="inferred"
+                  fi
+
+                  echo "value=${version}" >> "$GITHUB_OUTPUT"
+                  echo "source=${source}" >> "$GITHUB_OUTPUT"
+
+            - name: Promote changelog release
+              env:
+                  RELEASE_VERSION: ${{ steps.version.outputs.value }}
+              run: |
+                  release_date="$(date -u +%F)"
+                  vendor/bin/dev-tools changelog:promote "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
+
+            - name: Render release notes preview
+              env:
+                  RELEASE_VERSION: ${{ steps.version.outputs.value }}
+              run: |
+                  mkdir -p .dev-tools
+                  vendor/bin/dev-tools changelog:show "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+
+            - name: Create release preparation pull request
+              id: create_pr
+              uses: peter-evans/create-pull-request@v7
+              with:
+                  token: ${{ github.token }}
+                  branch: ${{ env.RELEASE_BRANCH_PREFIX }}${{ steps.version.outputs.value }}
+                  delete-branch: false
+                  base: ${{ github.event.repository.default_branch }}
+                  add-paths: |
+                      ${{ env.CHANGELOG_FILE }}
+                  commit-message: Prepare release v${{ steps.version.outputs.value }}
+                  title: Prepare release v${{ steps.version.outputs.value }}
+                  body: |
+                      ## Summary
+
+                      - promote `Unreleased` into `${{ steps.version.outputs.value }}`
+                      - prepare the GitHub release body from `${{ env.CHANGELOG_FILE }}`
+
+                      ## Version Resolution
+
+                      - source: `${{ steps.version.outputs.source }}`
+
+            - name: Summarize prepared release
+              run: |
+                  echo "Prepared release version: ${{ steps.version.outputs.value }}"
+                  echo "Pull request operation: ${{ steps.create_pr.outputs.pull-request-operation || 'none' }}"
+                  echo "Pull request URL: ${{ steps.create_pr.outputs.pull-request-url || 'not created' }}"
+
+    publish_merged_release:
+        name: Publish Merged Release
+        needs: resolve_php
+        if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, inputs.release-branch-prefix || 'release/v') }}
+        runs-on: ubuntu-latest
+        env:
+            CHANGELOG_FILE: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
+            RELEASE_BRANCH_PREFIX: ${{ inputs.release-branch-prefix || 'release/v' }}
+            CHANGELOG_ROOT_VERSION: ${{ format('dev-{0}', github.event.repository.default_branch) }}
+
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  token: ${{ github.token }}
+                  ref: ${{ github.event.pull_request.base.ref }}
+                  fetch-depth: 0
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ needs.resolve_php.outputs.php-version }}
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v5
+              with:
+                  path: /tmp/composer-cache
+                  key: ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-${{ needs.resolve_php.outputs.php-version }}-
+                      ${{ runner.os }}-composer-
+
+            - name: Mark workspace as safe for git
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Install dependencies
+              env:
+                  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ github.token }}"} }'
+                  COMPOSER_CACHE_DIR: /tmp/composer-cache
+                  COMPOSER_ROOT_VERSION: ${{ env.CHANGELOG_ROOT_VERSION }}
+              run: composer install --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+
+            - name: Resolve merged release version
+              id: version
+              env:
+                  HEAD_REF: ${{ github.event.pull_request.head.ref }}
+              run: |
+                  version="${HEAD_REF#${RELEASE_BRANCH_PREFIX}}"
+
+                  if [ -z "${version}" ] || [ "${version}" = "${HEAD_REF}" ]; then
+                    echo "Failed to derive the release version from ${HEAD_REF}." >&2
+                    exit 1
+                  fi
+
+                  echo "value=${version}" >> "$GITHUB_OUTPUT"
+
+            - name: Render release notes
+              env:
+                  RELEASE_VERSION: ${{ steps.version.outputs.value }}
+              run: |
+                  mkdir -p .dev-tools
+                  vendor/bin/dev-tools changelog:show "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" > .dev-tools/release-notes.md
+
+            - name: Publish GitHub release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_VERSION: ${{ steps.version.outputs.value }}
+                  RELEASE_TAG: v${{ steps.version.outputs.value }}
+                  RELEASE_TARGET: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+              run: |
+                  if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                    gh release edit "${RELEASE_TAG}" \
+                      --repo "${GITHUB_REPOSITORY}" \
+                      --title "${RELEASE_TAG}" \
+                      --notes-file .dev-tools/release-notes.md
+                  else
+                    gh release create "${RELEASE_TAG}" \
+                      --repo "${GITHUB_REPOSITORY}" \
+                      --target "${RELEASE_TARGET}" \
+                      --title "${RELEASE_TAG}" \
+                      --notes-file .dev-tools/release-notes.md
+                  fi

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -55,6 +55,7 @@ jobs:
         env:
             PAGES_ARTIFACT_NAME: ${{ github.event_name == 'pull_request' && format('github-pages-pr-{0}', github.event.pull_request.number) || 'github-pages' }}
             REPORTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
+            FORCE_COLOR: '1'
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,7 @@ jobs:
             matrix: ${{ fromJson(needs.resolve_php.outputs.test-matrix) }}
         env:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
+            FORCE_COLOR: '1'
         steps:
             - uses: actions/checkout@v6
 
@@ -130,6 +131,7 @@ jobs:
         continue-on-error: true
         env:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
+            FORCE_COLOR: '1'
         steps:
             - uses: actions/checkout@v6
 

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -43,6 +43,7 @@ jobs:
 
     env:
       WIKI_PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
+      FORCE_COLOR: '1'
 
     steps:
       - name: Checkout PR branch
@@ -142,6 +143,7 @@ jobs:
     env:
       WIKI_PUBLISH_BRANCH: master
       WIKI_PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
+      FORCE_COLOR: '1'
 
     steps:
       - name: Checkout main branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,4 @@ procedural source of truth.
 - Delegate to `docs-writer` when `docs/` must be created or updated.
 - Delegate to `consumer-sync-auditor` when packaged skills, sync assets, wiki, workflows, or consumer bootstrap behavior change.
 - Delegate to `quality-pipeline-auditor` when a task changes command orchestration, verification flow, or quality gates.
+- Delegate to `changelog-maintainer` when a task needs changelog authoring, changelog validation for PRs, release promotion, or release-note export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,222 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add Keep a Changelog management commands and release automation workflows (#28).
+- Package changelog maintenance skills, docs, and the changelog-maintainer project agent (#28).
+
+### Changed
+
+- Force workflow colors through FORCE_COLOR across packaged GitHub Actions for clearer CI logs (#28).
+
+## [1.11.0] - 2026-04-19
+
+### Added
+
+- Ship role-based project agents for issue implementation, docs, README, tests, and changelog work (#75) (#109).
+- Show diffs for overwritten synchronized resources and add preview/check modes to dev-tools:sync (#66) (#110) (#62) (#111).
+- Verify deployed reports health, synchronize funding metadata, and infer workflow PHP versions from project metadata (#70) (#112) (#56) (#113) (#76) (#114).
+
+### Fixed
+
+- Package the PHP version resolver action from resources/ so GitHub Actions can load it correctly (#115) (#116).
+
+## [1.10.0] - 2026-04-19
+
+### Changed
+
+- Refresh dependency and reporting docs to match the shipped commands and workflows (#105) (#106).
+- Move generated outputs into .dev-tools by default instead of public/ (#107) (#108).
+
+### Fixed
+
+- Preserve Git history in metrics previews so PhpMetrics reports show meaningful contributor and file history (#103) (#104).
+
+## [1.9.0] - 2026-04-19
+
+### Added
+
+- Generate PhpMetrics reports for consumer repositories (#98).
+- Add a Jack-powered dependency workflow to the dependencies command (#34) (#102).
+
+### Changed
+
+- Unify metrics outputs under a target directory (#99) (#100).
+
+### Fixed
+
+- Address code quality findings and sync safety regressions in command and test code (#94) (#95) (#96) (#97).
+
+## [1.8.0] - 2026-04-18
+
+### Added
+
+- Canonicalize packaged Git hooks during synchronization (#92) (#93).
+
+### Changed
+
+- Isolate Finder creation behind a factory to make filesystem traversal extensible (#90) (#91).
+
+## [1.7.0] - 2026-04-18
+
+### Added
+
+- Publish branch protection, migration, troubleshooting, and release-publishing guidance for consumer repositories (#61) (#72) (#79) (#80).
+- Synchronize README metadata during composer sync and expand PHPUnit output controls (#57) (#84).
+- Validate and clean up wiki and reports preview branches in packaged GitHub Actions workflows (#68) (#69) (#83).
+
+### Changed
+
+- Reduce default GitHub Actions token permissions across packaged workflows (#63).
+
+## [1.6.0] - 2026-04-17
+
+### Added
+
+- Introduce copy-resource, update-composer-json, and git-hooks commands plus packaged funding and support metadata.
+- Publish pull request Pages previews for reports and document the consumer preview workflow (#54) (#55).
+
+### Changed
+
+- Refactor command architecture around filesystem abstractions, resource copy and update commands, and dependency-injected process handling (#46).
+
+## [1.5.0] - 2026-04-14
+
+### Added
+
+- Package pull request auto-assign and label-sync GitHub Actions workflows (#35).
+
+### Changed
+
+- Standardize Composer installation and caching across packaged reports, tests, and wiki workflows.
+- Reorganize commands into the Console namespace and migrate to the GrumPHP shim (#42) (#44).
+
+### Fixed
+
+- Make wiki publishing work under branch protection and synced submodule pointer updates.
+
+## [1.4.0] - 2026-04-11
+
+### Changed
+
+- Replace external coverage-check tooling with native PHPUnit coverage summary validation (#30) (#31).
+
+### Fixed
+
+- Update Symfony component constraints to support Symfony 8.0 (#31).
+
+## [1.3.0] - 2026-04-11
+
+### Added
+
+- Manage .gitattributes export-ignore rules through dedicated gitattributes tooling (#27).
+
+### Changed
+
+- Exclude context7.json from packaged exports and broaden GitAttributes test coverage (#27).
+
+## [1.2.2] - 2026-03-26
+
+### Added
+
+- Bundle GrumPHP support into packaged scripts and installation commands.
+- Reuse packaged GitHub Actions workflows and synchronize .editorconfig and wiki submodule assets during setup.
+
+### Fixed
+
+- Resolve packaged workflow and wiki resource paths more reliably during script synchronization.
+
+## [1.2.1] - 2026-04-10
+
+### Changed
+
+- Refine license-generation documentation and export-ignore defaults (#26).
+
+## [1.2.0] - 2026-04-10
+
+### Added
+
+- Synchronize packaged skills into consumer repositories with the skills command (#23).
+- Bundle dependency analysis tooling and the dependencies command (#10).
+- Generate repository LICENSE files through dev-tools:sync and the license command (#25).
+
+## [1.1.0] - 2026-04-09
+
+### Added
+
+- Package reusable skills for Sphinx docs, README maintenance, PHPUnit, and GitHub issue workflows.
+- Synchronize .gitignore files through dedicated gitignore tooling (#21).
+
+### Changed
+
+- Make ECS and Rector configuration extensible for consumer overrides (#19).
+
+## [1.0.4] - 2026-03-26
+
+### Fixed
+
+- Resolve DocsCommand configuration files correctly from relative paths.
+
+## [1.0.3] - 2026-03-26
+
+### Changed
+
+- Verify the consumer package name before installing packaged scripts.
+
+## [1.0.2] - 2026-03-26
+
+### Fixed
+
+- Move the composer/composer dependency into the required package metadata.
+
+## [1.0.1] - 2026-03-26
+
+### Added
+
+- Introduce the unified Composer plugin command suite for tests, docs, reports, wiki publishing, and packaged script installation.
+
+### Fixed
+
+- Improve GitHub Actions and reports deployment handling for TTY, coverage, and Pages publishing.
+
+## [1.0.0] - 2026-04-08
+
+### Added
+
+- Rename the installation workflow to dev-tools:sync and synchronize Dependabot, GitHub Actions, and repository defaults.
+- Support PHPUnit test filtering, phpDocumentor bootstrap templates, and richer test notifications.
+
+### Changed
+
+- Standardize README badges, funding metadata, and documentation references for the packaged plugin.
+
+### Fixed
+
+- Normalize workflow PHP extension setup and Git submodule path handling for synced repositories.
+
+[unreleased]: https://github.com/php-fast-forward/dev-tools/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.10.0...v1.11.0
+[1.10.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.9.0...v1.10.0
+[1.9.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.2.2...v1.3.0
+[1.2.2]: https://github.com/php-fast-forward/dev-tools/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/php-fast-forward/dev-tools/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.4...v1.1.0
+[1.0.4]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/php-fast-forward/dev-tools/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ across Fast Forward libraries.
   single Composer-facing command vocabulary
 - Adds dependency analysis for missing and unused Composer packages through a
   single report entrypoint
+- Manages Keep a Changelog 1.1.0 files with local authoring, validation,
+  version inference, release promotion, and release-note rendering commands
 - Ships shared workflow stubs, `.editorconfig`, Dependabot configuration, and
   other onboarding defaults for consumer repositories
 - Synchronizes packaged agent skills into consumer `.agents/skills`
@@ -61,6 +63,23 @@ composer dependencies --upgrade --dev
 composer metrics
 composer metrics --target=.dev-tools/metrics
 composer --working-dir=packages/example metrics
+
+# Add one changelog entry to Unreleased or a published version
+composer changelog:entry "Add changelog automation for release workflows (#28)"
+composer changelog:entry --type=fixed --release=1.2.0 --date=2026-04-19 "Preserve published release sections during backfill (#28)"
+
+# Verify that the current branch added a meaningful Unreleased entry
+composer changelog:check
+composer changelog:check --against=origin/main
+
+# Infer the next semantic version from Unreleased
+composer changelog:next-version
+
+# Promote Unreleased into a published version
+composer changelog:promote 1.3.0
+
+# Render one published section as release notes
+composer changelog:show 1.3.0
 
 # Check and fix code style using ECS and Composer Normalize
 composer code-style
@@ -121,6 +140,20 @@ The `metrics` command ships with `phpmetrics/phpmetrics` as a direct
 dependency of `fast-forward/dev-tools`, so consumer repositories can generate
 metrics reports without extra setup.
 
+The changelog commands manage Keep a Changelog 1.1.0 files without requiring
+extra tooling in the consumer repository. `changelog:entry` bootstraps a
+missing changelog file on first use, `changelog:check` enforces meaningful
+`Unreleased` entries in pull requests, `changelog:next-version` infers the
+next semantic version from pending changes, `changelog:promote` publishes the
+current `Unreleased` section into a tagged version, and `changelog:show`
+renders one published section for GitHub release notes.
+
+When the packaged changelog workflow is synchronized into a consumer
+repository, pull requests are expected to add a notable changelog entry before
+merge. The same workflow can be triggered manually to prepare a release bump
+pull request from `Unreleased`, and merged release branches publish GitHub
+releases from the exact changelog section body.
+
 The `funding` command keeps supported `composer.json` funding entries aligned
 with `.github/FUNDING.yml`, including GitHub Sponsors handles and `custom`
 URLs, while preserving unsupported providers in place and re-running
@@ -131,6 +164,11 @@ Forward skill set. It creates missing links, repairs broken links, and
 preserves existing non-symlink directories. The `dev-tools:sync` command calls
 `skills` automatically after refreshing the rest of the consumer-facing
 automation assets.
+
+The packaged workflow stubs synchronized by `dev-tools:sync` now also include
+changelog automation for pull-request validation and release preparation, so
+consumer repositories can adopt the same changelog-driven release flow without
+copying workflow logic by hand.
 
 This repository also keeps role-based project agents in `.agents/agents`. They
 are mirrored through `.github/agents` for GitHub-oriented discovery, while the
@@ -145,6 +183,11 @@ source of truth.
 | `composer tests` | Runs PHPUnit with local-or-packaged configuration. |
 | `composer dependencies` | Previews Jack dependency updates, then reports missing, unused, and overly outdated Composer dependencies. |
 | `composer metrics` | Runs PhpMetrics for the current project and generates requested report artifacts. |
+| `composer changelog:entry` | Adds one categorized changelog entry to `Unreleased` or a published release section. |
+| `composer changelog:check` | Verifies that a changelog file contains meaningful `Unreleased` notes, optionally against a git base reference. |
+| `composer changelog:next-version` | Infers the next semantic version from the current changelog state. |
+| `composer changelog:promote` | Moves `Unreleased` entries into a published version section and records the release date. |
+| `composer changelog:show` | Renders one published changelog section for release notes and automation. |
 | `composer docs` | Builds the HTML documentation site from PSR-4 code and `docs/`. |
 | `composer skills` | Creates or repairs packaged skill links in `.agents/skills`. |
 | `composer funding` | Synchronizes managed funding metadata between `composer.json` and `.github/FUNDING.yml`. |
@@ -172,6 +215,29 @@ Each command is self-contained and receives its dependencies through constructor
 Run `composer dev-tools` before opening a pull request. If you change public
 commands or consumer onboarding behavior, update `README.md` and `docs/`
 together so downstream libraries keep accurate guidance.
+
+Notable pull requests are also expected to add a changelog entry before
+review is complete. A typical contributor flow looks like this:
+
+```bash
+# Record the user-visible change
+composer changelog:entry --type=changed "Refine changelog automation for release publication (#28)"
+
+# Validate that the branch added meaningful Unreleased notes
+composer changelog:check --against=origin/main
+```
+
+For release preparation, maintainers can infer and promote the next version
+locally before using the packaged GitHub workflow:
+
+```bash
+# Inspect the version that Unreleased implies
+composer changelog:next-version
+
+# Publish Unreleased into the selected version and review the resulting notes
+composer changelog:promote 1.3.0
+composer changelog:show 1.3.0
+```
 
 ## 📄 License
 

--- a/docs/api/commands.rst
+++ b/docs/api/commands.rst
@@ -14,6 +14,21 @@ dependencies through constructor injection. The architecture uses
    * - ``FastForward\DevTools\Console\Command\StandardsCommand``
      - ``standards``
      - Runs the full quality pipeline.
+   * - ``FastForward\DevTools\Console\Command\ChangelogEntryCommand``
+     - ``changelog:entry``
+     - Adds a changelog entry to ``Unreleased`` or a published version.
+   * - ``FastForward\DevTools\Console\Command\ChangelogCheckCommand``
+     - ``changelog:check``
+     - Verifies that a branch adds meaningful unreleased changelog changes.
+   * - ``FastForward\DevTools\Console\Command\ChangelogNextVersionCommand``
+     - ``changelog:next-version``
+     - Infers the next semantic version from ``Unreleased``.
+   * - ``FastForward\DevTools\Console\Command\ChangelogPromoteCommand``
+     - ``changelog:promote``
+     - Promotes ``Unreleased`` entries into a published release section.
+   * - ``FastForward\DevTools\Console\Command\ChangelogShowCommand``
+     - ``changelog:show``
+     - Renders the notes body for a published changelog release.
    * - ``FastForward\DevTools\Console\Command\RefactorCommand``
      - ``refactor``
      - Runs Rector with local or packaged configuration.

--- a/docs/commands/changelog.rst
+++ b/docs/commands/changelog.rst
@@ -1,0 +1,114 @@
+changelog commands
+==================
+
+Author, validate, infer, promote, and render managed Keep a Changelog
+sections with the local changelog command set.
+
+Description
+-----------
+
+Fast Forward DevTools ships a focused changelog surface built around the local
+``CHANGELOG.md`` file:
+
+- ``changelog:entry`` adds one categorized entry to ``Unreleased`` or to an
+  explicit release section;
+- ``changelog:check`` verifies that a branch or repository state contains a
+  meaningful ``Unreleased`` change;
+- ``changelog:next-version`` infers the next semantic version from the current
+  ``Unreleased`` categories;
+- ``changelog:promote`` publishes ``Unreleased`` into a dated release section;
+- ``changelog:show`` renders one published section body for GitHub release
+  notes or other automation.
+
+These commands intentionally work on the minimum Keep a Changelog 1.1.0
+structure managed by this repository and by synchronized Fast Forward consumer
+repositories.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   composer changelog:entry "Add changelog automation for release workflows (#28)"
+   composer changelog:entry --type=fixed --release=1.2.0 --date=2026-04-19 "Preserve published release sections during backfill (#28)"
+
+   composer changelog:check
+   composer changelog:check --against=origin/main
+
+   composer changelog:next-version
+
+   composer changelog:promote 1.3.0
+   composer changelog:promote 1.3.0 --date=2026-04-19
+
+   composer changelog:show 1.3.0
+
+Options
+-------
+
+``changelog:entry``
+   Supports:
+
+   - ``--type=<category>`` for ``added``, ``changed``, ``deprecated``,
+     ``removed``, ``fixed``, or ``security``;
+   - ``--release=<version>`` to target a published section instead of
+     ``Unreleased``;
+   - ``--date=<YYYY-MM-DD>`` when a published section should carry a release
+     date immediately;
+   - ``--file=<path>`` to work with a changelog file other than
+     ``CHANGELOG.md``.
+
+``changelog:check``
+   Supports:
+
+   - ``--against=<git-ref>`` to compare the current changelog against a base
+     branch or commit;
+   - ``--file=<path>`` to validate another changelog path.
+
+``changelog:next-version``
+   Supports:
+
+   - ``--current-version=<semver>`` when the current published version should
+     be supplied explicitly instead of inferred from the changelog;
+   - ``--file=<path>`` to inspect another changelog path.
+
+``changelog:promote``
+   Supports:
+
+   - the required version argument;
+   - ``--date=<YYYY-MM-DD>`` to control the published release date;
+   - ``--file=<path>`` to promote another changelog path.
+
+``changelog:show``
+   Supports:
+
+   - the required version argument;
+   - ``--file=<path>`` to render another changelog path.
+
+Behavior
+--------
+
+- ``changelog:entry`` creates the managed changelog structure automatically
+  when the selected file does not exist yet;
+- ``changelog:check`` returns a failing exit code when ``Unreleased`` is empty
+  or does not differ from the selected baseline ref;
+- ``changelog:next-version`` uses ``Removed`` or ``Deprecated`` entries for a
+  major bump, ``Added`` or ``Changed`` entries for a minor bump, and otherwise
+  falls back to a patch bump;
+- ``changelog:promote`` restores an empty ``Unreleased`` section after
+  publishing the requested version;
+- ``changelog:show`` prints only the release body so workflows can feed it
+  directly into GitHub release notes.
+
+Workflow Integration
+--------------------
+
+The packaged changelog workflow consumes these commands in two places:
+
+- pull-request validation runs ``changelog:check`` against the base branch to
+  require a meaningful changelog update;
+- manual release preparation uses ``changelog:next-version`` and
+  ``changelog:promote`` to create a release pull request, then
+  ``changelog:show`` to publish the merged section as GitHub release notes.
+
+See :doc:`../usage/github-actions` and :doc:`../internals/release-publishing`
+for the workflow-level behavior around those commands.

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -8,6 +8,7 @@ Detailed documentation for each dev-tools command.
 
    standards
    tests
+   changelog
    dependencies
    metrics
    code-style

--- a/docs/commands/sync.rst
+++ b/docs/commands/sync.rst
@@ -9,7 +9,7 @@ Description
 The ``dev-tools:sync`` command synchronizes consumer-facing automation and defaults:
 
 1. ``update-composer-json`` - adds dev-tools scripts to composer.json
-2. ``copy-resource`` - copies GitHub Actions workflows
+2. ``copy-resource`` - copies GitHub Actions workflows, including changelog automation
 3. ``copy-resource`` - copies .editorconfig
 4. ``copy-resource`` - copies dependabot.yml
 5. ``funding`` - synchronizes ``composer.json`` funding metadata with ``.github/FUNDING.yml``
@@ -92,7 +92,8 @@ Behavior
 
 - Updates ``composer.json`` scripts, extra configuration, and managed funding
   metadata.
-- Copies missing workflow stubs, ``.editorconfig``, and ``dependabot.yml``.
+- Copies missing workflow stubs, including tests, reports, wiki, and changelog
+  automation, plus ``.editorconfig`` and ``dependabot.yml``.
 - Synchronizes supported funding metadata between ``composer.json`` and
   ``.github/FUNDING.yml``.
 - When ``--overwrite`` is enabled, replaced text resources emit a unified diff

--- a/docs/internals/release-publishing.rst
+++ b/docs/internals/release-publishing.rst
@@ -2,8 +2,9 @@ Release and Publishing Workflow
 ===============================
 
 This guide is for maintainers preparing a Fast Forward DevTools release. It
-documents the current manual release flow and the publishing surfaces affected
-by a merge or tag. It does not add release automation.
+documents the changelog-driven release flow, the automated GitHub Actions
+sequence that supports it, and the publishing surfaces affected by a merge or
+tag.
 
 Release Surfaces
 ----------------
@@ -19,7 +20,7 @@ Release Surfaces
      - Pull requests merge into ``main`` after required checks pass.
    * - Git tags
      - Immutable release markers consumed by Composer and maintainers.
-     - Created manually when maintainers decide to publish a release.
+     - Created by the changelog release workflow when a prepared release pull request is merged.
    * - Packagist
      - Composer package discovery for ``fast-forward/dev-tools``.
      - Reads repository tags and metadata for installable versions.
@@ -31,25 +32,28 @@ Release Surfaces
      - Updated by the wiki workflow after changes land on ``main``.
    * - GitHub Releases
      - Human-facing release notes and changelog summary.
-     - Created manually when a tagged version should be announced.
+     - Published by the changelog release workflow from the released changelog section.
 
 Versioning and Branch Flow
 --------------------------
 
-Use pull requests for all release-bound changes. The release candidate should
-land on ``main`` before any tag is created.
+Use pull requests for all release-bound changes. The release candidate SHOULD
+land on ``main`` through a dedicated release-preparation pull request before the
+tag or GitHub release is published.
 
 The expected flow is:
 
-1. merge feature, bug fix, and documentation pull requests into ``main``;
+1. merge feature, bug fix, and documentation pull requests into ``main`` while keeping ``Unreleased`` current;
 2. run the release verification checklist against the current ``main``;
-3. prepare changelog or release notes from merged work;
-4. create a version tag from the verified ``main`` commit;
-5. publish the GitHub release notes for that tag;
-6. confirm Packagist, reports, and wiki publication.
+3. trigger the changelog workflow manually through ``workflow_dispatch`` to infer the next version or accept an explicit version;
+4. review the release notes preview written to ``.dev-tools/release-notes.md`` in the release-preparation branch;
+5. review and merge the release-preparation pull request created from that workflow;
+6. let the merged release workflow create or update the GitHub release and tag from the released changelog section;
+7. confirm Packagist, reports, and wiki publication.
 
 Do not retag an existing published version. If a release needs correction,
-create a follow-up commit and publish a new version tag.
+prepare a follow-up changelog entry, open a new release-preparation pull
+request, and publish a new version tag.
 
 Pre-Release Verification
 ------------------------
@@ -82,7 +86,16 @@ The working tree should be clean, and the release commit should already be on
 Tagging and GitHub Release Notes
 --------------------------------
 
-Create the tag from the verified ``main`` commit:
+The changelog workflow now handles the tag and GitHub release publication after
+the release-preparation pull request is merged. Manual tagging SHOULD only be
+used for recovery or exceptional maintenance.
+
+The same workflow also owns pull-request changelog validation. Regular feature
+and fix pull requests SHOULD expect ``changelog:check`` to run against the base
+branch and fail when no meaningful ``Unreleased`` entry is added.
+
+If maintainers must recover the release manually, create the tag from the
+verified ``main`` commit:
 
 .. code-block:: bash
 
@@ -91,8 +104,8 @@ Create the tag from the verified ``main`` commit:
     git tag <version>
     git push origin <version>
 
-Use the GitHub release page for the pushed tag to publish release notes. The
-notes SHOULD include:
+When the workflow publishes the GitHub release, the notes come from the
+matching released changelog section. Those notes SHOULD include:
 
 - user-facing changes;
 - breaking changes or migration notes;
@@ -146,12 +159,14 @@ After the tag and release notes are published:
 7. open follow-up issues for any release automation or changelog improvements
    discovered during the process.
 
-Current Manual Steps Versus Future Automation
----------------------------------------------
+Current Automation and Remaining Manual Checks
+----------------------------------------------
 
-Maintainers currently choose the release commit, create the tag, and write
-release notes manually. That keeps release intent explicit.
+Maintainers still decide when to prepare a release and when to merge the
+release-preparation pull request. After that merge, the workflow owns the tag
+and GitHub release publication so branch protection rules remain intact.
 
-Future automation could help generate changelog drafts, validate Packagist
-publication, or summarize post-release checks. Those improvements should remain
-separate from this guide unless the release process itself changes.
+Further automation may still help validate Packagist publication, summarize
+post-release checks, or backfill historical changelog sections. Those
+improvements should remain separate from this guide unless the release process
+itself changes again.

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -4,6 +4,30 @@ Specialized Commands
 Use the standalone commands when you want one tool instead of the full
 ``standards`` pipeline.
 
+``changelog:*``
+---------------
+
+Manages Keep a Changelog 1.1.0 files and supports the packaged changelog
+workflow.
+
+.. code-block:: bash
+
+   composer changelog:entry --type=added "Add release automation workflow (#28)"
+   composer changelog:check --against=origin/main
+   composer changelog:next-version
+   composer changelog:promote 1.3.0 --date=2026-04-19
+   composer changelog:show 1.3.0
+
+Important details:
+
+- ``changelog:entry`` creates the changelog file automatically when it does not
+  exist yet;
+- ``changelog:check`` is the command used by pull-request validation;
+- ``changelog:next-version`` and ``changelog:promote`` support the manual
+  release-preparation workflow;
+- ``changelog:show`` renders the published release body used by GitHub Release
+  publication.
+
 ``tests``
 ---------
 

--- a/docs/usage/common-workflows.rst
+++ b/docs/usage/common-workflows.rst
@@ -22,9 +22,17 @@ Most day-to-day work falls into one of the flows below.
    * - Refresh only the documentation site
      - ``composer docs``
      - Runs phpDocumentor using PSR-4 namespaces and the ``docs/`` guide.
+   * - Record a notable pull-request change
+     - ``composer changelog:entry``
+     - Appends one categorized entry to ``Unreleased`` or to a selected
+       published version section.
    * - Refresh packaged agent skills only
      - ``composer skills``
      - Creates or repairs symlinks in ``.agents/skills``.
+   * - Prepare a release from the current changelog
+     - ``composer changelog:next-version`` then ``composer changelog:promote``
+     - Infers the next semantic version, publishes ``Unreleased``, and leaves
+       the released section ready for GitHub release automation.
    * - Publish local automation defaults into a consumer repository
      - ``composer dev-tools:sync``
      - Updates scripts, copies missing automation assets, and refreshes
@@ -46,10 +54,12 @@ A Safe Beginner Routine
 -----------------------
 
 1. Run ``composer tests``.
-2. Run ``composer skills`` if you changed packaged consumer skills.
-3. Run ``composer docs`` if you changed guides or public APIs.
-4. Run ``composer dev-tools:fix`` when you want automated help.
-5. Run ``composer dev-tools`` before pushing.
+2. Run ``composer changelog:entry`` when the branch introduces a notable
+   user-facing or automation-facing change.
+3. Run ``composer skills`` if you changed packaged consumer skills.
+4. Run ``composer docs`` if you changed guides or public APIs.
+5. Run ``composer dev-tools:fix`` when you want automated help.
+6. Run ``composer dev-tools`` before pushing.
 
 .. tip::
 

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -71,6 +71,45 @@ The ``tests.yml`` workflow provides standard Continuous Integration.
 *   Runs dependency health as a separate non-blocking job when enabled.
 *   Uses PR-scoped concurrency so newer pushes cancel older in-progress runs for the same pull request.
 
+Fast Forward Changelog
+----------------------
+
+The ``changelog.yml`` workflow validates pull-request changelog updates and
+automates the release-preparation flow for repositories that use the local
+changelog commands. Consumer repositories typically expose it through the thin
+wrapper in ``resources/github-actions/changelog.yml``.
+
+**Triggers:**
+*   Pull Request (opened, synchronized, reopened).
+*   Pull Request Target (closed) for merged release-preparation pull requests.
+*   Manual trigger (workflow_dispatch).
+
+**Behavior:**
+*   **Pull Requests**:
+    *   Resolves the workflow PHP version from ``composer.lock`` or
+        ``composer.json`` before installing dependencies.
+    *   Uses ``fetch-depth: 0`` so the base branch reference can be compared
+        safely.
+    *   Fetches the base branch changelog reference.
+    *   Runs ``vendor/bin/dev-tools changelog:check`` against the base ref.
+    *   Fails when the current branch does not add a meaningful ``Unreleased`` change.
+*   **Manual Release Preparation**:
+    *   Checks out the repository default branch with full history.
+    *   Resolves the next version from ``Unreleased`` unless a version input is provided.
+    *   Promotes ``Unreleased`` into the selected version with the current UTC release date.
+    *   Writes a release-notes preview file to ``.dev-tools/release-notes.md`` with
+        ``vendor/bin/dev-tools changelog:show``.
+    *   Opens or updates a release-preparation pull request instead of committing directly to ``main``.
+*   **Merged Release Pull Requests**:
+    *   Detects merged branches that match the configured release branch prefix.
+    *   Renders the released changelog section with ``vendor/bin/dev-tools changelog:show``.
+    *   Creates or updates the Git tag and GitHub release with the rendered changelog section as the release body.
+
+**Inputs:**
+*   ``changelog-file``: managed changelog path, default ``CHANGELOG.md``.
+*   ``version``: optional explicit version for manual release preparation.
+*   ``release-branch-prefix``: release branch prefix, default ``release/v``.
+
 Maintenance Workflows
 ---------------------
 

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -91,18 +91,18 @@ wrapper in ``resources/github-actions/changelog.yml``.
     *   Uses ``fetch-depth: 0`` so the base branch reference can be compared
         safely.
     *   Fetches the base branch changelog reference.
-    *   Runs ``vendor/bin/dev-tools changelog:check`` against the base ref.
+    *   Runs ``composer dev-tools changelog:check -- --against=<base-ref>`` against the base ref.
     *   Fails when the current branch does not add a meaningful ``Unreleased`` change.
 *   **Manual Release Preparation**:
     *   Checks out the repository default branch with full history.
     *   Resolves the next version from ``Unreleased`` unless a version input is provided.
     *   Promotes ``Unreleased`` into the selected version with the current UTC release date.
     *   Writes a release-notes preview file to ``.dev-tools/release-notes.md`` with
-        ``vendor/bin/dev-tools changelog:show``.
+        ``composer dev-tools changelog:show -- <version>``.
     *   Opens or updates a release-preparation pull request instead of committing directly to ``main``.
 *   **Merged Release Pull Requests**:
     *   Detects merged branches that match the configured release branch prefix.
-    *   Renders the released changelog section with ``vendor/bin/dev-tools changelog:show``.
+    *   Renders the released changelog section with ``composer dev-tools changelog:show -- <version>``.
     *   Creates or updates the Git tag and GitHub release with the rendered changelog section as the release body.
 
 **Inputs:**

--- a/resources/github-actions/changelog.yml
+++ b/resources/github-actions/changelog.yml
@@ -1,0 +1,37 @@
+name: "Fast Forward Changelog"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      changelog-file:
+        description: Path to the managed changelog file.
+        required: false
+        type: string
+        default: CHANGELOG.md
+      version:
+        description: Optional version to promote. Leave empty to infer from Unreleased.
+        required: false
+        type: string
+        default: ''
+      release-branch-prefix:
+        description: Prefix used for release-preparation branches.
+        required: false
+        type: string
+        default: release/v
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changelog:
+    uses: php-fast-forward/dev-tools/.github/workflows/changelog.yml@main
+    with:
+      changelog-file: ${{ inputs.changelog-file || 'CHANGELOG.md' }}
+      version: ${{ inputs.version || '' }}
+      release-branch-prefix: ${{ inputs.release-branch-prefix || 'release/v' }}
+    secrets: inherit

--- a/src/Changelog/Checker/UnreleasedEntryChecker.php
+++ b/src/Changelog/Checker/UnreleasedEntryChecker.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Checker;
+
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
+use FastForward\DevTools\Changelog\Parser\ChangelogParserInterface;
+use Throwable;
+
+use function array_diff;
+use function array_values;
+
+/**
+ * Compares unreleased changelog entries against the current branch or a base ref.
+ */
+final readonly class UnreleasedEntryChecker implements UnreleasedEntryCheckerInterface
+{
+    /**
+     * Constructs a new UnreleasedEntryChecker.
+     *
+     * @param GitClientInterface $gitClient the Git client used for baseline inspection
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogParserInterface $parser
+     */
+    public function __construct(
+        private FilesystemInterface $filesystem,
+        private GitClientInterface $gitClient,
+        private ChangelogParserInterface $parser,
+    ) {}
+
+    /**
+     * Checks if there are pending unreleased entries in the changelog compared to a given reference.
+     *
+     * @param string $file the changelog file path to inspect
+     * @param string|null $againstReference The reference to compare against (e.g., a branch or commit hash).
+     *
+     * @return bool true if there are pending unreleased entries, false otherwise
+     */
+    public function hasPendingChanges(string $file, ?string $againstReference = null): bool
+    {
+        try {
+            $content = $this->filesystem->readFile($file);
+        } catch (Throwable) {
+            return false;
+        }
+
+        $currentEntries = $this->flattenEntries($this->parser->parse($content)->getUnreleased());
+
+        if ([] === $currentEntries) {
+            return false;
+        }
+
+        if (null === $againstReference) {
+            return true;
+        }
+
+        try {
+            $baseline = $this->gitClient->show($againstReference, $file, $this->filesystem->dirname($file));
+        } catch (Throwable) {
+            return true;
+        }
+
+        $baselineEntries = $this->flattenEntries($this->parser->parse($baseline)->getUnreleased());
+
+        return [] !== array_values(array_diff($currentEntries, $baselineEntries));
+    }
+
+    /**
+     * Flattens release entries for set comparison.
+     *
+     * @param ChangelogRelease $release
+     *
+     * @return list<string>
+     */
+    private function flattenEntries(ChangelogRelease $release): array
+    {
+        $entries = [];
+
+        foreach (ChangelogEntryType::ordered() as $type) {
+            $entries = [...$entries, ...$release->getEntriesFor($type)];
+        }
+
+        return array_values(array_unique($entries));
+    }
+}

--- a/src/Changelog/Checker/UnreleasedEntryCheckerInterface.php
+++ b/src/Changelog/Checker/UnreleasedEntryCheckerInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Checker;
+
+/**
+ * Verifies that the changelog contains meaningful unreleased changes.
+ *
+ * This is used to prevent merging changes that have not been documented in the changelog.
+ * It compares the unreleased entries in the changelog against the current branch or a specified reference (e.g., a base branch or commit hash).
+ */
+interface UnreleasedEntryCheckerInterface
+{
+    /**
+     * Checks if there are pending unreleased entries in the changelog compared to a given reference.
+     *
+     * This method MUST read the unreleased section of the changelog and compare it against the changes in the current branch or a specified reference.
+     * If there are entries in the unreleased section that are not present in the reference, it indicates that there are pending changes that have not been released yet.
+     * The method MUST return true if there are pending unreleased entries, and false otherwise.
+     *
+     * @param string $file the changelog file path, relative to the working directory or absolute
+     * @param string|null $againstReference The reference to compare against (e.g., a branch or commit hash).
+     *
+     * @return bool true if there are pending unreleased entries, false otherwise
+     */
+    public function hasPendingChanges(string $file, ?string $againstReference = null): bool;
+}

--- a/src/Changelog/Document/ChangelogDocument.php
+++ b/src/Changelog/Document/ChangelogDocument.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Document;
+
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+
+/**
+ * Represents the minimal Keep a Changelog document structure used by dev-tools.
+ */
+final readonly class ChangelogDocument
+{
+    public const string UNRELEASED_VERSION = 'Unreleased';
+
+    /**
+     * @param list<ChangelogRelease> $releases
+     */
+    public function __construct(
+        private array $releases,
+    ) {}
+
+    /**
+     * Creates a new document with an empty Unreleased section.
+     */
+    public static function create(): self
+    {
+        return new self([new ChangelogRelease(self::UNRELEASED_VERSION)]);
+    }
+
+    /**
+     * Returns the release sections in document order.
+     *
+     * @return list<ChangelogRelease>
+     */
+    public function getReleases(): array
+    {
+        return $this->releases;
+    }
+
+    /**
+     * Returns the Unreleased section, creating an empty one when needed.
+     */
+    public function getUnreleased(): ChangelogRelease
+    {
+        foreach ($this->releases as $release) {
+            if ($release->isUnreleased()) {
+                return $release;
+            }
+        }
+
+        return new ChangelogRelease(self::UNRELEASED_VERSION);
+    }
+
+    /**
+     * Returns the requested release section when present.
+     *
+     * @param string $version
+     */
+    public function getRelease(string $version): ?ChangelogRelease
+    {
+        foreach ($this->releases as $release) {
+            if ($release->getVersion() === $version) {
+                return $release;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the newest published release section when available.
+     */
+    public function getLatestPublishedRelease(): ?ChangelogRelease
+    {
+        foreach ($this->releases as $release) {
+            if (! $release->isUnreleased()) {
+                return $release;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a copy with the provided release inserted or replaced.
+     *
+     * @param ChangelogRelease $target
+     */
+    public function withRelease(ChangelogRelease $target): self
+    {
+        $releases = [];
+        $replaced = false;
+
+        foreach ($this->releases as $release) {
+            if ($release->getVersion() === $target->getVersion()) {
+                $releases[] = $target;
+                $replaced = true;
+
+                continue;
+            }
+
+            $releases[] = $release;
+        }
+
+        if (! $replaced) {
+            if ($target->isUnreleased()) {
+                array_unshift($releases, $target);
+            } else {
+                $inserted = false;
+
+                foreach ($releases as $index => $release) {
+                    if ($release->isUnreleased()) {
+                        continue;
+                    }
+
+                    array_splice($releases, $index, 0, [$target]);
+                    $inserted = true;
+
+                    break;
+                }
+
+                if (! $inserted) {
+                    $releases[] = $target;
+                }
+            }
+        }
+
+        return new self($this->normalizeUnreleasedPosition($releases));
+    }
+
+    /**
+     * Returns a copy with the unreleased entries promoted into a published release.
+     *
+     * @param string $version
+     * @param string $date
+     */
+    public function promoteUnreleased(string $version, string $date): self
+    {
+        $unreleased = $this->getUnreleased();
+
+        $promoted = new ChangelogRelease($version, $date, $unreleased->getEntries());
+        $currentVersion = $this->getRelease($version);
+
+        if ($currentVersion instanceof ChangelogRelease) {
+            $mergedEntries = $currentVersion->getEntries();
+
+            foreach (ChangelogEntryType::ordered() as $type) {
+                $mergedEntries[$type->value] = array_values(array_unique([
+                    ...$currentVersion->getEntriesFor($type),
+                    ...$unreleased->getEntriesFor($type),
+                ]));
+            }
+
+            $promoted = new ChangelogRelease($version, $date, $mergedEntries);
+        }
+
+        $releases = [];
+
+        foreach ($this->releases as $release) {
+            if ($release->isUnreleased()) {
+                $releases[] = new ChangelogRelease(self::UNRELEASED_VERSION);
+                $releases[] = $promoted;
+
+                continue;
+            }
+
+            if ($release->getVersion() === $version) {
+                continue;
+            }
+
+            $releases[] = $release;
+        }
+
+        if ([] === $releases) {
+            $releases = [new ChangelogRelease(self::UNRELEASED_VERSION), $promoted];
+        }
+
+        return new self($this->normalizeUnreleasedPosition($releases));
+    }
+
+    /**
+     * Ensures the Unreleased section stays first in the document.
+     *
+     * @param list<ChangelogRelease> $releases
+     *
+     * @return list<ChangelogRelease>
+     */
+    private function normalizeUnreleasedPosition(array $releases): array
+    {
+        $unreleased = null;
+        $published = [];
+
+        foreach ($releases as $release) {
+            if ($release->isUnreleased()) {
+                $unreleased ??= $release;
+
+                continue;
+            }
+
+            $published[] = $release;
+        }
+
+        return [$unreleased ?? new ChangelogRelease(self::UNRELEASED_VERSION), ...$published];
+    }
+}

--- a/src/Changelog/Document/ChangelogRelease.php
+++ b/src/Changelog/Document/ChangelogRelease.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Document;
+
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+
+/**
+ * Represents one Keep a Changelog release section.
+ */
+final class ChangelogRelease
+{
+    /**
+     * @var array<string, list<string>>
+     */
+    private array $entries = [];
+
+    /**
+     * @param array<string, list<string>> $entries
+     * @param string $version
+     * @param ?string $date
+     */
+    public function __construct(
+        private readonly string $version,
+        private readonly ?string $date = null,
+        array $entries = [],
+    ) {
+        foreach (ChangelogEntryType::ordered() as $type) {
+            $this->entries[$type->value] = array_values(array_unique($entries[$type->value] ?? []));
+        }
+    }
+
+    /**
+     * Returns the section version label.
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
+     * Returns the release date when present.
+     */
+    public function getDate(): ?string
+    {
+        return $this->date;
+    }
+
+    /**
+     * Returns whether this section is the active Unreleased section.
+     */
+    public function isUnreleased(): bool
+    {
+        return ChangelogDocument::UNRELEASED_VERSION === $this->version;
+    }
+
+    /**
+     * Returns all entries keyed by changelog category.
+     *
+     * @return array<string, list<string>>
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+
+    /**
+     * Returns the entries for a specific changelog category.
+     *
+     * @param ChangelogEntryType $type
+     *
+     * @return list<string>
+     */
+    public function getEntriesFor(ChangelogEntryType $type): array
+    {
+        return $this->entries[$type->value];
+    }
+
+    /**
+     * Returns whether the section contains at least one meaningful entry.
+     */
+    public function hasEntries(): bool
+    {
+        foreach ($this->entries as $entries) {
+            if ([] !== $entries) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a copy with an additional entry appended to the given category.
+     *
+     * @param ChangelogEntryType $type
+     * @param string $entry
+     */
+    public function withEntry(ChangelogEntryType $type, string $entry): self
+    {
+        $entries = $this->entries;
+        $entry = trim($entry);
+
+        if ('' === $entry) {
+            return $this;
+        }
+
+        $entries[$type->value][] = $entry;
+        $entries[$type->value] = array_values(array_unique($entries[$type->value]));
+
+        return new self($this->version, $this->date, $entries);
+    }
+
+    /**
+     * Returns a copy with all entries replaced by the supplied map.
+     *
+     * @param array<string, list<string>> $entries
+     */
+    public function withEntries(array $entries): self
+    {
+        return new self($this->version, $this->date, $entries);
+    }
+
+    /**
+     * Returns a copy with the release date replaced.
+     *
+     * @param ?string $date
+     */
+    public function withDate(?string $date): self
+    {
+        return new self($this->version, $date, $this->entries);
+    }
+}

--- a/src/Changelog/Entry/ChangelogEntryType.php
+++ b/src/Changelog/Entry/ChangelogEntryType.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Entry;
+
+use InvalidArgumentException;
+
+/**
+ * Represents the supported Keep a Changelog entry categories.
+ */
+enum ChangelogEntryType: string
+{
+    case Added = 'Added';
+    case Changed = 'Changed';
+    case Deprecated = 'Deprecated';
+    case Removed = 'Removed';
+    case Fixed = 'Fixed';
+    case Security = 'Security';
+
+    /**
+     * Returns the changelog section ordering expected by the renderer.
+     *
+     * @return list<self>
+     */
+    public static function ordered(): array
+    {
+        return [self::Added, self::Changed, self::Deprecated, self::Removed, self::Fixed, self::Security];
+    }
+
+    /**
+     * Resolves a user-provided category value to an enum case.
+     *
+     * @param string $value the raw category value
+     *
+     * @return self the resolved changelog entry type
+     */
+    public static function fromInput(string $value): self
+    {
+        $normalized = ucfirst(strtolower(trim($value)));
+
+        return self::tryFrom($normalized)
+            ?? throw new InvalidArgumentException(\sprintf('Unsupported changelog type "%s".', $value));
+    }
+}

--- a/src/Changelog/Manager/ChangelogManager.php
+++ b/src/Changelog/Manager/ChangelogManager.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Manager;
+
+use Throwable;
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
+use FastForward\DevTools\Changelog\Parser\ChangelogParserInterface;
+use FastForward\DevTools\Changelog\Renderer\MarkdownRendererInterface;
+use RuntimeException;
+
+/**
+ * Applies changelog mutations and derived release metadata.
+ */
+final readonly class ChangelogManager implements ChangelogManagerInterface
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogParserInterface $parser
+     * @param MarkdownRendererInterface $renderer
+     * @param GitClientInterface $gitClient
+     */
+    public function __construct(
+        private FilesystemInterface $filesystem,
+        private ChangelogParserInterface $parser,
+        private MarkdownRendererInterface $renderer,
+        private GitClientInterface $gitClient,
+    ) {}
+
+    /**
+     * Adds a changelog entry to the selected release section.
+     *
+     * @param string $file
+     * @param ChangelogEntryType $type
+     * @param string $message
+     * @param string $version
+     * @param ?string $date
+     */
+    public function addEntry(
+        string $file,
+        ChangelogEntryType $type,
+        string $message,
+        string $version = ChangelogDocument::UNRELEASED_VERSION,
+        ?string $date = null,
+    ): void {
+        $document = $this->load($file);
+        $release = $document->getRelease($version) ?? new ChangelogRelease($version, $date);
+
+        if (null !== $date && $release->getDate() !== $date) {
+            $release = $release->withDate($date);
+        }
+
+        $document = $document->withRelease($release->withEntry($type, $message));
+
+        $this->persist($file, $document);
+    }
+
+    /**
+     * Promotes the Unreleased section into a published release.
+     *
+     * @param string $file
+     * @param string $version
+     * @param string $date
+     */
+    public function promote(string $file, string $version, string $date): void
+    {
+        $document = $this->load($file);
+
+        if (! $document->getUnreleased()->hasEntries()) {
+            throw new RuntimeException(\sprintf('%s does not contain unreleased entries to promote.', $file));
+        }
+
+        $document = $document->promoteUnreleased($version, $date);
+
+        $this->persist($file, $document);
+    }
+
+    /**
+     * Returns the next semantic version inferred from unreleased entries.
+     *
+     * @param string $file
+     * @param ?string $currentVersion
+     */
+    public function inferNextVersion(string $file, ?string $currentVersion = null): string
+    {
+        $document = $this->load($file);
+        $unreleased = $document->getUnreleased();
+
+        if (! $unreleased->hasEntries()) {
+            throw new RuntimeException(\sprintf(
+                '%s does not contain unreleased entries to infer a version from.',
+                $file
+            ));
+        }
+
+        $currentVersion ??= $document->getLatestPublishedRelease()?->getVersion() ?? '0.0.0';
+        [$major, $minor, $patch] = array_map(intval(...), explode('.', $currentVersion));
+
+        if ([] !== $unreleased->getEntriesFor(ChangelogEntryType::Removed)
+            || [] !== $unreleased->getEntriesFor(ChangelogEntryType::Deprecated)
+        ) {
+            return \sprintf('%d.0.0', $major + 1);
+        }
+
+        if ([] !== $unreleased->getEntriesFor(ChangelogEntryType::Added)
+            || [] !== $unreleased->getEntriesFor(ChangelogEntryType::Changed)
+        ) {
+            return \sprintf('%d.%d.0', $major, $minor + 1);
+        }
+
+        return \sprintf('%d.%d.%d', $major, $minor, $patch + 1);
+    }
+
+    /**
+     * Returns the rendered notes body for a specific released version.
+     *
+     * @param string $file
+     * @param string $version
+     */
+    public function renderReleaseNotes(string $file, string $version): string
+    {
+        $release = $this->load($file)
+            ->getRelease($version);
+
+        if (! $release instanceof ChangelogRelease) {
+            throw new RuntimeException(\sprintf('%s does not contain a [%s] section.', $file, $version));
+        }
+
+        return $this->renderer->renderReleaseBody($release);
+    }
+
+    /**
+     * Loads and parses the changelog file.
+     *
+     * @param string $file
+     */
+    public function load(string $file): ChangelogDocument
+    {
+        if (! $this->filesystem->exists($file)) {
+            return ChangelogDocument::create();
+        }
+
+        return $this->parser->parse($this->filesystem->readFile($file));
+    }
+
+    /**
+     * Resolves the canonical repository URL for compare links.
+     *
+     * @param string $workingDirectory
+     */
+    private function resolveRepositoryUrl(string $workingDirectory): ?string
+    {
+        try {
+            $repositoryUrl = $this->gitClient->getConfig('remote.origin.url', $workingDirectory);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return '' === $repositoryUrl ? null : $repositoryUrl;
+    }
+
+    /**
+     * Persists the rendered changelog document to disk.
+     *
+     * @param string $file
+     * @param ChangelogDocument $document
+     */
+    private function persist(string $file, ChangelogDocument $document): void
+    {
+        $this->filesystem->dumpFile(
+            $file,
+            $this->renderer->render($document, $this->resolveRepositoryUrl($this->filesystem->dirname($file))),
+        );
+    }
+}

--- a/src/Changelog/Manager/ChangelogManagerInterface.php
+++ b/src/Changelog/Manager/ChangelogManagerInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Manager;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+
+/**
+ * Applies changelog mutations and derives release metadata.
+ */
+interface ChangelogManagerInterface
+{
+    /**
+     * Adds a changelog entry to the selected release section.
+     *
+     * @param string $file
+     * @param ChangelogEntryType $type
+     * @param string $message
+     * @param string $version
+     * @param ?string $date
+     */
+    public function addEntry(
+        string $file,
+        ChangelogEntryType $type,
+        string $message,
+        string $version = ChangelogDocument::UNRELEASED_VERSION,
+        ?string $date = null,
+    ): void;
+
+    /**
+     * Promotes the Unreleased section into a published release.
+     *
+     * @param string $file
+     * @param string $version
+     * @param string $date
+     */
+    public function promote(string $file, string $version, string $date): void;
+
+    /**
+     * Returns the next semantic version inferred from unreleased entries.
+     *
+     * @param string $file
+     * @param ?string $currentVersion
+     */
+    public function inferNextVersion(string $file, ?string $currentVersion = null): string;
+
+    /**
+     * Returns the rendered notes body for a specific released version.
+     *
+     * @param string $file
+     * @param string $version
+     */
+    public function renderReleaseNotes(string $file, string $version): string;
+
+    /**
+     * Loads and parses the changelog file.
+     *
+     * @param string $file
+     */
+    public function load(string $file): ChangelogDocument;
+}

--- a/src/Changelog/Parser/ChangelogParser.php
+++ b/src/Changelog/Parser/ChangelogParser.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Parser;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+
+use function Safe\preg_match;
+use function Safe\preg_match_all;
+use function Safe\preg_split;
+use function array_values;
+use function preg_quote;
+use function trim;
+
+/**
+ * Parses the subset of Keep a Changelog structure managed by dev-tools.
+ */
+final class ChangelogParser implements ChangelogParserInterface
+{
+    /**
+     * Parses markdown content into a changelog document.
+     *
+     * @param string $contents
+     */
+    public function parse(string $contents): ChangelogDocument
+    {
+        if ('' === trim($contents)) {
+            return ChangelogDocument::create();
+        }
+
+        preg_match_all(
+            '/^## \[(?<version>[^\]]+)\](?: - (?<date>\d{4}-\d{2}-\d{2}))?$/m',
+            $contents,
+            $matches,
+            \PREG_OFFSET_CAPTURE,
+        );
+
+        if ([] === $matches[0]) {
+            return ChangelogDocument::create();
+        }
+
+        $releases = [];
+        $sectionCount = \count($matches[0]);
+
+        for ($index = 0; $index < $sectionCount; ++$index) {
+            $heading = $matches[0][$index][0];
+            $offset = $matches[0][$index][1];
+            $bodyStart = $offset + \strlen((string) $heading);
+            $bodyEnd = $matches[0][$index + 1][1] ?? \strlen($contents);
+            $body = trim(substr($contents, $bodyStart, $bodyEnd - $bodyStart));
+
+            $entries = [];
+
+            foreach (ChangelogEntryType::ordered() as $type) {
+                $entries[$type->value] = $this->extractEntries($body, $type);
+            }
+
+            $releases[] = new ChangelogRelease(
+                $matches['version'][$index][0],
+                '' === ($matches['date'][$index][0] ?? '') ? null : $matches['date'][$index][0],
+                $entries,
+            );
+        }
+
+        return new ChangelogDocument($releases);
+    }
+
+    /**
+     * Extracts bullet entries for one changelog category.
+     *
+     * @param string $body
+     * @param ChangelogEntryType $type
+     *
+     * @return list<string>
+     */
+    private function extractEntries(string $body, ChangelogEntryType $type): array
+    {
+        $pattern = \sprintf('/^### %s\s*(?:\R(?<body>.*?))?(?=^### |\z)/ms', preg_quote($type->value, '/'));
+
+        if (1 !== preg_match($pattern, $body, $matches)) {
+            return [];
+        }
+
+        $lines = preg_split('/\R/', trim($matches['body'] ?? ''));
+        $entries = [];
+
+        foreach ($lines as $line) {
+            $line = trim((string) $line);
+
+            if (! str_starts_with($line, '- ')) {
+                continue;
+            }
+
+            $entry = trim(substr($line, 2));
+
+            if ('' === $entry) {
+                continue;
+            }
+
+            $entries[] = $entry;
+        }
+
+        return array_values(array_unique($entries));
+    }
+}

--- a/src/Changelog/Parser/ChangelogParserInterface.php
+++ b/src/Changelog/Parser/ChangelogParserInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Parser;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+
+/**
+ * Parses managed changelog markdown into domain objects.
+ */
+interface ChangelogParserInterface
+{
+    /**
+     * Parses markdown contents into a changelog document.
+     *
+     * @param string $contents
+     */
+    public function parse(string $contents): ChangelogDocument;
+}

--- a/src/Changelog/Renderer/MarkdownRenderer.php
+++ b/src/Changelog/Renderer/MarkdownRenderer.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Renderer;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+
+use function Safe\preg_match;
+use function explode;
+use function implode;
+use function rtrim;
+use function str_ends_with;
+use function substr;
+use function trim;
+
+/**
+ * Renders Keep a Changelog markdown in a deterministic package-friendly format.
+ */
+final readonly class MarkdownRenderer implements MarkdownRendererInterface
+{
+    private const string INTRODUCTION = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).";
+
+    /**
+     * Renders the full changelog markdown content.
+     *
+     * @param ChangelogDocument $document
+     * @param ?string $repositoryUrl
+     */
+    public function render(ChangelogDocument $document, ?string $repositoryUrl = null): string
+    {
+        $lines = explode("\n", self::INTRODUCTION);
+
+        foreach ($document->getReleases() as $release) {
+            if ('' !== $lines[array_key_last($lines)]) {
+                $lines[] = '';
+            }
+
+            $lines = [...$lines, ...$this->renderRelease($release)];
+        }
+
+        $references = $this->renderReferences($document, $repositoryUrl);
+
+        if ([] !== $references) {
+            if ('' !== $lines[array_key_last($lines)]) {
+                $lines[] = '';
+            }
+
+            $lines = [...$lines, ...$references];
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Renders only the body content of one released version.
+     *
+     * @param ChangelogRelease $release
+     */
+    public function renderReleaseBody(ChangelogRelease $release): string
+    {
+        return implode("\n", \array_slice($this->renderRelease($release), 2)) . "\n";
+    }
+
+    /**
+     * @param ChangelogRelease $release
+     *
+     * @return list<string>
+     */
+    private function renderRelease(ChangelogRelease $release): array
+    {
+        $heading = $release->isUnreleased()
+            ? \sprintf('## [%s]', ChangelogDocument::UNRELEASED_VERSION)
+            : (null === $release->getDate()
+                ? \sprintf('## [%s]', $release->getVersion())
+                : \sprintf('## [%s] - %s', $release->getVersion(), $release->getDate()));
+
+        $lines = [$heading, ''];
+        $renderedSections = 0;
+
+        foreach (ChangelogEntryType::ordered() as $type) {
+            $sectionEntries = $release->getEntriesFor($type);
+
+            if ([] === $sectionEntries) {
+                continue;
+            }
+
+            if (0 < $renderedSections) {
+                $lines[] = '';
+            }
+
+            $lines[] = '### ' . $type->value;
+            $lines[] = '';
+
+            foreach ($sectionEntries as $entry) {
+                $lines[] = '- ' . $entry;
+            }
+
+            ++$renderedSections;
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param ChangelogDocument $document
+     * @param ?string $repositoryUrl
+     *
+     * @return list<string>
+     */
+    private function renderReferences(ChangelogDocument $document, ?string $repositoryUrl): array
+    {
+        $normalizedRepositoryUrl = $this->normalizeRepositoryUrl($repositoryUrl);
+
+        if (null === $normalizedRepositoryUrl) {
+            return [];
+        }
+
+        $published = array_values(array_filter(
+            $document->getReleases(),
+            static fn(ChangelogRelease $release): bool => ! $release->isUnreleased(),
+        ));
+
+        if ([] === $published) {
+            return [];
+        }
+
+        $references = [
+            \sprintf(
+                '[unreleased]: %s/compare/%s...HEAD',
+                $normalizedRepositoryUrl,
+                $this->resolveTag($published[0]),
+            ),
+        ];
+
+        foreach ($published as $index => $release) {
+            $references[] = isset($published[$index + 1])
+                ? \sprintf(
+                    '[%s]: %s/compare/%s...%s',
+                    $release->getVersion(),
+                    $normalizedRepositoryUrl,
+                    $this->resolveTag($published[$index + 1]),
+                    $this->resolveTag($release),
+                )
+                : \sprintf(
+                    '[%s]: %s/releases/tag/%s',
+                    $release->getVersion(),
+                    $normalizedRepositoryUrl,
+                    $this->resolveTag($release),
+                );
+        }
+
+        return ['', ...$references];
+    }
+
+    /**
+     * Resolves the git tag name for a rendered release.
+     *
+     * @param ChangelogRelease $release
+     */
+    private function resolveTag(ChangelogRelease $release): string
+    {
+        return 'v' . $release->getVersion();
+    }
+
+    /**
+     * Normalizes repository URLs to the public HTTPS form expected by footer links.
+     *
+     * @param ?string $repositoryUrl
+     */
+    private function normalizeRepositoryUrl(?string $repositoryUrl): ?string
+    {
+        if (null === $repositoryUrl) {
+            return null;
+        }
+
+        $repositoryUrl = trim($repositoryUrl);
+
+        if ('' === $repositoryUrl) {
+            return null;
+        }
+
+        if (1 === preg_match('~^git@(?<host>[^:]+):(?<path>.+)$~', $repositoryUrl, $matches)) {
+            $repositoryUrl = 'https://' . $matches['host'] . '/' . $matches['path'];
+        }
+
+        if (1 === preg_match('~^ssh://git@(?<host>[^/]+)/(?<path>.+)$~', $repositoryUrl, $matches)) {
+            $repositoryUrl = 'https://' . $matches['host'] . '/' . $matches['path'];
+        }
+
+        if (str_ends_with($repositoryUrl, '.git')) {
+            $repositoryUrl = substr($repositoryUrl, 0, -4);
+        }
+
+        return rtrim($repositoryUrl, '/');
+    }
+}

--- a/src/Changelog/Renderer/MarkdownRendererInterface.php
+++ b/src/Changelog/Renderer/MarkdownRendererInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Changelog\Renderer;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+
+/**
+ * Renders managed changelog domain objects into markdown.
+ */
+interface MarkdownRendererInterface
+{
+    /**
+     * Renders the full changelog markdown content.
+     *
+     * @param ChangelogDocument $document
+     * @param ?string $repositoryUrl
+     */
+    public function render(ChangelogDocument $document, ?string $repositoryUrl = null): string;
+
+    /**
+     * Renders only the body content of one released version.
+     *
+     * @param ChangelogRelease $release
+     */
+    public function renderReleaseBody(ChangelogRelease $release): string;
+}

--- a/src/Console/Command/ChangelogCheckCommand.php
+++ b/src/Console/Command/ChangelogCheckCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use FastForward\DevTools\Changelog\Checker\UnreleasedEntryCheckerInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Verifies that the changelog contains pending unreleased notes.
+ */
+#[AsCommand(
+    name: 'changelog:check',
+    description: 'Checks whether a changelog file contains meaningful unreleased entries.',
+    help: 'This command validates the current Unreleased section and may compare it against a base git reference to enforce pull request changelog updates.'
+)]
+final class ChangelogCheckCommand extends BaseCommand
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param UnreleasedEntryCheckerInterface $unreleasedEntryChecker
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly UnreleasedEntryCheckerInterface $unreleasedEntryChecker,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures changelog verification options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                name: 'against',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Optional git reference used as the baseline changelog file.',
+            )
+            ->addOption(
+                name: 'file',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Path to the changelog file.',
+                default: 'CHANGELOG.md',
+            );
+    }
+
+    /**
+     * Executes the changelog verification.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $this->filesystem->getAbsolutePath($input->getOption('file'));
+        $against = $input->getOption('against');
+
+        $hasPendingChanges = $this->unreleasedEntryChecker
+            ->hasPendingChanges($path, $against);
+
+        $file = (string) $input->getOption('file');
+
+        if ($hasPendingChanges) {
+            $output->writeln(\sprintf('<info>%s contains unreleased changes ready for review.</info>', $file));
+
+            return self::SUCCESS;
+        }
+
+        $output->writeln(\sprintf('<error>%s must add a meaningful entry to the Unreleased section.</error>', $file));
+
+        return self::FAILURE;
+    }
+}

--- a/src/Console/Command/ChangelogEntryCommand.php
+++ b/src/Console/Command/ChangelogEntryCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Inserts a changelog entry into the managed changelog file.
+ */
+#[AsCommand(
+    name: 'changelog:entry',
+    description: 'Adds a changelog entry to Unreleased or a specific version section.',
+    help: 'This command appends one categorized changelog entry to the selected changelog file so it can be reused by local authoring flows and skills.'
+)]
+final class ChangelogEntryCommand extends BaseCommand
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogManagerInterface $changelogManager
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly ChangelogManagerInterface $changelogManager,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures the entry authoring arguments and options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                name: 'message',
+                mode: InputArgument::REQUIRED,
+                description: 'The changelog entry text to append.',
+            )
+            ->addOption(
+                name: 'type',
+                shortcut: 't',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'The changelog category (added, changed, deprecated, removed, fixed, security).',
+                default: 'added',
+                suggestedValues: array_map(
+                    static fn(ChangelogEntryType $type): string => strtolower($type->value),
+                    ChangelogEntryType::ordered()
+                ),
+            )
+            ->addOption(
+                name: 'release',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'The target release section. Defaults to Unreleased.',
+                default: ChangelogDocument::UNRELEASED_VERSION,
+            )
+            ->addOption(
+                name: 'date',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Optional release date for published sections in YYYY-MM-DD format.',
+            )
+            ->addOption(
+                name: 'file',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Path to the changelog file.',
+                default: 'CHANGELOG.md',
+            );
+    }
+
+    /**
+     * Appends a changelog entry to the requested section.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = $this->filesystem->getAbsolutePath((string) $input->getOption('file'));
+        $type = ChangelogEntryType::fromInput((string) $input->getOption('type'));
+        $version = (string) $input->getOption('release');
+        $date = $input->getOption('date');
+        $message = (string) $input->getArgument('message');
+
+        $this->changelogManager->addEntry($file, $type, $message, $version, \is_string($date) ? $date : null);
+
+        $output->writeln(\sprintf(
+            '<info>Added %s changelog entry to [%s] in %s.</info>',
+            strtolower($type->value),
+            $version,
+            $file,
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Command/ChangelogNextVersionCommand.php
+++ b/src/Console/Command/ChangelogNextVersionCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Infers the next semantic version from changelog content.
+ */
+#[AsCommand(
+    name: 'changelog:next-version',
+    description: 'Infers the next semantic version from the Unreleased changelog section.',
+    help: 'This command inspects Unreleased changelog categories and prints the next semantic version inferred from the current changelog state.'
+)]
+final class ChangelogNextVersionCommand extends BaseCommand
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogManagerInterface $changelogManager
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly ChangelogManagerInterface $changelogManager,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures version inference options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                name: 'file',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Path to the changelog file.',
+                default: 'CHANGELOG.md',
+            )
+            ->addOption(
+                name: 'current-version',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Explicit current version to use as the bump base.',
+            );
+    }
+
+    /**
+     * Prints the inferred next semantic version.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $this->filesystem->getAbsolutePath($input->getOption('file'));
+        $currentVersion = $input->getOption('current-version');
+
+        $output->writeln($this->changelogManager->inferNextVersion($path, $currentVersion));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Command/ChangelogPromoteCommand.php
+++ b/src/Console/Command/ChangelogPromoteCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Promotes the Unreleased section into a published changelog version.
+ */
+#[AsCommand(
+    name: 'changelog:promote',
+    description: 'Promotes Unreleased entries into a published changelog version.',
+    help: 'This command moves the current Unreleased entries into a released version section, records the release date, and restores an empty Unreleased section.'
+)]
+final class ChangelogPromoteCommand extends BaseCommand
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogManagerInterface $changelogManager
+     * @param ClockInterface $clock
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly ChangelogManagerInterface $changelogManager,
+        private readonly ClockInterface $clock,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures the promotion arguments and options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                name: 'version',
+                mode: InputArgument::REQUIRED,
+                description: 'The semantic version that should receive the current Unreleased entries.',
+            )
+            ->addOption(
+                name: 'date',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'The release date to record in YYYY-MM-DD format.',
+            )
+            ->addOption(
+                name: 'file',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Path to the changelog file.',
+                default: 'CHANGELOG.md',
+            );
+    }
+
+    /**
+     * Promotes unreleased entries into the requested version section.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = $this->filesystem->getAbsolutePath((string) $input->getOption('file'));
+        $version = (string) $input->getArgument('version');
+        $date = (string) ($input->getOption('date') ?: $this->clock->now()->format('Y-m-d'));
+
+        $this->changelogManager->promote($file, $version, $date);
+
+        $output->writeln(\sprintf(
+            '<info>Promoted Unreleased changelog entries to [%s] in %s.</info>',
+            $version,
+            $file,
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Command/ChangelogShowCommand.php
+++ b/src/Console/Command/ChangelogShowCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Composer\Command\BaseCommand;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Prints the rendered notes body for a released changelog version.
+ */
+#[AsCommand(
+    name: 'changelog:show',
+    description: 'Prints the notes body for a released changelog version.',
+    help: 'This command renders the body of one released changelog section so it can be reused for GitHub release notes.'
+)]
+final class ChangelogShowCommand extends BaseCommand
+{
+    /**
+     * @param FilesystemInterface $filesystem
+     * @param ChangelogManagerInterface $changelogManager
+     */
+    public function __construct(
+        private readonly FilesystemInterface $filesystem,
+        private readonly ChangelogManagerInterface $changelogManager,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * Configures the show command arguments and options.
+     */
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                name: 'version',
+                mode: InputArgument::REQUIRED,
+                description: 'The released version to render.',
+            )
+            ->addOption(
+                name: 'file',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Path to the changelog file.',
+                default: 'CHANGELOG.md',
+            );
+    }
+
+    /**
+     * Prints the rendered release notes body.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->write($this->changelogManager->renderReleaseNotes(
+            $this->filesystem->getAbsolutePath((string) $input->getOption('file')),
+            (string) $input->getArgument('version'),
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -121,7 +121,12 @@ final class FundingCommand extends BaseCommand
         $output->writeln('<info>Synchronizing funding metadata...</info>');
 
         if (! $this->filesystem->exists($composerFile)) {
-            $output->writeln(\sprintf('<comment>Composer file %s does not exist. Skipping funding synchronization.</comment>', $composerFile));
+            $output->writeln(
+                \sprintf(
+                    '<comment>Composer file %s does not exist. Skipping funding synchronization.</comment>',
+                    $composerFile
+                )
+            );
 
             return self::SUCCESS;
         }
@@ -167,6 +172,15 @@ final class FundingCommand extends BaseCommand
     /**
      * Handles composer.json synchronization reporting and writes.
      *
+     * @param string $composerFile
+     * @param string $composerContents
+     * @param string $updatedComposerContents
+     * @param bool $dryRun
+     * @param bool $check
+     * @param bool $interactive
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
      * @return int the command status code
      */
     private function handleComposerFile(
@@ -209,7 +223,11 @@ final class FundingCommand extends BaseCommand
             return self::SUCCESS;
         }
 
-        if ($interactive && $input->isInteractive() && ! $this->shouldWriteManagedFile($input, $output, $composerFile)) {
+        if ($interactive && $input->isInteractive() && ! $this->shouldWriteManagedFile(
+            $input,
+            $output,
+            $composerFile
+        )) {
             $output->writeln(\sprintf('<comment>Skipped updating %s.</comment>', $composerFile));
 
             return self::SUCCESS;
@@ -229,6 +247,15 @@ final class FundingCommand extends BaseCommand
     /**
      * Handles .github/FUNDING.yml synchronization reporting and writes.
      *
+     * @param string $fundingFile
+     * @param ?string $currentFundingContents
+     * @param ?string $updatedFundingContents
+     * @param bool $dryRun
+     * @param bool $check
+     * @param bool $interactive
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
      * @return int the command status code
      */
     private function handleFundingFile(
@@ -242,7 +269,9 @@ final class FundingCommand extends BaseCommand
         OutputInterface $output,
     ): int {
         if (null === $updatedFundingContents && null === $currentFundingContents) {
-            $output->writeln('<comment>No supported funding metadata found. Skipping .github/FUNDING.yml synchronization.</comment>');
+            $output->writeln(
+                '<comment>No supported funding metadata found. Skipping .github/FUNDING.yml synchronization.</comment>'
+            );
 
             return self::SUCCESS;
         }
@@ -257,7 +286,10 @@ final class FundingCommand extends BaseCommand
             $updatedFundingContents,
             $currentFundingContents,
             null === $currentFundingContents
-                ? \sprintf('Managed file %s will be created from generated funding metadata synchronization.', $fundingFile)
+                ? \sprintf(
+                    'Managed file %s will be created from generated funding metadata synchronization.',
+                    $fundingFile
+                )
                 : \sprintf('Updating managed file %s from generated funding metadata synchronization.', $fundingFile),
         );
 
@@ -291,6 +323,7 @@ final class FundingCommand extends BaseCommand
 
         $this->filesystem->mkdir($this->filesystem->dirname($fundingFile));
         $this->filesystem->dumpFile($fundingFile, $updatedFundingContents);
+
         $output->writeln(\sprintf('<info>Updated funding metadata in %s.</info>', $fundingFile));
 
         return self::SUCCESS;
@@ -299,13 +332,18 @@ final class FundingCommand extends BaseCommand
     /**
      * Prompts whether a managed file should be written.
      *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param string $targetFile
+     *
      * @return bool true when the write SHOULD proceed
      */
     private function shouldWriteManagedFile(InputInterface $input, OutputInterface $output, string $targetFile): bool
     {
         $question = new ConfirmationQuestion(\sprintf('Update managed file %s? [y/N] ', $targetFile), false);
 
-        return (bool) $this->getHelper('question')->ask($input, $output, $question);
+        return (bool) $this->getHelper('question')
+            ->ask($input, $output, $question);
     }
 
     /**

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Console\Command;
 use Composer\Command\BaseCommand;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -51,12 +52,14 @@ final class WikiCommand extends BaseCommand
      * @param ProcessBuilderInterface $processBuilder
      * @param ProcessQueueInterface $processQueue
      * @param FilesystemInterface $filesystem the filesystem used to inspect the wiki target
+     * @param GitClientInterface $gitClient
      */
     public function __construct(
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
         private readonly ComposerJsonInterface $composer,
         private readonly FilesystemInterface $filesystem,
+        private readonly GitClientInterface $gitClient,
     ) {
         return parent::__construct();
     }
@@ -173,14 +176,6 @@ final class WikiCommand extends BaseCommand
      */
     private function getGitRepositoryUrl(): string
     {
-        $process = $this->processBuilder
-            ->withArgument('config')
-            ->withArgument('--get')
-            ->withArgument('remote.origin.url')
-            ->build('git');
-
-        $process->mustRun();
-
-        return trim($process->getOutput());
+        return $this->gitClient->getConfig('remote.origin.url', getcwd());
     }
 }

--- a/src/Funding/ComposerFundingCodec.php
+++ b/src/Funding/ComposerFundingCodec.php
@@ -20,13 +20,11 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Funding;
 
 use Composer\Json\JsonFile;
+
+use function Safe\json_encode;
+use function Safe\parse_url;
+use function Safe\preg_match;
 use function array_values;
-use function is_array;
-use function is_string;
-use function json_encode;
-use function parse_url;
-use function preg_match;
-use function sprintf;
 use function trim;
 
 /**
@@ -46,7 +44,7 @@ final readonly class ComposerFundingCodec
         $data = JsonFile::parseJson($contents);
         $funding = $data['funding'] ?? [];
 
-        if (! is_array($funding)) {
+        if (! \is_array($funding)) {
             return new FundingProfile();
         }
 
@@ -55,12 +53,12 @@ final readonly class ComposerFundingCodec
         $unsupported = [];
 
         foreach ($funding as $entry) {
-            if (! is_array($entry)) {
+            if (! \is_array($entry)) {
                 continue;
             }
 
-            $type = is_string($entry['type'] ?? null) ? trim($entry['type']) : '';
-            $url = is_string($entry['url'] ?? null) ? trim($entry['url']) : '';
+            $type = \is_string($entry['type'] ?? null) ? trim($entry['type']) : '';
+            $url = \is_string($entry['url'] ?? null) ? trim($entry['url']) : '';
 
             if ('' === $url) {
                 $unsupported[] = $entry;
@@ -107,7 +105,7 @@ final readonly class ComposerFundingCodec
         foreach ($profile->getGithubSponsors() as $githubSponsor) {
             $entries[] = [
                 'type' => 'github',
-                'url' => sprintf('https://github.com/sponsors/%s', $githubSponsor),
+                'url' => \sprintf('https://github.com/sponsors/%s', $githubSponsor),
             ];
         }
 
@@ -126,15 +124,12 @@ final readonly class ComposerFundingCodec
         unset($data['funding']);
 
         if ([] === $entries) {
-            return json_encode(
-                $data,
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
-            ) . "\n";
+            return json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) . "\n";
         }
 
         return json_encode(
             $this->insertFundingEntries($data, $entries),
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
         ) . "\n";
     }
 
@@ -147,10 +142,10 @@ final readonly class ComposerFundingCodec
      */
     private function extractGithubSponsor(string $url): ?string
     {
-        $host = parse_url($url, PHP_URL_HOST);
-        $path = parse_url($url, PHP_URL_PATH);
+        $host = parse_url($url, \PHP_URL_HOST);
+        $path = parse_url($url, \PHP_URL_PATH);
 
-        if (! is_string($host) || ! is_string($path)) {
+        if (! \is_string($host) || ! \is_string($path)) {
             return null;
         }
 

--- a/src/Funding/FundingProfile.php
+++ b/src/Funding/FundingProfile.php
@@ -37,8 +37,7 @@ final readonly class FundingProfile
         private array $customUrls = [],
         private array $unsupportedYamlEntries = [],
         private array $unsupportedComposerEntries = [],
-    ) {
-    }
+    ) {}
 
     /**
      * Returns the normalized GitHub Sponsors handles.

--- a/src/Funding/FundingProfileMerger.php
+++ b/src/Funding/FundingProfileMerger.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Funding;
 
-use function array_merge;
 use function array_unique;
 use function sort;
 

--- a/src/Funding/FundingYamlCodec.php
+++ b/src/Funding/FundingYamlCodec.php
@@ -23,9 +23,6 @@ use Symfony\Component\Yaml\Yaml;
 
 use function array_filter;
 use function array_values;
-use function count;
-use function is_array;
-use function is_string;
 use function trim;
 
 /**
@@ -48,14 +45,14 @@ final readonly class FundingYamlCodec
 
         $data = Yaml::parse($contents);
 
-        if (! is_array($data)) {
+        if (! \is_array($data)) {
             return new FundingProfile();
         }
 
         $unsupported = array_filter(
             $data,
             static fn(string $key): bool => ! \in_array($key, ['github', 'custom'], true),
-            ARRAY_FILTER_USE_KEY,
+            \ARRAY_FILTER_USE_KEY,
         );
 
         return new FundingProfile(
@@ -96,17 +93,17 @@ final readonly class FundingYamlCodec
      */
     private function normalizeList(mixed $value): array
     {
-        if (is_string($value) && '' !== trim($value)) {
+        if (\is_string($value) && '' !== trim($value)) {
             return [trim($value)];
         }
 
-        if (! is_array($value)) {
+        if (! \is_array($value)) {
             return [];
         }
 
         return array_values(array_filter(
             array_map(
-                static fn(mixed $entry): ?string => is_string($entry) && '' !== trim($entry) ? trim($entry) : null,
+                static fn(mixed $entry): ?string => \is_string($entry) && '' !== trim($entry) ? trim($entry) : null,
                 $value,
             ),
         ));
@@ -121,6 +118,6 @@ final readonly class FundingYamlCodec
      */
     private function denormalizeList(array $values): string|array
     {
-        return 1 === count($values) ? $values[0] : $values;
+        return 1 === \count($values) ? $values[0] : $values;
     }
 }

--- a/src/Git/GitClient.php
+++ b/src/Git/GitClient.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Git;
+
+use Symfony\Component\Process\Process;
+use FastForward\DevTools\Process\ProcessBuilderInterface;
+use FastForward\DevTools\Process\ProcessQueueInterface;
+use RuntimeException;
+use Symfony\Component\Filesystem\Path;
+
+use function rtrim;
+use function str_starts_with;
+use function trim;
+
+/**
+ * Executes semantic Git operations using the local Git binary.
+ */
+final readonly class GitClient implements GitClientInterface
+{
+    /**
+     * @param ProcessBuilderInterface $processBuilder
+     * @param ProcessQueueInterface $processQueue
+     */
+    public function __construct(
+        private ProcessBuilderInterface $processBuilder,
+        private ProcessQueueInterface $processQueue,
+    ) {}
+
+    /**
+     * Returns a Git config value for the selected repository.
+     *
+     * @param string $key
+     * @param ?string $workingDirectory
+     */
+    public function getConfig(string $key, ?string $workingDirectory = null): string
+    {
+        return $this->run(
+            $this->processBuilder
+                ->withArgument('config')
+                ->withArgument('--get')
+                ->withArgument($key)
+                ->build('git'),
+            $workingDirectory,
+        );
+    }
+
+    /**
+     * Returns the file contents shown from a specific Git reference.
+     *
+     * @param string $reference
+     * @param string $path
+     * @param ?string $workingDirectory
+     */
+    public function show(string $reference, string $path, ?string $workingDirectory = null): string
+    {
+        if (null !== $workingDirectory && Path::isAbsolute($path)) {
+            $normalizedWorkingDirectory = rtrim(Path::canonicalize($workingDirectory), '/');
+            $normalizedPath = Path::canonicalize($path);
+
+            if (str_starts_with($normalizedPath, $normalizedWorkingDirectory . '/')) {
+                $path = Path::makeRelative($normalizedPath, $normalizedWorkingDirectory);
+            }
+        }
+
+        return $this->run(
+            $this->processBuilder
+                ->withArgument('show')
+                ->withArgument($reference . ':' . $path)
+                ->build('git'),
+            $workingDirectory,
+        );
+    }
+
+    /**
+     * Executes a Git process and returns trimmed stdout.
+     *
+     * @param Process $process
+     * @param ?string $workingDirectory
+     */
+    private function run(Process $process, ?string $workingDirectory = null): string
+    {
+        if (null !== $workingDirectory) {
+            $process->setWorkingDirectory($workingDirectory);
+        }
+
+        $this->processQueue->add($process);
+
+        if (ProcessQueueInterface::SUCCESS !== $this->processQueue->run()) {
+            throw new RuntimeException(trim($process->getErrorOutput()));
+        }
+
+        return trim($process->getOutput());
+    }
+}

--- a/src/Git/GitClientInterface.php
+++ b/src/Git/GitClientInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Git;
+
+/**
+ * Provides semantic Git operations for repository-aware services.
+ */
+interface GitClientInterface
+{
+    /**
+     * Returns a Git config value for the selected repository.
+     *
+     * @param string $key
+     * @param ?string $workingDirectory
+     */
+    public function getConfig(string $key, ?string $workingDirectory = null): string;
+
+    /**
+     * Returns the file contents shown from a specific Git reference.
+     *
+     * @param string $reference
+     * @param string $path
+     * @param ?string $workingDirectory
+     */
+    public function show(string $reference, string $path, ?string $workingDirectory = null): string;
+}

--- a/src/Process/ProcessQueue.php
+++ b/src/Process/ProcessQueue.php
@@ -147,6 +147,7 @@ final class ProcessQueue implements ProcessQueueInterface
         }
 
         $this->drainDetachedProcessesOutput($output, true);
+        $this->entries = [];
 
         return $statusCode;
     }

--- a/src/ServiceProvider/DevToolsServiceProvider.php
+++ b/src/ServiceProvider/DevToolsServiceProvider.php
@@ -20,9 +20,19 @@ declare(strict_types=1);
 namespace FastForward\DevTools\ServiceProvider;
 
 use Composer\Plugin\Capability\CommandProvider;
+use FastForward\DevTools\Changelog\Manager\ChangelogManager;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Changelog\Parser\ChangelogParser;
+use FastForward\DevTools\Changelog\Parser\ChangelogParserInterface;
 use FastForward\DevTools\Composer\Capability\DevToolsCommandProvider;
 use FastForward\DevTools\Composer\Json\ComposerJson;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
+use FastForward\DevTools\Git\GitClient;
+use FastForward\DevTools\Git\GitClientInterface;
+use FastForward\DevTools\Changelog\Renderer\MarkdownRenderer;
+use FastForward\DevTools\Changelog\Renderer\MarkdownRendererInterface;
+use FastForward\DevTools\Changelog\Checker\UnreleasedEntryChecker;
+use FastForward\DevTools\Changelog\Checker\UnreleasedEntryCheckerInterface;
 use FastForward\DevTools\Console\CommandLoader\DevToolsCommandLoader;
 use FastForward\DevTools\Filesystem\FinderFactory;
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
@@ -99,6 +109,16 @@ final class DevToolsServiceProvider implements ServiceProviderInterface
 
             // Composer
             ComposerJsonInterface::class => get(ComposerJson::class),
+
+            // Changelog
+            ChangelogManagerInterface::class => get(ChangelogManager::class),
+            ChangelogParserInterface::class => get(ChangelogParser::class),
+            MarkdownRendererInterface::class => get(MarkdownRenderer::class),
+            UnreleasedEntryCheckerInterface::class => get(UnreleasedEntryChecker::class),
+
+            // Git
+            GitClientInterface::class => get(GitClient::class),
+
             // Symfony Components
             FileLocatorInterface::class => create(FileLocator::class)->constructor([getcwd(), \dirname(__DIR__, 2)]),
 

--- a/tests/Changelog/Checker/UnreleasedEntryCheckerTest.php
+++ b/tests/Changelog/Checker/UnreleasedEntryCheckerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Checker;
+
+use FastForward\DevTools\Changelog\Checker\UnreleasedEntryChecker;
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Parser\ChangelogParserInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+
+#[CoversClass(UnreleasedEntryChecker::class)]
+#[UsesClass(ChangelogDocument::class)]
+#[UsesClass(ChangelogRelease::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class UnreleasedEntryCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const string FILE = '/repo/CHANGELOG.md';
+
+    private const string WORKING_DIRECTORY = '/repo';
+
+    /**
+     * @var ObjectProphecy<GitClientInterface>
+     */
+    private ObjectProphecy $gitClient;
+
+    /**
+     * @var ObjectProphecy<FilesystemInterface>
+     */
+    private ObjectProphecy $filesystem;
+
+    /**
+     * @var ObjectProphecy<ChangelogParserInterface>
+     */
+    private ObjectProphecy $parser;
+
+    private UnreleasedEntryChecker $checker;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->gitClient = $this->prophesize(GitClientInterface::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->parser = $this->prophesize(ChangelogParserInterface::class);
+        $this->filesystem->dirname(self::FILE)
+            ->willReturn(self::WORKING_DIRECTORY);
+        $this->checker = new UnreleasedEntryChecker(
+            $this->filesystem->reveal(),
+            $this->gitClient->reveal(),
+            $this->parser->reveal(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillReturnFalseWhenTheFileCannotBeRead(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willThrow(new RuntimeException('Missing file'))
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->shouldNotBeCalled();
+
+        self::assertFalse($this->checker->hasPendingChanges(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillReturnFalseWhenTheUnreleasedSectionIsEmpty(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn(ChangelogDocument::create())
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->shouldNotBeCalled();
+
+        self::assertFalse($this->checker->hasPendingChanges(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillReturnTrueWhenUnreleasedSectionContainsEntries(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument(['Added changelog automation']))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->shouldNotBeCalled();
+
+        self::assertTrue($this->checker->hasPendingChanges(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillCompareAgainstBaselineReference(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument(['Added changelog automation']))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->willReturn('baseline changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('baseline changelog')
+            ->willReturn($this->createDocument(['Added changelog automation']))
+            ->shouldBeCalledOnce();
+
+        self::assertFalse($this->checker->hasPendingChanges(self::FILE, 'origin/main'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillReturnTrueWhenBaselineDoesNotContainNewEntries(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument(['Added changelog automation']))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->willReturn('baseline changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('baseline changelog')
+            ->willReturn($this->createDocument(['Initial release']))
+            ->shouldBeCalledOnce();
+
+        self::assertTrue($this->checker->hasPendingChanges(self::FILE, 'origin/main'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillReturnTrueWhenTheBaselineCannotBeLoaded(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument(['Added changelog automation']))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->willThrow(new RuntimeException('Missing baseline'))
+            ->shouldBeCalledOnce();
+        $this->parser->parse('baseline changelog')
+            ->shouldNotBeCalled();
+
+        self::assertTrue($this->checker->hasPendingChanges(self::FILE, 'origin/main'));
+    }
+
+    /**
+     * @param list<string> $entries
+     *
+     * @return ChangelogDocument
+     */
+    private function createDocument(array $entries): ChangelogDocument
+    {
+        $release = new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION);
+
+        foreach ($entries as $entry) {
+            $release = $release->withEntry(ChangelogEntryType::Added, $entry);
+        }
+
+        return new ChangelogDocument([
+            $release,
+            (new ChangelogRelease('1.0.0', '2026-04-08'))->withEntry(ChangelogEntryType::Added, 'Initial release'),
+        ]);
+    }
+}

--- a/tests/Changelog/Document/ChangelogDocumentTest.php
+++ b/tests/Changelog/Document/ChangelogDocumentTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Document;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChangelogDocument::class)]
+#[CoversClass(ChangelogRelease::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class ChangelogDocumentTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function withReleaseWillKeepTheUnreleasedSectionAtTheTop(): void
+    {
+        $document = ChangelogDocument::create()
+            ->withRelease((new ChangelogRelease('1.1.0', '2026-04-10'))->withEntry(
+                ChangelogEntryType::Added,
+                'Ship changelog automation',
+            ))
+            ->withRelease((new ChangelogRelease('1.0.0', '2026-04-01'))->withEntry(
+                ChangelogEntryType::Fixed,
+                'Stabilize command output',
+            ));
+
+        self::assertSame(
+            [ChangelogDocument::UNRELEASED_VERSION, '1.0.0', '1.1.0'],
+            array_map(
+                static fn(ChangelogRelease $release): string => $release->getVersion(),
+                $document->getReleases(),
+            ),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function promoteUnreleasedWillMergeWithAnExistingPublishedVersion(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))
+                ->withEntry(ChangelogEntryType::Added, 'Add release command')
+                ->withEntry(ChangelogEntryType::Fixed, 'Preserve release sections'),
+            (new ChangelogRelease('1.2.0', '2026-04-01'))
+                ->withEntry(ChangelogEntryType::Added, 'Existing release note'),
+        ]);
+
+        $promoted = $document->promoteUnreleased('1.2.0', '2026-04-19');
+        $release = $promoted->getRelease('1.2.0');
+
+        self::assertInstanceOf(ChangelogRelease::class, $release);
+        self::assertSame('2026-04-19', $release->getDate());
+        self::assertSame(
+            ['Existing release note', 'Add release command'],
+            $release->getEntriesFor(ChangelogEntryType::Added),
+        );
+        self::assertSame(['Preserve release sections'], $release->getEntriesFor(ChangelogEntryType::Fixed));
+        self::assertFalse($promoted->getUnreleased()->hasEntries());
+    }
+}

--- a/tests/Changelog/Manager/ChangelogManagerTest.php
+++ b/tests/Changelog/Manager/ChangelogManagerTest.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Manager;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Manager\ChangelogManager;
+use FastForward\DevTools\Changelog\Parser\ChangelogParserInterface;
+use FastForward\DevTools\Changelog\Renderer\MarkdownRendererInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+
+#[CoversClass(ChangelogManager::class)]
+#[UsesClass(ChangelogDocument::class)]
+#[UsesClass(ChangelogRelease::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class ChangelogManagerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const string FILE = '/repo/CHANGELOG.md';
+
+    private const string WORKING_DIRECTORY = '/repo';
+
+    /**
+     * @var ObjectProphecy<FilesystemInterface>
+     */
+    private ObjectProphecy $filesystem;
+
+    /**
+     * @var ObjectProphecy<ChangelogParserInterface>
+     */
+    private ObjectProphecy $parser;
+
+    /**
+     * @var ObjectProphecy<MarkdownRendererInterface>
+     */
+    private ObjectProphecy $renderer;
+
+    /**
+     * @var ObjectProphecy<GitClientInterface>
+     */
+    private ObjectProphecy $gitClient;
+
+    private ChangelogManager $manager;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->parser = $this->prophesize(ChangelogParserInterface::class);
+        $this->renderer = $this->prophesize(MarkdownRendererInterface::class);
+        $this->gitClient = $this->prophesize(GitClientInterface::class);
+        $this->manager = new ChangelogManager(
+            $this->filesystem->reveal(),
+            $this->parser->reveal(),
+            $this->renderer->reveal(),
+            $this->gitClient->reveal(),
+        );
+        $this->filesystem->dirname(self::FILE)
+            ->willReturn(self::WORKING_DIRECTORY);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function addEntryWillCreateTheManagedChangelogWhenNeeded(): void
+    {
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->gitClient->getConfig('remote.origin.url', self::WORKING_DIRECTORY)
+            ->willThrow(new RuntimeException('Missing remote'))
+            ->shouldBeCalledOnce();
+        $this->renderer->render(
+            Argument::that(static function (ChangelogDocument $document): bool {
+                $release = $document->getUnreleased();
+
+                return ['Ship changelog automation'] === $release->getEntriesFor(ChangelogEntryType::Added);
+            }),
+            null,
+        )->willReturn('rendered changelog')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(self::FILE, 'rendered changelog')
+            ->shouldBeCalledOnce();
+
+        $this->manager->addEntry(self::FILE, ChangelogEntryType::Added, 'Ship changelog automation');
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function addEntryWillPreserveExistingReleaseDatesWhenNoNewDateIsProvided(): void
+    {
+        $document = new ChangelogDocument([
+            new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION),
+            (new ChangelogRelease('1.2.0', '2026-04-19'))->withEntry(
+                ChangelogEntryType::Added,
+                'Keep previous release note',
+            ),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+        $this->gitClient->getConfig('remote.origin.url', self::WORKING_DIRECTORY)
+            ->willReturn('git@github.com:php-fast-forward/dev-tools.git')
+            ->shouldBeCalledOnce();
+        $this->renderer->render(
+            Argument::that(static function (ChangelogDocument $updated): bool {
+                $release = $updated->getRelease('1.2.0');
+
+                return $release instanceof ChangelogRelease
+                    && '2026-04-19' === $release->getDate()
+                    && [
+                        'Keep previous release note',
+                        'Add release automation',
+                    ] === $release->getEntriesFor(ChangelogEntryType::Added);
+            }),
+            'git@github.com:php-fast-forward/dev-tools.git',
+        )->willReturn('rendered changelog')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(self::FILE, 'rendered changelog')
+            ->shouldBeCalledOnce();
+
+        $this->manager->addEntry(self::FILE, ChangelogEntryType::Added, 'Add release automation', '1.2.0');
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function addEntryWillUpdateAnExistingReleaseDateWhenANewOneIsProvided(): void
+    {
+        $document = new ChangelogDocument([
+            new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION),
+            (new ChangelogRelease('1.2.0', '2026-04-01'))->withEntry(
+                ChangelogEntryType::Changed,
+                'Keep previous release note',
+            ),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+        $this->gitClient->getConfig('remote.origin.url', self::WORKING_DIRECTORY)
+            ->willReturn('')
+            ->shouldBeCalledOnce();
+        $this->renderer->render(
+            Argument::that(static function (ChangelogDocument $updated): bool {
+                $release = $updated->getRelease('1.2.0');
+
+                return $release instanceof ChangelogRelease
+                    && '2026-04-19' === $release->getDate()
+                    && [
+                        'Keep previous release note',
+                        'Refresh release links',
+                    ] === $release->getEntriesFor(ChangelogEntryType::Changed);
+            }),
+            null,
+        )->willReturn('rendered changelog')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(self::FILE, 'rendered changelog')
+            ->shouldBeCalledOnce();
+
+        $this->manager->addEntry(
+            self::FILE,
+            ChangelogEntryType::Changed,
+            'Refresh release links',
+            '1.2.0',
+            '2026-04-19',
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function promoteWillThrowWhenTheUnreleasedSectionIsEmpty(): void
+    {
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn(ChangelogDocument::create())
+            ->shouldBeCalledOnce();
+        $this->renderer->render(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->filesystem->dumpFile(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(self::FILE . ' does not contain unreleased entries to promote.');
+
+        $this->manager->promote(self::FILE, '1.2.0', '2026-04-19');
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function promoteWillPersistThePublishedReleaseWhenUnreleasedEntriesExist(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                ChangelogEntryType::Added,
+                'Prepare release automation',
+            ),
+            (new ChangelogRelease('1.1.0', '2026-04-01'))->withEntry(
+                ChangelogEntryType::Fixed,
+                'Keep previous release note',
+            ),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+        $this->gitClient->getConfig('remote.origin.url', self::WORKING_DIRECTORY)
+            ->willReturn('')
+            ->shouldBeCalledOnce();
+        $this->renderer->render(
+            Argument::that(static function (ChangelogDocument $updated): bool {
+                $release = $updated->getRelease('1.2.0');
+
+                return $release instanceof ChangelogRelease
+                    && '2026-04-19' === $release->getDate()
+                    && ['Prepare release automation'] === $release->getEntriesFor(ChangelogEntryType::Added)
+                    && ! $updated->getUnreleased()
+                        ->hasEntries();
+            }),
+            null,
+        )->willReturn('rendered changelog')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(self::FILE, 'rendered changelog')
+            ->shouldBeCalledOnce();
+
+        $this->manager->promote(self::FILE, '1.2.0', '2026-04-19');
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function inferNextVersionWillThrowWhenThereAreNoUnreleasedEntries(): void
+    {
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn(ChangelogDocument::create())
+            ->shouldBeCalledOnce();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(self::FILE . ' does not contain unreleased entries to infer a version from.');
+
+        $this->manager->inferNextVersion(self::FILE);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function inferNextVersionWillBumpMinorVersionsWhenAddedEntriesExist(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                ChangelogEntryType::Added,
+                'Add release command',
+            ),
+            new ChangelogRelease('1.4.2', '2026-04-01'),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+
+        self::assertSame('1.5.0', $this->manager->inferNextVersion(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function inferNextVersionWillBumpMajorVersionsWhenRemovedEntriesExist(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                ChangelogEntryType::Removed,
+                'Remove legacy command',
+            ),
+            new ChangelogRelease('1.4.2', '2026-04-01'),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+
+        self::assertSame('2.0.0', $this->manager->inferNextVersion(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function inferNextVersionWillBumpPatchVersionsWhenOnlyFixesExist(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                ChangelogEntryType::Fixed,
+                'Fix release note export',
+            ),
+            new ChangelogRelease('1.4.2', '2026-04-01'),
+        ]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+
+        self::assertSame('1.4.3', $this->manager->inferNextVersion(self::FILE));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderReleaseNotesWillReturnTheRendererOutputForTheRequestedRelease(): void
+    {
+        $release = (new ChangelogRelease('1.2.0', '2026-04-19'))->withEntry(
+            ChangelogEntryType::Added,
+            'Ship release notes',
+        );
+        $document = new ChangelogDocument([new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION), $release]);
+
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('existing changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('existing changelog')
+            ->willReturn($document)
+            ->shouldBeCalledOnce();
+        $this->renderer->renderReleaseBody($release)
+            ->willReturn("### Added\n\n- Ship release notes\n")
+            ->shouldBeCalledOnce();
+
+        self::assertSame(
+            "### Added\n\n- Ship release notes\n",
+            $this->manager->renderReleaseNotes(self::FILE, '1.2.0'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderReleaseNotesWillThrowWhenTheRequestedReleaseDoesNotExist(): void
+    {
+        $this->filesystem->exists(self::FILE)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->renderer->renderReleaseBody(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(self::FILE . ' does not contain a [1.2.0] section.');
+
+        $this->manager->renderReleaseNotes(self::FILE, '1.2.0');
+    }
+}

--- a/tests/Changelog/Parser/ChangelogParserTest.php
+++ b/tests/Changelog/Parser/ChangelogParserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Parser;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Parser\ChangelogParser;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChangelogParser::class)]
+#[UsesClass(ChangelogDocument::class)]
+#[UsesClass(ChangelogRelease::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class ChangelogParserTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillExtractReleaseSectionsAndEntries(): void
+    {
+        $document = (new ChangelogParser())->parse(<<<'MD'
+            # Changelog
+
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [Unreleased]
+
+            ### Added
+
+            - Add release preparation workflow
+
+            ### Fixed
+
+            - Correct changelog checks
+
+            ## [1.0.0] - 2026-04-01
+
+            ### Added
+
+            - Initial release
+            MD);
+
+        self::assertSame(ChangelogDocument::UNRELEASED_VERSION, $document->getUnreleased()->getVersion());
+        self::assertSame(['Add release preparation workflow'], $document->getUnreleased()->getEntries()['Added']);
+        self::assertSame('2026-04-01', $document->getRelease('1.0.0')?->getDate());
+    }
+}

--- a/tests/Changelog/Renderer/MarkdownRendererTest.php
+++ b/tests/Changelog/Renderer/MarkdownRendererTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Renderer;
+
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Document\ChangelogRelease;
+use FastForward\DevTools\Changelog\Renderer\MarkdownRenderer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MarkdownRenderer::class)]
+#[UsesClass(ChangelogDocument::class)]
+#[UsesClass(ChangelogRelease::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class MarkdownRendererTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillGenerateChangelogWithHeaderAndUnreleasedSection(): void
+    {
+        $output = (new MarkdownRenderer())->render(ChangelogDocument::create());
+
+        self::assertStringStartsWith('# Changelog', $output);
+        self::assertStringContainsString('## [' . ChangelogDocument::UNRELEASED_VERSION . ']', $output);
+        self::assertStringNotContainsString("## [Unreleased]\n\n\n", $output);
+        self::assertStringEndsWith("\n", $output);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillIncludePublishedSectionsAndReferences(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                ChangelogEntryType::Changed,
+                'Pending change'
+            ),
+            (new ChangelogRelease('1.1.0', '2026-04-02'))->withEntry(ChangelogEntryType::Changed, 'Feature B'),
+            (new ChangelogRelease('1.0.0', '2026-04-01'))->withEntry(ChangelogEntryType::Added, 'Feature A'),
+        ]);
+
+        $output = (new MarkdownRenderer())->render($document, 'git@github.com:php-fast-forward/dev-tools.git');
+
+        self::assertStringContainsString('## [1.1.0] - 2026-04-02', $output);
+        self::assertStringContainsString('### Added', $output);
+        self::assertStringContainsString('### Changed', $output);
+        self::assertStringContainsString(
+            '[unreleased]: https://github.com/php-fast-forward/dev-tools/compare/v1.1.0...HEAD',
+            $output,
+        );
+        self::assertStringContainsString(
+            '[1.1.0]: https://github.com/php-fast-forward/dev-tools/compare/v1.0.0...v1.1.0',
+            $output,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderReleaseBodyWillOmitTheReleaseHeading(): void
+    {
+        $release = (new ChangelogRelease('1.2.0', '2026-04-19'))
+            ->withEntry(ChangelogEntryType::Added, 'Ship changelog automation');
+
+        $output = (new MarkdownRenderer())->renderReleaseBody($release);
+
+        self::assertStringNotContainsString('## [1.2.0]', $output);
+        self::assertStringContainsString('### Added', $output);
+        self::assertStringContainsString('- Ship changelog automation', $output);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillOmitDanglingReleaseDateSeparatorsWhenDateIsMissing(): void
+    {
+        $document = new ChangelogDocument([
+            new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION),
+            (new ChangelogRelease('1.2.0'))->withEntry(ChangelogEntryType::Added, 'Ship changelog automation'),
+        ]);
+
+        $output = (new MarkdownRenderer())->render($document);
+
+        self::assertStringContainsString('## [1.2.0]', $output);
+        self::assertStringNotContainsString('## [1.2.0] - ', $output);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillNotInsertExtraBlankLinesBetweenRenderedSections(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease('1.2.0', '2026-04-19'))
+                ->withEntry(ChangelogEntryType::Added, 'Add changelog automation')
+                ->withEntry(ChangelogEntryType::Fixed, 'Preserve release sections'),
+        ]);
+
+        $output = (new MarkdownRenderer())->render($document);
+
+        self::assertStringContainsString("### Added\n\n- Add changelog automation\n\n### Fixed", $output);
+        self::assertStringNotContainsString("\n\n\n### Fixed", $output);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillKeepOnlyOneBlankLineBetweenAnEmptyUnreleasedSectionAndTheNextRelease(): void
+    {
+        $document = new ChangelogDocument([
+            new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION),
+            (new ChangelogRelease('1.2.0', '2026-04-19'))->withEntry(
+                ChangelogEntryType::Added,
+                'Ship changelog automation',
+            ),
+        ]);
+
+        $output = (new MarkdownRenderer())->render($document);
+
+        self::assertStringContainsString("## [Unreleased]\n\n## [1.2.0] - 2026-04-19", $output);
+        self::assertStringNotContainsString("## [Unreleased]\n\n\n## [1.2.0] - 2026-04-19", $output);
+    }
+}

--- a/tests/Console/Command/ChangelogCheckCommandTest.php
+++ b/tests/Console/Command/ChangelogCheckCommandTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Console\Command;
+
+use FastForward\DevTools\Changelog\Checker\UnreleasedEntryCheckerInterface;
+use FastForward\DevTools\Console\Command\ChangelogCheckCommand;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[CoversClass(ChangelogCheckCommand::class)]
+final class ChangelogCheckCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<UnreleasedEntryCheckerInterface>
+     */
+    private ObjectProphecy $checker;
+
+    /**
+     * @var ObjectProphecy<FilesystemInterface>
+     */
+    private ObjectProphecy $filesystem;
+
+    private ObjectProphecy $input;
+
+    private ObjectProphecy $output;
+
+    private ChangelogCheckCommand $command;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->checker = $this->prophesize(UnreleasedEntryCheckerInterface::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+        $this->input->getOption('against')
+            ->willReturn(null);
+        $this->input->getOption('file')
+            ->willReturn('CHANGELOG.md');
+        $this->filesystem->getAbsolutePath('CHANGELOG.md')
+            ->willReturn('/repo/CHANGELOG.md');
+        $this->command = new ChangelogCheckCommand($this->filesystem->reveal(), $this->checker->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessWhenUnreleasedEntriesExist(): void
+    {
+        $this->checker->hasPendingChanges('/repo/CHANGELOG.md', null)
+            ->willReturn(true);
+        $this->output->writeln(Argument::containingString('ready for review'))->shouldBeCalled();
+
+        self::assertSame(ChangelogCheckCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureWhenUnreleasedEntriesAreMissing(): void
+    {
+        $this->checker->hasPendingChanges('/repo/CHANGELOG.md', null)
+            ->willReturn(false);
+        $this->output->writeln(Argument::containingString('must add a meaningful entry'))->shouldBeCalled();
+
+        self::assertSame(ChangelogCheckCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return int
+     */
+    private function invokeExecute(): int
+    {
+        return (new ReflectionMethod($this->command, 'execute'))
+            ->invoke($this->command, $this->input->reveal(), $this->output->reveal());
+    }
+}

--- a/tests/Console/Command/ChangelogCommandTest.php
+++ b/tests/Console/Command/ChangelogCommandTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Console\Command;
+
+use DateTimeImmutable;
+use FastForward\DevTools\Changelog\Document\ChangelogDocument;
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use FastForward\DevTools\Changelog\Manager\ChangelogManagerInterface;
+use FastForward\DevTools\Console\Command\ChangelogEntryCommand;
+use FastForward\DevTools\Console\Command\ChangelogNextVersionCommand;
+use FastForward\DevTools\Console\Command\ChangelogPromoteCommand;
+use FastForward\DevTools\Console\Command\ChangelogShowCommand;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Clock\ClockInterface;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[CoversClass(ChangelogEntryCommand::class)]
+#[CoversClass(ChangelogPromoteCommand::class)]
+#[CoversClass(ChangelogNextVersionCommand::class)]
+#[CoversClass(ChangelogShowCommand::class)]
+#[UsesClass(ChangelogEntryType::class)]
+final class ChangelogCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<ChangelogManagerInterface>
+     */
+    private ObjectProphecy $manager;
+
+    /**
+     * @var ObjectProphecy<FilesystemInterface>
+     */
+    private ObjectProphecy $filesystem;
+
+    private ObjectProphecy $clock;
+
+    private ObjectProphecy $input;
+
+    private ObjectProphecy $output;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->manager = $this->prophesize(ChangelogManagerInterface::class);
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function entryCommandWillDelegateToTheManager(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('CHANGELOG.md');
+        $this->input->getOption('type')
+            ->willReturn('added');
+        $this->input->getOption('release')
+            ->willReturn(ChangelogDocument::UNRELEASED_VERSION);
+        $this->input->getOption('date')
+            ->willReturn(null);
+        $this->input->getArgument('message')
+            ->willReturn('Add a release workflow');
+        $this->filesystem->getAbsolutePath('CHANGELOG.md')
+            ->willReturn('/repo/CHANGELOG.md')
+            ->shouldBeCalledOnce();
+        $this->manager->addEntry(
+            '/repo/CHANGELOG.md',
+            ChangelogEntryType::Added,
+            'Add a release workflow',
+            ChangelogDocument::UNRELEASED_VERSION,
+            null,
+        )->shouldBeCalledOnce();
+
+        $command = new ChangelogEntryCommand($this->filesystem->reveal(), $this->manager->reveal());
+
+        self::assertSame(ChangelogEntryCommand::SUCCESS, $this->execute($command));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function promoteCommandWillUseTheProvidedOrCurrentDate(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('CHANGELOG.md');
+        $this->input->getOption('date')
+            ->willReturn(null);
+        $this->input->getArgument('version')
+            ->willReturn('1.2.0');
+        $this->clock->now()
+            ->willReturn(new DateTimeImmutable('2026-04-19T12:00:00+00:00'));
+        $this->filesystem->getAbsolutePath('CHANGELOG.md')
+            ->willReturn('/repo/CHANGELOG.md')
+            ->shouldBeCalledOnce();
+        $this->manager->promote('/repo/CHANGELOG.md', '1.2.0', '2026-04-19')
+            ->shouldBeCalledOnce();
+
+        $command = new ChangelogPromoteCommand(
+            $this->filesystem->reveal(),
+            $this->manager->reveal(),
+            $this->clock->reveal(),
+        );
+
+        self::assertSame(ChangelogPromoteCommand::SUCCESS, $this->execute($command));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function nextVersionCommandWillPrintTheInferredVersion(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('CHANGELOG.md');
+        $this->input->getOption('current-version')
+            ->willReturn(null);
+        $this->filesystem->getAbsolutePath('CHANGELOG.md')
+            ->willReturn('/repo/CHANGELOG.md')
+            ->shouldBeCalledOnce();
+        $this->manager->inferNextVersion('/repo/CHANGELOG.md', null)
+            ->willReturn('1.5.0')
+            ->shouldBeCalledOnce();
+        $this->output->writeln('1.5.0')
+            ->shouldBeCalledOnce();
+
+        $command = new ChangelogNextVersionCommand($this->filesystem->reveal(), $this->manager->reveal());
+
+        self::assertSame(ChangelogNextVersionCommand::SUCCESS, $this->execute($command));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function showCommandWillPrintTheRenderedReleaseNotes(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('CHANGELOG.md');
+        $this->input->getArgument('version')
+            ->willReturn('1.2.0');
+        $this->filesystem->getAbsolutePath('CHANGELOG.md')
+            ->willReturn('/repo/CHANGELOG.md')
+            ->shouldBeCalledOnce();
+        $this->manager->renderReleaseNotes('/repo/CHANGELOG.md', '1.2.0')
+            ->willReturn("### Added\n\n- Ship it\n")
+            ->shouldBeCalledOnce();
+        $this->output->write("### Added\n\n- Ship it\n")
+            ->shouldBeCalledOnce();
+
+        $command = new ChangelogShowCommand($this->filesystem->reveal(), $this->manager->reveal());
+
+        self::assertSame(ChangelogShowCommand::SUCCESS, $this->execute($command));
+    }
+
+    /**
+     * @param object $command
+     *
+     * @return int
+     */
+    private function execute(object $command): int
+    {
+        return (new ReflectionMethod($command, 'execute'))
+            ->invoke($command, $this->input->reveal(), $this->output->reveal());
+    }
+}

--- a/tests/Console/Command/FundingCommandTest.php
+++ b/tests/Console/Command/FundingCommandTest.php
@@ -70,6 +70,9 @@ final class FundingCommandTest extends TestCase
 
     private FundingCommand $command;
 
+    /**
+     * @return void
+     */
     protected function setUp(): void
     {
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
@@ -79,20 +82,32 @@ final class FundingCommandTest extends TestCase
         $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->normalizeProcess = $this->prophesize(Process::class);
-        $this->output->isDecorated()->willReturn(false);
+        $this->output->isDecorated()
+            ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())->willReturn(null);
-        $this->input->getOption('composer-file')->willReturn('composer.json');
-        $this->input->getOption('funding-file')->willReturn('.github/FUNDING.yml');
-        $this->input->getOption('dry-run')->willReturn(false);
-        $this->input->getOption('check')->willReturn(false);
-        $this->input->getOption('interactive')->willReturn(false);
-        $this->filesystem->dirname('.github/FUNDING.yml')->willReturn('.github');
-        $this->filesystem->dirname('composer.json')->willReturn('.');
-        $this->filesystem->basename('composer.json')->willReturn('composer.json');
+        $this->input->getOption('composer-file')
+            ->willReturn('composer.json');
+        $this->input->getOption('funding-file')
+            ->willReturn('.github/FUNDING.yml');
+        $this->input->getOption('dry-run')
+            ->willReturn(false);
+        $this->input->getOption('check')
+            ->willReturn(false);
+        $this->input->getOption('interactive')
+            ->willReturn(false);
+        $this->filesystem->dirname('.github/FUNDING.yml')
+            ->willReturn('.github');
+        $this->filesystem->dirname('composer.json')
+            ->willReturn('.');
+        $this->filesystem->basename('composer.json')
+            ->willReturn('composer.json');
         $this->processBuilder->withArgument(Argument::any())->willReturn($this->processBuilder->reveal());
-        $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn($this->processBuilder->reveal());
-        $this->processBuilder->build('composer normalize')->willReturn($this->normalizeProcess->reveal());
+        $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn(
+            $this->processBuilder->reveal()
+        );
+        $this->processBuilder->build('composer normalize')
+            ->willReturn($this->normalizeProcess->reveal());
 
         $this->command = new FundingCommand(
             $this->filesystem->reveal(),
@@ -105,16 +120,23 @@ final class FundingCommandTest extends TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function executeWillCreateComposerFundingFromFundingYaml(): void
     {
         $composerContents = '{"name":"example/package"}';
         $fundingYaml = "github: foo\ncustom: https://example.com/support\n";
 
-        $this->filesystem->exists('composer.json')->willReturn(true);
-        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
-        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
-        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
         $this->fileDiffer->diffContents(
             'generated funding metadata synchronization',
             'composer.json',
@@ -122,8 +144,14 @@ final class FundingCommandTest extends TestCase
                 $decoded = json_decode($contents, true);
 
                 return [
-                    ['type' => 'github', 'url' => 'https://github.com/sponsors/foo'],
-                    ['type' => 'custom', 'url' => 'https://example.com/support'],
+                    [
+                        'type' => 'github',
+                        'url' => 'https://github.com/sponsors/foo',
+                    ],
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.com/support',
+                    ],
                 ] === $decoded['funding'];
             }),
             $composerContents,
@@ -136,8 +164,10 @@ final class FundingCommandTest extends TestCase
             $fundingYaml,
             'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
-        $this->processQueue->add($this->normalizeProcess->reveal())->shouldBeCalledOnce();
-        $this->processQueue->run($this->output->reveal())->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
         $this->filesystem->dumpFile(
             'composer.json',
             Argument::that(static fn(string $contents): bool => str_contains($contents, '"funding"')),
@@ -146,16 +176,22 @@ final class FundingCommandTest extends TestCase
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function executeWillCreateFundingYamlFromComposerFunding(): void
     {
         $composerContents = <<<'JSON'
-{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
-JSON;
+            {"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
+            JSON;
 
-        $this->filesystem->exists('composer.json')->willReturn(true);
-        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
-        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(false);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(false);
         $this->fileDiffer->diffContents(
             'generated funding metadata synchronization',
             'composer.json',
@@ -175,24 +211,32 @@ JSON;
             null,
             'Managed file .github/FUNDING.yml will be created from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Funding changed'))->shouldBeCalledOnce();
-        $this->filesystem->mkdir('.github')->shouldBeCalledOnce();
+        $this->filesystem->mkdir('.github')
+            ->shouldBeCalledOnce();
         $this->filesystem->dumpFile('.github/FUNDING.yml', Argument::type('string'))->shouldBeCalledOnce();
 
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function executeWillMergeBothSourcesWithoutDuplicatingEntries(): void
     {
         $composerContents = <<<'JSON'
-{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"}]}
-JSON;
+            {"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"}]}
+            JSON;
         $fundingYaml = "custom: https://example.com/support\n";
 
-        $this->filesystem->exists('composer.json')->willReturn(true);
-        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
-        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
-        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
         $this->fileDiffer->diffContents(
             'generated funding metadata synchronization',
             'composer.json',
@@ -200,8 +244,14 @@ JSON;
                 $decoded = json_decode($contents, true);
 
                 return [
-                    ['type' => 'github', 'url' => 'https://github.com/sponsors/foo'],
-                    ['type' => 'custom', 'url' => 'https://example.com/support'],
+                    [
+                        'type' => 'github',
+                        'url' => 'https://github.com/sponsors/foo',
+                    ],
+                    [
+                        'type' => 'custom',
+                        'url' => 'https://example.com/support',
+                    ],
                 ] === $decoded['funding'];
             }),
             $composerContents,
@@ -219,27 +269,37 @@ JSON;
             $fundingYaml,
             'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
         )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Funding changed'))->shouldBeCalledOnce();
-        $this->processQueue->add($this->normalizeProcess->reveal())->shouldBeCalledOnce();
-        $this->processQueue->run($this->output->reveal())->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
         $this->filesystem->dumpFile('composer.json', Argument::type('string'))->shouldBeCalledOnce();
-        $this->filesystem->mkdir('.github')->shouldBeCalledOnce();
+        $this->filesystem->mkdir('.github')
+            ->shouldBeCalledOnce();
         $this->filesystem->dumpFile('.github/FUNDING.yml', Argument::type('string'))->shouldBeCalledOnce();
 
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function executeWillBeIdempotentWhenFundingMetadataAlreadyMatches(): void
     {
         $composerContents = <<<'JSON'
-{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
-JSON;
+            {"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"},{"type":"custom","url":"https://example.com/support"}]}
+            JSON;
         $fundingYaml = "github: foo\ncustom: https://example.com/support\n";
 
-        $this->filesystem->exists('composer.json')->willReturn(true);
-        $this->filesystem->readFile('composer.json')->willReturn($composerContents);
-        $this->filesystem->exists('.github/FUNDING.yml')->willReturn(true);
-        $this->filesystem->readFile('.github/FUNDING.yml')->willReturn($fundingYaml);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
         $this->fileDiffer->diffContents(
             'generated funding metadata synchronization',
             'composer.json',
@@ -260,6 +320,9 @@ JSON;
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function commandWillSetExpectedNameDescriptionAndHelp(): void
     {
@@ -274,6 +337,9 @@ JSON;
         );
     }
 
+    /**
+     * @return int
+     */
     private function executeCommand(): int
     {
         $reflectionMethod = new ReflectionMethod($this->command, 'execute');

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Tests\Console\Command;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\Command\WikiCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Git\GitClientInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,6 +49,8 @@ final class WikiCommandTest extends TestCase
 
     private ObjectProphecy $filesystem;
 
+    private ObjectProphecy $gitClient;
+
     private ObjectProphecy $input;
 
     private ObjectProphecy $output;
@@ -65,6 +68,7 @@ final class WikiCommandTest extends TestCase
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->composer = $this->prophesize(ComposerJsonInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->gitClient = $this->prophesize(GitClientInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->process = $this->prophesize(Process::class);
@@ -89,6 +93,7 @@ final class WikiCommandTest extends TestCase
             $this->processQueue->reveal(),
             $this->composer->reveal(),
             $this->filesystem->reveal(),
+            $this->gitClient->reveal(),
         );
     }
 

--- a/tests/Funding/ComposerFundingCodecTest.php
+++ b/tests/Funding/ComposerFundingCodecTest.php
@@ -32,30 +32,39 @@ use function Safe\json_decode;
 #[UsesClass(FundingProfile::class)]
 final class ComposerFundingCodecTest extends TestCase
 {
+    /**
+     * @return void
+     */
     #[Test]
     public function parseWillNormalizeSupportedAndUnsupportedFundingEntries(): void
     {
         $codec = new ComposerFundingCodec();
 
         $profile = $codec->parse(<<<'JSON'
-{
-  "name": "example/package",
-  "funding": [
-    {"type": "github", "url": "https://github.com/sponsors/foo"},
-    {"type": "custom", "url": "https://example.com/support"},
-    {"type": "patreon", "url": "https://patreon.com/example"}
-  ]
-}
-JSON);
+            {
+              "name": "example/package",
+              "funding": [
+                {"type": "github", "url": "https://github.com/sponsors/foo"},
+                {"type": "custom", "url": "https://example.com/support"},
+                {"type": "patreon", "url": "https://patreon.com/example"}
+              ]
+            }
+            JSON);
 
         self::assertSame(['foo'], $profile->getGithubSponsors());
         self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
         self::assertSame(
-            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            [[
+                'type' => 'patreon',
+                'url' => 'https://patreon.com/example',
+            ]],
             $profile->getUnsupportedComposerEntries(),
         );
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function dumpWillWriteSupportedFundingAndPreserveUnsupportedEntries(): void
     {
@@ -66,7 +75,10 @@ JSON);
             new FundingProfile(
                 ['bar'],
                 ['https://example.com/support'],
-                unsupportedComposerEntries: [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+                unsupportedComposerEntries: [[
+                    'type' => 'patreon',
+                    'url' => 'https://patreon.com/example',
+                ]],
             ),
         );
 
@@ -74,9 +86,18 @@ JSON);
 
         self::assertSame(
             [
-                ['type' => 'github', 'url' => 'https://github.com/sponsors/bar'],
-                ['type' => 'custom', 'url' => 'https://example.com/support'],
-                ['type' => 'patreon', 'url' => 'https://patreon.com/example'],
+                [
+                    'type' => 'github',
+                    'url' => 'https://github.com/sponsors/bar',
+                ],
+                [
+                    'type' => 'custom',
+                    'url' => 'https://example.com/support',
+                ],
+                [
+                    'type' => 'patreon',
+                    'url' => 'https://patreon.com/example',
+                ],
             ],
             $decoded['funding'],
         );

--- a/tests/Funding/FundingProfileMergerTest.php
+++ b/tests/Funding/FundingProfileMergerTest.php
@@ -30,6 +30,9 @@ use PHPUnit\Framework\TestCase;
 #[UsesClass(FundingProfile::class)]
 final class FundingProfileMergerTest extends TestCase
 {
+    /**
+     * @return void
+     */
     #[Test]
     public function mergeWillCombineSupportedFundingAndPreserveUnsupportedEntries(): void
     {
@@ -39,20 +42,30 @@ final class FundingProfileMergerTest extends TestCase
             new FundingProfile(
                 ['foo'],
                 ['https://example.com/a'],
-                unsupportedComposerEntries: [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+                unsupportedComposerEntries: [[
+                    'type' => 'patreon',
+                    'url' => 'https://patreon.com/example',
+                ]],
             ),
             new FundingProfile(
                 ['bar', 'foo'],
                 ['https://example.com/b'],
-                ['ko_fi' => 'example'],
+                [
+                    'ko_fi' => 'example',
+                ],
             ),
         );
 
         self::assertSame(['bar', 'foo'], $merged->getGithubSponsors());
         self::assertSame(['https://example.com/a', 'https://example.com/b'], $merged->getCustomUrls());
-        self::assertSame(['ko_fi' => 'example'], $merged->getUnsupportedYamlEntries());
+        self::assertSame([
+            'ko_fi' => 'example',
+        ], $merged->getUnsupportedYamlEntries());
         self::assertSame(
-            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            [[
+                'type' => 'patreon',
+                'url' => 'https://patreon.com/example',
+            ]],
             $merged->getUnsupportedComposerEntries(),
         );
     }

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -31,23 +31,31 @@ use Symfony\Component\Yaml\Yaml;
 #[UsesClass(FundingProfile::class)]
 final class FundingYamlCodecTest extends TestCase
 {
+    /**
+     * @return void
+     */
     #[Test]
     public function parseWillNormalizeSupportedAndUnsupportedYamlEntries(): void
     {
         $codec = new FundingYamlCodec();
 
         $profile = $codec->parse(<<<'YAML'
-github:
-  - foo
-custom: https://example.com/support
-patreon: example
-YAML);
+            github:
+              - foo
+            custom: https://example.com/support
+            patreon: example
+            YAML);
 
         self::assertSame(['foo'], $profile->getGithubSponsors());
         self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
-        self::assertSame(['patreon' => 'example'], $profile->getUnsupportedYamlEntries());
+        self::assertSame([
+            'patreon' => 'example',
+        ], $profile->getUnsupportedYamlEntries());
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function dumpWillRenderScalarAndListFundingKeys(): void
     {
@@ -56,7 +64,9 @@ YAML);
         $contents = $codec->dump(new FundingProfile(
             ['foo'],
             ['https://example.com/support', 'https://example.com/other'],
-            ['patreon' => 'example'],
+            [
+                'patreon' => 'example',
+            ],
         ));
 
         self::assertSame(
@@ -69,15 +79,15 @@ YAML);
         );
     }
 
+    /**
+     * @return void
+     */
     #[Test]
     public function dumpWillRenderSingleCustomUrlAsList(): void
     {
         $codec = new FundingYamlCodec();
 
-        $contents = $codec->dump(new FundingProfile(
-            ['foo'],
-            ['https://example.com/support'],
-        ));
+        $contents = $codec->dump(new FundingProfile(['foo'], ['https://example.com/support']));
 
         self::assertSame(
             [

--- a/tests/Git/GitClientTest.php
+++ b/tests/Git/GitClientTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Git;
+
+use FastForward\DevTools\Git\GitClient;
+use FastForward\DevTools\Process\ProcessBuilderInterface;
+use FastForward\DevTools\Process\ProcessQueueInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+#[CoversClass(GitClient::class)]
+final class GitClientTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<ProcessBuilderInterface>
+     */
+    private ObjectProphecy $processBuilder;
+
+    /**
+     * @var ObjectProphecy<ProcessQueueInterface>
+     */
+    private ObjectProphecy $processQueue;
+
+    /**
+     * @var ObjectProphecy<Process>
+     */
+    private ObjectProphecy $process;
+
+    private GitClient $client;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
+        $this->process = $this->prophesize(Process::class);
+        $this->client = new GitClient($this->processBuilder->reveal(), $this->processQueue->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getConfigWillBuildAndRunTheExpectedGitCommand(): void
+    {
+        $this->processBuilder->withArgument('config')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--get')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('remote.origin.url')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('git')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->process->setWorkingDirectory('/repo')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run()
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+        $this->process->getOutput()
+            ->willReturn(" git@github.com:php-fast-forward/dev-tools.git \n")
+            ->shouldBeCalledOnce();
+
+        self::assertSame(
+            'git@github.com:php-fast-forward/dev-tools.git',
+            $this->client->getConfig('remote.origin.url', '/repo'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function showWillRelativizeAbsolutePathsWithinTheRepository(): void
+    {
+        $this->processBuilder->withArgument('show')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('origin/main:docs/CHANGELOG.md')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('git')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->process->setWorkingDirectory('/repo')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run()
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+        $this->process->getOutput()
+            ->willReturn("baseline contents\n")
+            ->shouldBeCalledOnce();
+
+        self::assertSame(
+            'baseline contents',
+            $this->client->show('origin/main', '/repo/docs/CHANGELOG.md', '/repo'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function showWillKeepPathsThatDoNotBelongToTheRepositoryUnchanged(): void
+    {
+        $this->processBuilder->withArgument('show')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('origin/main:/external/CHANGELOG.md')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('git')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->process->setWorkingDirectory('/repo')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run()
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+        $this->process->getOutput()
+            ->willReturn("baseline contents\n")
+            ->shouldBeCalledOnce();
+
+        self::assertSame(
+            'baseline contents',
+            $this->client->show('origin/main', '/external/CHANGELOG.md', '/repo'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getConfigWillThrowTheTrimmedErrorOutputWhenTheQueueFails(): void
+    {
+        $this->processBuilder->withArgument('config')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--get')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('remote.origin.url')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('git')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->process->setWorkingDirectory('/repo')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run()
+            ->willReturn(ProcessQueueInterface::FAILURE)
+            ->shouldBeCalledOnce();
+        $this->process->getErrorOutput()
+            ->willReturn(" git failed \n")
+            ->shouldBeCalledOnce();
+        $this->process->getOutput()
+            ->shouldNotBeCalled();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('git failed');
+
+        $this->client->getConfig('remote.origin.url', '/repo');
+    }
+}


### PR DESCRIPTION
## Summary

Implements the changelog management surface for #28 with local Keep a Changelog automation, supporting commands, workflow automation, skills, tests, documentation, and the repository changelog backfill.

## Included

- add local changelog domain classes, parser, renderer, manager, and git client integration
- add changelog commands for entry authoring, validation, version inference, promotion, and release note rendering
- add reusable changelog GitHub Actions workflow plus packaged consumer stub
- add changelog skill and changelog-maintainer agent guidance
- backfill the repository `CHANGELOG.md` from published tags and normalize existing GitHub release notes to match it
- document repository permissions required for changelog release automation, including the blocked/grayed-out settings case
- update README and Sphinx docs for changelog commands and release workflow
- add focused PHPUnit coverage for Git and Changelog behavior

## Validation

- `./vendor/bin/phpunit tests/Git/GitClientTest.php tests/Changelog/Document/ChangelogDocumentTest.php tests/Changelog/Manager/ChangelogManagerTest.php tests/Changelog/Checker/UnreleasedEntryCheckerTest.php tests/Changelog/Renderer/MarkdownRendererTest.php tests/Changelog/Parser/ChangelogParserTest.php tests/Console/Command/ChangelogCheckCommandTest.php tests/Console/Command/ChangelogCommandTest.php tests/Funding/ComposerFundingCodecTest.php tests/Funding/FundingProfileMergerTest.php tests/Funding/FundingYamlCodecTest.php tests/Console/Command/WikiCommandTest.php`
- YAML parse for `.github/workflows/changelog.yml`, `.github/workflows/tests.yml`, `.github/workflows/reports.yml`, and `.github/workflows/wiki.yml`
- exercised the changelog CLI flow manually in temporary and repository contexts:
  - `php bin/dev-tools changelog:check`
  - `php bin/dev-tools changelog:next-version`
  - `php bin/dev-tools changelog:show 1.11.0`
- used `composer dev-tools changelog:show -- <version>` to update the notes body of existing GitHub releases

## Notes

- the release workflow is intentionally two-step: `workflow_dispatch` prepares a `release/v...` pull request, and merging that release pull request publishes the GitHub release and tag
- consumer repositories must enable GitHub Actions **Read and write permissions** and **Allow GitHub Actions to create and approve pull requests**
- if those controls appear disabled or grayed out, an organization or repository admin must unlock them before release-preparation PR creation can work

Closes #28