### PR TITLE
[tests] Start closing coverage gaps (#133)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,10 @@
     "autoload-dev": {
         "psr-4": {
             "FastForward\\DevTools\\Tests\\": "tests/"
-        }
+        },
+        "classmap": [
+            "tests/Fixtures/"
+        ]
     },
     "bin": "bin/dev-tools",
     "config": {

--- a/tests/Changelog/Document/ChangelogDocumentTest.php
+++ b/tests/Changelog/Document/ChangelogDocumentTest.php
@@ -83,4 +83,100 @@ final class ChangelogDocumentTest extends TestCase
         self::assertSame(['Preserve release sections'], $release->getEntriesFor(ChangelogEntryType::Fixed));
         self::assertFalse($promoted->getUnreleased()->hasEntries());
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function documentAccessorsWillResolveExpectedReleaseVariants(): void
+    {
+        $document = new ChangelogDocument([
+            new ChangelogRelease('1.2.0', '2026-04-19'),
+        ]);
+
+        self::assertSame(ChangelogDocument::UNRELEASED_VERSION, $document->getUnreleased()->getVersion());
+        self::assertNull($document->getRelease('9.9.9'));
+        self::assertSame('1.2.0', $document->getLatestPublishedRelease()?->getVersion());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getLatestPublishedReleaseWillReturnNullWhenOnlyUnreleasedExists(): void
+    {
+        self::assertNull(ChangelogDocument::create()->getLatestPublishedRelease());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function withReleaseWillReplaceExistingVersionAndInsertUnreleasedAtTheTop(): void
+    {
+        $existing = new ChangelogRelease('1.2.0', '2026-04-01');
+        $replacement = (new ChangelogRelease('1.2.0', '2026-04-19'))
+            ->withEntry(ChangelogEntryType::Added, 'Updated note');
+        $document = (new ChangelogDocument([$existing]))
+            ->withRelease(new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))
+            ->withRelease($replacement);
+
+        self::assertSame(
+            [ChangelogDocument::UNRELEASED_VERSION, '1.2.0'],
+            array_map(
+                static fn(ChangelogRelease $release): string => $release->getVersion(),
+                $document->getReleases(),
+            ),
+        );
+        self::assertSame(['Updated note'], $document->getRelease('1.2.0')?->getEntriesFor(ChangelogEntryType::Added));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function promoteUnreleasedWillCreatePublishedReleaseWhenDocumentIsEmpty(): void
+    {
+        $document = new ChangelogDocument([]);
+
+        $promoted = $document->promoteUnreleased('1.0.0', '2026-04-20');
+
+        self::assertSame(
+            [ChangelogDocument::UNRELEASED_VERSION, '1.0.0'],
+            array_map(
+                static fn(ChangelogRelease $release): string => $release->getVersion(),
+                $promoted->getReleases(),
+            ),
+        );
+        self::assertSame('2026-04-20', $promoted->getRelease('1.0.0')?->getDate());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function releaseHelpersWillNormalizeEntriesAndSupportImmutableMutators(): void
+    {
+        $release = new ChangelogRelease('1.3.0', null, [
+            ChangelogEntryType::Added->value => ['Ship feature', 'Ship feature'],
+        ]);
+
+        self::assertSame('1.3.0', $release->getVersion());
+        self::assertNull($release->getDate());
+        self::assertFalse($release->isUnreleased());
+        self::assertTrue($release->hasEntries());
+        self::assertSame(['Ship feature'], $release->getEntriesFor(ChangelogEntryType::Added));
+
+        $sameRelease = $release->withEntry(ChangelogEntryType::Fixed, '   ');
+        self::assertSame($release, $sameRelease);
+
+        $updated = $release
+            ->withEntry(ChangelogEntryType::Fixed, 'Repair behavior')
+            ->withEntries([ChangelogEntryType::Security->value => ['Security hardening']])
+            ->withDate('2026-04-20');
+
+        self::assertSame('2026-04-20', $updated->getDate());
+        self::assertSame(['Security hardening'], $updated->getEntriesFor(ChangelogEntryType::Security));
+        self::assertSame([], $updated->getEntriesFor(ChangelogEntryType::Added));
+    }
 }

--- a/tests/Changelog/Document/ChangelogDocumentTest.php
+++ b/tests/Changelog/Document/ChangelogDocumentTest.php
@@ -90,9 +90,7 @@ final class ChangelogDocumentTest extends TestCase
     #[Test]
     public function documentAccessorsWillResolveExpectedReleaseVariants(): void
     {
-        $document = new ChangelogDocument([
-            new ChangelogRelease('1.2.0', '2026-04-19'),
-        ]);
+        $document = new ChangelogDocument([new ChangelogRelease('1.2.0', '2026-04-19')]);
 
         self::assertSame(ChangelogDocument::UNRELEASED_VERSION, $document->getUnreleased()->getVersion());
         self::assertNull($document->getRelease('9.9.9'));
@@ -172,7 +170,9 @@ final class ChangelogDocumentTest extends TestCase
 
         $updated = $release
             ->withEntry(ChangelogEntryType::Fixed, 'Repair behavior')
-            ->withEntries([ChangelogEntryType::Security->value => ['Security hardening']])
+            ->withEntries([
+                ChangelogEntryType::Security->value => ['Security hardening'],
+            ])
             ->withDate('2026-04-20');
 
         self::assertSame('2026-04-20', $updated->getDate());

--- a/tests/Changelog/Entry/ChangelogEntryTypeTest.php
+++ b/tests/Changelog/Entry/ChangelogEntryTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Changelog\Entry;
+
+use FastForward\DevTools\Changelog\Entry\ChangelogEntryType;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChangelogEntryType::class)]
+final class ChangelogEntryTypeTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function orderedWillReturnKeepAChangelogSectionOrder(): void
+    {
+        self::assertSame(
+            [
+                ChangelogEntryType::Added,
+                ChangelogEntryType::Changed,
+                ChangelogEntryType::Deprecated,
+                ChangelogEntryType::Removed,
+                ChangelogEntryType::Fixed,
+                ChangelogEntryType::Security,
+            ],
+            ChangelogEntryType::ordered(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function fromInputWillNormalizeSupportedValues(): void
+    {
+        self::assertSame(ChangelogEntryType::Fixed, ChangelogEntryType::fromInput(' fixed '));
+        self::assertSame(ChangelogEntryType::Security, ChangelogEntryType::fromInput('security'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function fromInputWillRejectUnsupportedValues(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported changelog type "unknown".');
+
+        ChangelogEntryType::fromInput('unknown');
+    }
+}

--- a/tests/Changelog/Parser/ChangelogParserTest.php
+++ b/tests/Changelog/Parser/ChangelogParserTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 #[CoversClass(ChangelogParser::class)]
 #[UsesClass(ChangelogDocument::class)]
@@ -145,5 +146,20 @@ final class ChangelogParserTest extends TestCase
 
         self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Added));
         self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Fixed));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function extractEntriesWillReturnEmptyArrayWhenCategoryHeadingIsMissing(): void
+    {
+        $parser = new ChangelogParser();
+        $reflectionMethod = new ReflectionMethod($parser, 'extractEntries');
+
+        self::assertSame(
+            [],
+            $reflectionMethod->invoke($parser, "### Fixed\n\n- Repair release notes", ChangelogEntryType::Added),
+        );
     }
 }

--- a/tests/Changelog/Parser/ChangelogParserTest.php
+++ b/tests/Changelog/Parser/ChangelogParserTest.php
@@ -69,4 +69,60 @@ final class ChangelogParserTest extends TestCase
         self::assertSame(['Add release preparation workflow'], $document->getUnreleased()->getEntries()['Added']);
         self::assertSame('2026-04-01', $document->getRelease('1.0.0')?->getDate());
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillReturnDefaultDocumentForEmptyContents(): void
+    {
+        $document = (new ChangelogParser())->parse("   \n\n");
+
+        self::assertSame([ChangelogDocument::UNRELEASED_VERSION], array_map(
+            static fn(ChangelogRelease $release): string => $release->getVersion(),
+            $document->getReleases(),
+        ));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillReturnDefaultDocumentWhenNoReleaseHeadingsExist(): void
+    {
+        $document = (new ChangelogParser())->parse("# Changelog\n\nThis file has no release headings yet.\n");
+
+        self::assertSame(ChangelogDocument::UNRELEASED_VERSION, $document->getUnreleased()->getVersion());
+        self::assertFalse($document->getUnreleased()->hasEntries());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillIgnoreUnsupportedLinesAndDeduplicateEntriesWithinASection(): void
+    {
+        $document = (new ChangelogParser())->parse(<<<'MD'
+            ## [Unreleased]
+
+            ### Added
+
+            Intro line that should be ignored
+            - Add sync command
+            - Add sync command
+            *
+
+            ### Fixed
+
+            - Repair coverage report
+            -
+            MD);
+
+        self::assertSame(['Add sync command'], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Added));
+        self::assertSame(
+            ['Repair coverage report'],
+            $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Fixed)
+        );
+        self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Security));
+    }
 }

--- a/tests/Changelog/Parser/ChangelogParserTest.php
+++ b/tests/Changelog/Parser/ChangelogParserTest.php
@@ -121,8 +121,29 @@ final class ChangelogParserTest extends TestCase
         self::assertSame(['Add sync command'], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Added));
         self::assertSame(
             ['Repair coverage report'],
-            $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Fixed)
+            $document->getUnreleased()
+                ->getEntriesFor(ChangelogEntryType::Fixed)
         );
         self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Security));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillTreatEmptyCategoryBodiesAsEmptyEntryLists(): void
+    {
+        $document = (new ChangelogParser())->parse(<<<'MD'
+            ## [Unreleased]
+
+            ### Added
+
+            ### Fixed
+
+            Not a bullet entry
+            MD);
+
+        self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Added));
+        self::assertSame([], $document->getUnreleased()->getEntriesFor(ChangelogEntryType::Fixed));
     }
 }

--- a/tests/Changelog/Renderer/MarkdownRendererTest.php
+++ b/tests/Changelog/Renderer/MarkdownRendererTest.php
@@ -148,4 +148,68 @@ final class MarkdownRendererTest extends TestCase
         self::assertStringContainsString("## [Unreleased]\n\n## [1.2.0] - 2026-04-19", $output);
         self::assertStringNotContainsString("## [Unreleased]\n\n\n## [1.2.0] - 2026-04-19", $output);
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillOmitReferencesWhenRepositoryUrlIsMissingOrBlank(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease('1.2.0', '2026-04-19'))->withEntry(
+                ChangelogEntryType::Added,
+                'Ship changelog automation',
+            ),
+        ]);
+
+        $renderer = new MarkdownRenderer();
+
+        self::assertStringNotContainsString('[1.2.0]:', $renderer->render($document));
+        self::assertStringNotContainsString('[1.2.0]:', $renderer->render($document, '   '));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillNormalizeSshRepositoryUrlsAndTrimTrailingGitSuffix(): void
+    {
+        $document = new ChangelogDocument([
+            (new ChangelogRelease('1.2.0', '2026-04-19'))->withEntry(
+                ChangelogEntryType::Added,
+                'Ship changelog automation',
+            ),
+        ]);
+
+        $output = (new MarkdownRenderer())->render($document, 'ssh://git@github.com/php-fast-forward/dev-tools.git');
+
+        self::assertStringContainsString(
+            '[unreleased]: https://github.com/php-fast-forward/dev-tools/compare/v1.2.0...HEAD',
+            $output,
+        );
+        self::assertStringContainsString(
+            '[1.2.0]: https://github.com/php-fast-forward/dev-tools/releases/tag/v1.2.0',
+            $output,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function renderWillOmitReferencesWhenOnlyUnreleasedSectionExists(): void
+    {
+        $output = (new MarkdownRenderer())->render(
+            new ChangelogDocument([
+                (new ChangelogRelease(ChangelogDocument::UNRELEASED_VERSION))->withEntry(
+                    ChangelogEntryType::Added,
+                    'Pending change',
+                ),
+            ]),
+            'https://github.com/php-fast-forward/dev-tools'
+        );
+
+        self::assertStringNotContainsString('[unreleased]:', $output);
+        self::assertStringNotContainsString('releases/tag', $output);
+    }
 }

--- a/tests/CodeOwners/CodeOwnersGeneratorTest.php
+++ b/tests/CodeOwners/CodeOwnersGeneratorTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionMethod;
 use Symfony\Component\Config\FileLocatorInterface;
 
 #[CoversClass(CodeOwnersGenerator::class)]
@@ -208,5 +209,32 @@ final class CodeOwnersGeneratorTest extends TestCase
             ['@php-fast-forward', 'security@example.com'],
             $this->generator->normalizeOwners('  php-fast-forward,, @php-fast-forward security@example.com  '),
         );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function extractGitHubHelpersWillHandleSupportedAndUnsupportedUrls(): void
+    {
+        $handleMethod = new ReflectionMethod($this->generator, 'extractGitHubHandleFromUrl');
+        $ownerMethod = new ReflectionMethod($this->generator, 'extractGitHubRepositoryOwner');
+        $pathMethod = new ReflectionMethod($this->generator, 'githubPath');
+
+        self::assertSame(
+            'mentordosnerds',
+            $handleMethod->invoke($this->generator, 'https://github.com/mentordosnerds/')
+        );
+        self::assertNull($handleMethod->invoke($this->generator, 'https://github.com/mentordosnerds/dev-tools'));
+        self::assertSame(
+            'php-fast-forward',
+            $ownerMethod->invoke($this->generator, 'https://github.com/php-fast-forward/dev-tools/')
+        );
+        self::assertNull($ownerMethod->invoke($this->generator, 'https://github.com/php-fast-forward'));
+        self::assertSame(
+            '//php-fast-forward///dev-tools/',
+            $pathMethod->invoke($this->generator, 'https://github.com//php-fast-forward///dev-tools/')
+        );
+        self::assertNull($pathMethod->invoke($this->generator, 'https://example.com/php-fast-forward/dev-tools'));
     }
 }

--- a/tests/CodeOwners/CodeOwnersGeneratorTest.php
+++ b/tests/CodeOwners/CodeOwnersGeneratorTest.php
@@ -117,6 +117,36 @@ final class CodeOwnersGeneratorTest extends TestCase
      * @return void
      */
     #[Test]
+    public function inferOwnersWillIgnoreUnsupportedAuthorEntriesAndInvalidUrls(): void
+    {
+        $this->composerJson->getSupport()
+            ->willReturn(new Support(source: 'https://github.com/php-fast-forward/dev-tools'));
+        $this->composerJson->getAuthors()
+            ->willReturn([
+                'not-an-author',
+                new Author(homepage: 'https://github.com/mentordosnerds/dev-tools'),
+                new Author(homepage: 'https://github.com'),
+            ]);
+
+        self::assertSame(['@php-fast-forward'], $this->generator->inferOwners());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function inferGroupOwnerWillReturnNullWhenSupportSourceIsMissingOrInvalid(): void
+    {
+        $this->composerJson->getSupport()
+            ->willReturn(new Support(source: 'https://example.com/php-fast-forward/dev-tools'));
+
+        self::assertNull($this->generator->inferGroupOwner());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function generateWillRenderExplicitOwners(): void
     {
         self::assertSame(
@@ -165,6 +195,18 @@ final class CodeOwnersGeneratorTest extends TestCase
         self::assertSame(
             ['@php-fast-forward', '@mentordosnerds', 'security@example.com'],
             $this->generator->normalizeOwners('php-fast-forward, @mentordosnerds security@example.com'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function normalizeOwnersWillDropEmptyTokensAndDeduplicateRepeatedOwners(): void
+    {
+        self::assertSame(
+            ['@php-fast-forward', 'security@example.com'],
+            $this->generator->normalizeOwners('  php-fast-forward,, @php-fast-forward security@example.com  '),
         );
     }
 }

--- a/tests/Composer/Json/ComposerJsonTest.php
+++ b/tests/Composer/Json/ComposerJsonTest.php
@@ -596,6 +596,63 @@ final class ComposerJsonTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    #[Test]
+    public function getMinimumStabilityAndConfigWillReturnNormalizedValues(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'minimum-stability' => 'dev',
+            'config' => [
+                'sort-packages' => true,
+                'preferred-install' => [
+                    '*' => 'dist',
+                ],
+            ],
+        ]);
+
+        self::assertSame('dev', $composerJson->getMinimumStability());
+        self::assertSame([
+            'sort-packages' => true,
+            'preferred-install' => [
+                '*' => 'dist',
+            ],
+        ], $composerJson->getConfig(null));
+        self::assertSame('1', $composerJson->getConfig('sort-packages'));
+        self::assertSame([
+            '*' => 'dist',
+        ], $composerJson->getConfig('preferred-install'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getMinimumStabilityAndConfigWillReturnDefaultsForInvalidSections(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'config' => 'invalid',
+        ]);
+
+        self::assertSame('stable', $composerJson->getMinimumStability());
+        self::assertSame([], $composerJson->getConfig(null));
+        self::assertSame('', $composerJson->getConfig('preferred-install'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getBinWillReturnScalarStringWhenDeclaredAsSingleBinary(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'bin' => 'bin/dev-tools',
+        ]);
+
+        self::assertSame('bin/dev-tools', $composerJson->getBin());
+    }
+
+    /**
      * @param array<string, mixed> $contents
      *
      * @return ComposerJson

--- a/tests/Composer/Json/ComposerJsonTest.php
+++ b/tests/Composer/Json/ComposerJsonTest.php
@@ -117,6 +117,22 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function metadataAccessorsWillReturnDefaultsWhenOptionalFieldsAreMissing(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'name' => 'fast-forward/dev-tools',
+        ]);
+
+        self::assertSame([], $composerJson->getKeywords());
+        self::assertSame('', $composerJson->getHomepage());
+        self::assertSame('', $composerJson->getReadme());
+        self::assertNull($composerJson->getTime());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getLicenseWillReturnResolvedValue(): void
     {
         $composerJson = $this->createComposerJson([
@@ -201,6 +217,20 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function getSupportWillReturnEmptySupportObjectWhenSectionIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'support' => 'invalid',
+        ]);
+
+        self::assertSame('', $composerJson->getSupport()->getIssues());
+        self::assertSame('', $composerJson->getSupport()->getSource());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getFundingWillReturnFundingEntries(): void
     {
         $composerJson = $this->createComposerJson([
@@ -217,6 +247,38 @@ final class ComposerJsonTest extends TestCase
         self::assertCount(1, $funding);
         self::assertInstanceOf(Funding::class, $funding[0]);
         self::assertSame('github', $funding[0]->getType());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getFundingWillIgnoreInvalidEntriesAndInvalidSectionTypes(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'funding' => [
+                'invalid',
+                [
+                    'type' => 'custom',
+                    'url' => 'https://example.com/support',
+                ],
+                [
+                    'type' => 'github',
+                ],
+            ],
+        ]);
+
+        $funding = $composerJson->getFunding();
+        self::assertCount(2, $funding);
+        self::assertSame('custom', $funding[0]->getType());
+        self::assertSame('https://example.com/support', $funding[0]->getUrl());
+        self::assertSame('github', $funding[1]->getType());
+        self::assertSame('', $funding[1]->getUrl());
+
+        $composerJson = $this->createComposerJson([
+            'funding' => 'invalid',
+        ]);
+        self::assertSame([], $composerJson->getFunding());
     }
 
     /**
@@ -250,6 +312,25 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function getAutoloadWillReturnEmptyArrayWhenSectionOrRequestedMappingIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'autoload' => 'invalid',
+        ]);
+        self::assertSame([], $composerJson->getAutoload());
+
+        $composerJson = $this->createComposerJson([
+            'autoload' => [
+                'files' => 'src/functions.php',
+            ],
+        ]);
+        self::assertSame([], $composerJson->getAutoload('files'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getAutoloadDevWillReturnConfiguredMappings(): void
     {
         $composerJson = $this->createComposerJson([
@@ -268,6 +349,25 @@ final class ComposerJsonTest extends TestCase
         self::assertSame([
             'Foo\\Tests\\' => 'tests/',
         ], $composerJson->getAutoloadDev('psr-4'));
+        self::assertSame([], $composerJson->getAutoloadDev('files'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getAutoloadDevWillReturnEmptyArrayWhenSectionOrRequestedMappingIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'autoload-dev' => 'invalid',
+        ]);
+        self::assertSame([], $composerJson->getAutoloadDev());
+
+        $composerJson = $this->createComposerJson([
+            'autoload-dev' => [
+                'files' => 'tests/bootstrap.php',
+            ],
+        ]);
         self::assertSame([], $composerJson->getAutoloadDev('files'));
     }
 
@@ -339,6 +439,19 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function getScriptsWillReturnEmptyArrayWhenSectionIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'scripts' => 'phpunit',
+        ]);
+
+        self::assertSame([], $composerJson->getScripts());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getExtraWillReturnExtraSectionOrSpecificKey(): void
     {
         $composerJson = $this->createComposerJson([
@@ -364,6 +477,25 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function getExtraWillReturnEmptyArrayWhenSectionOrRequestedValueIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'extra' => 'invalid',
+        ]);
+        self::assertSame([], $composerJson->getExtra());
+
+        $composerJson = $this->createComposerJson([
+            'extra' => [
+                'foo' => 'bar',
+            ],
+        ]);
+        self::assertSame([], $composerJson->getExtra('foo'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getBinWillReturnConfiguredBinaries(): void
     {
         $composerJson = $this->createComposerJson([
@@ -375,6 +507,23 @@ final class ComposerJsonTest extends TestCase
             'bin' => ['bin/tool1', 'bin/tool2'],
         ]);
         self::assertSame(['bin/tool1', 'bin/tool2'], $composerJson->getBin());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getBinWillFilterInvalidEntriesAndReturnEmptyArrayForInvalidSections(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'bin' => ['bin/tool1', 42, 'bin/tool2'],
+        ]);
+        self::assertSame(['bin/tool1', 'bin/tool2'], $composerJson->getBin());
+
+        $composerJson = $this->createComposerJson([
+            'bin' => 42,
+        ]);
+        self::assertSame([], $composerJson->getBin());
     }
 
     /**
@@ -398,6 +547,28 @@ final class ComposerJsonTest extends TestCase
      * @return void
      */
     #[Test]
+    public function getSuggestWillIgnoreInvalidEntriesAndInvalidSections(): void
+    {
+        $composerJson = $this->createComposerJson([
+            'suggest' => [
+                'foo/bar' => 'For extra features',
+                'foo/baz' => ['invalid'],
+            ],
+        ]);
+        self::assertSame([
+            'foo/bar' => 'For extra features',
+        ], $composerJson->getSuggest());
+
+        $composerJson = $this->createComposerJson([
+            'suggest' => 'invalid',
+        ]);
+        self::assertSame([], $composerJson->getSuggest());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function getCommentsWillReturnCommentData(): void
     {
         $composerJson = $this->createComposerJson([
@@ -409,6 +580,19 @@ final class ComposerJsonTest extends TestCase
             '_comment' => ['Comment 1', 'Comment 2'],
         ]);
         self::assertSame(['Comment 1', 'Comment 2'], $composerJson->getComments());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getCommentsWillReturnEmptyArrayWhenSectionIsInvalid(): void
+    {
+        $composerJson = $this->createComposerJson([
+            '_comment' => 42,
+        ]);
+
+        self::assertSame([], $composerJson->getComments());
     }
 
     /**

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -19,14 +19,39 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Config;
 
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use FastForward\DevTools\Rector\AddMissingMethodPhpDocRector;
+use ReflectionProperty;
 use FastForward\DevTools\Config\RectorConfig;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\Config\RectorConfig as RectorConfigInterface;
+
+use function Safe\getcwd;
 
 #[CoversClass(RectorConfig::class)]
 final class RectorConfigTest extends TestCase
 {
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        self::resetSimpleParameterProvider();
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        self::resetSimpleParameterProvider();
+    }
+
     /**
      * @return void
      */
@@ -45,11 +70,66 @@ final class RectorConfigTest extends TestCase
     public function configureWithCustomCallbackWillReturnCallable(): void
     {
         $customCallback = static function ($config): void {
-            \assert($config instanceof \Rector\Config\RectorConfig);
+            \assert($config instanceof RectorConfigInterface);
         };
 
         $result = RectorConfig::configure($customCallback);
 
         self::assertIsCallable($result);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configureWillApplyTheDefaultRectorConfigurationAndCustomizationCallback(): void
+    {
+        $customizeWasCalled = false;
+        $callback = RectorConfig::configure(static function (RectorConfigInterface $rectorConfig) use (
+            &$customizeWasCalled
+        ): void {
+            $customizeWasCalled = true;
+            $rectorConfig->parallel(42);
+        });
+
+        $callback(new RectorConfigInterface());
+
+        self::assertTrue($customizeWasCalled);
+        self::assertSame([getcwd()], SimpleParameterProvider::provideArrayParameter(Option::PATHS));
+        self::assertSame(
+            [
+                getcwd() . '/.dev-tools',
+                getcwd() . '/resources',
+                getcwd() . '/vendor',
+                getcwd() . '/tmp',
+                RemoveUselessReturnTagRector::class,
+                RemoveUselessParamTagRector::class,
+            ],
+            SimpleParameterProvider::provideArrayParameter(Option::SKIP),
+        );
+        self::assertSame(
+            getcwd() . '/tmp/cache/rector',
+            SimpleParameterProvider::provideStringParameter(Option::CACHE_DIR)
+        );
+        self::assertSame(['php'], SimpleParameterProvider::provideArrayParameter(Option::FILE_EXTENSIONS));
+        self::assertTrue(SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_NAMES));
+        self::assertTrue(SimpleParameterProvider::provideBoolParameter(Option::AUTO_IMPORT_DOC_BLOCK_NAMES));
+        self::assertTrue(SimpleParameterProvider::provideBoolParameter(Option::REMOVE_UNUSED_IMPORTS));
+        self::assertTrue(SimpleParameterProvider::provideBoolParameter(Option::PARALLEL));
+        self::assertSame(42, SimpleParameterProvider::provideIntParameter(Option::PARALLEL_JOB_TIMEOUT_IN_SECONDS));
+        self::assertContains(
+            AddMissingMethodPhpDocRector::class,
+            SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_RULES),
+        );
+        self::assertNotEmpty(SimpleParameterProvider::provideArrayParameter(Option::REGISTERED_RECTOR_SETS));
+    }
+
+    /**
+     * @return void
+     */
+    public static function resetSimpleParameterProvider(): void
+    {
+        $reflectionProperty = new ReflectionProperty(SimpleParameterProvider::class, 'parameters');
+        $reflectionProperty->setValue(null, []);
     }
 }

--- a/tests/Console/Command/CodeOwnersCommandTest.php
+++ b/tests/Console/Command/CodeOwnersCommandTest.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Console\Command;
 
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use FastForward\DevTools\CodeOwners\CodeOwnersGenerator;
 use FastForward\DevTools\Console\Command\CodeOwnersCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
@@ -32,6 +34,8 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -66,6 +70,11 @@ final class CodeOwnersCommandTest extends TestCase
      */
     private ObjectProphecy $fileDiffer;
 
+    /**
+     * @var ObjectProphecy<QuestionHelper>
+     */
+    private ObjectProphecy $questionHelper;
+
     private CodeOwnersCommand $command;
 
     /**
@@ -80,6 +89,7 @@ final class CodeOwnersCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
 
         $this->input->getOption('file')
             ->willReturn('.github/CODEOWNERS');
@@ -98,12 +108,19 @@ final class CodeOwnersCommandTest extends TestCase
             ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
 
         $this->command = new CodeOwnersCommand(
             $this->generator->reveal(),
             $this->filesystem->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -224,6 +241,147 @@ final class CodeOwnersCommandTest extends TestCase
         $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(CodeOwnersCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillPromptForOwnersWhenInteractiveInferenceFails(): void
+    {
+        $targetPath = '/project/.github/CODEOWNERS';
+        $targetDirectory = '/project/.github';
+        $generatedContent = "* @php-fast-forward @mentordosnerds\n";
+
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('.github/CODEOWNERS')
+            ->willReturn($targetPath);
+        $this->filesystem->dirname($targetPath)
+            ->willReturn($targetDirectory);
+        $this->filesystem->exists($targetPath)
+            ->willReturn(false, false);
+        $this->filesystem->exists($targetDirectory)
+            ->willReturn(true);
+        $this->generator->inferOwners()
+            ->willReturn([]);
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(Question::class),
+        )->willReturn('php-fast-forward @mentordosnerds')
+            ->shouldBeCalledOnce();
+        $this->generator->normalizeOwners('php-fast-forward @mentordosnerds')
+            ->willReturn(['@php-fast-forward', '@mentordosnerds'])
+            ->shouldBeCalledOnce();
+        $this->generator->generate(['@php-fast-forward', '@mentordosnerds'])
+            ->willReturn($generatedContent)
+            ->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated CODEOWNERS content',
+            $targetPath,
+            $generatedContent,
+            null,
+            'Managed file ' . $targetPath . ' will be created from generated CODEOWNERS content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Managed file ' . $targetPath . ' will be created from generated CODEOWNERS content.',
+        ))->shouldBeCalledOnce();
+        $this->filesystem->mkdir(Argument::cetera())->shouldNotBeCalled();
+        $this->filesystem->dumpFile($targetPath, $generatedContent)
+            ->shouldBeCalledOnce();
+
+        self::assertSame(CodeOwnersCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessOnDryRunWhenDriftIsDetected(): void
+    {
+        $targetPath = '/project/.github/CODEOWNERS';
+        $generatedContent = "* @php-fast-forward\n";
+        $existingContent = "* @legacy-owner\n";
+
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('.github/CODEOWNERS')
+            ->willReturn($targetPath);
+        $this->filesystem->dirname($targetPath)
+            ->willReturn('/project/.github');
+        $this->filesystem->exists($targetPath)
+            ->willReturn(true);
+        $this->filesystem->readFile($targetPath)
+            ->willReturn($existingContent);
+        $this->generator->inferOwners()
+            ->willReturn(['@php-fast-forward']);
+        $this->generator->generate(['@php-fast-forward'])
+            ->willReturn($generatedContent);
+        $this->fileDiffer->diffContents(
+            'generated CODEOWNERS content',
+            $targetPath,
+            $generatedContent,
+            $existingContent,
+            'Updating managed file ' . $targetPath . ' from generated CODEOWNERS content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Updating managed file ' . $targetPath . ' from generated CODEOWNERS content.',
+        ))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(CodeOwnersCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipReplacingExistingCodeOwnersWhenConfirmationIsDeclined(): void
+    {
+        $targetPath = '/project/.github/CODEOWNERS';
+        $generatedContent = "* @php-fast-forward\n";
+        $existingContent = "* @legacy-owner\n";
+
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('.github/CODEOWNERS')
+            ->willReturn($targetPath);
+        $this->filesystem->dirname($targetPath)
+            ->willReturn('/project/.github');
+        $this->filesystem->exists($targetPath)
+            ->willReturn(true);
+        $this->filesystem->readFile($targetPath)
+            ->willReturn($existingContent);
+        $this->generator->inferOwners()
+            ->willReturn(['@php-fast-forward']);
+        $this->generator->generate(['@php-fast-forward'])
+            ->willReturn($generatedContent);
+        $this->fileDiffer->diffContents(
+            'generated CODEOWNERS content',
+            $targetPath,
+            $generatedContent,
+            $existingContent,
+            'Updating managed file ' . $targetPath . ' from generated CODEOWNERS content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Updating managed file ' . $targetPath . ' from generated CODEOWNERS content.',
+        ))->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating ' . $targetPath . '.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(CodeOwnersCommand::SUCCESS, $this->invokeExecute());
     }
 
     /**

--- a/tests/Console/Command/CopyResourceCommandTest.php
+++ b/tests/Console/Command/CopyResourceCommandTest.php
@@ -33,8 +33,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Finder\Finder;
 
 use function Safe\mkdir;
@@ -60,6 +63,8 @@ final class CopyResourceCommandTest extends TestCase
 
     private ObjectProphecy $fileDiffer;
 
+    private ObjectProphecy $questionHelper;
+
     private CopyResourceCommand $command;
 
     private string $sourceDirectory;
@@ -79,6 +84,7 @@ final class CopyResourceCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
@@ -88,8 +94,14 @@ final class CopyResourceCommandTest extends TestCase
             ->willReturn(false);
         $this->input->getOption('interactive')
             ->willReturn(false);
+        $this->input->isInteractive()
+            ->willReturn(false);
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->will(static fn(array $arguments): ?string => $arguments[0]);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
 
         $this->command = new CopyResourceCommand(
             $this->filesystem->reveal(),
@@ -97,6 +109,9 @@ final class CopyResourceCommandTest extends TestCase
             $this->finderFactory->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -157,6 +172,52 @@ final class CopyResourceCommandTest extends TestCase
         )->shouldBeCalledOnce();
         $this->output->writeln(Argument::containingString('Copied resource'))
             ->shouldBeCalled();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillFailWhenSourceOrTargetAreMissing(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('');
+        $this->input->getOption('target')
+            ->willReturn('');
+        $this->input->getOption('overwrite')
+            ->willReturn(false);
+        $this->output->writeln('<error>The --source and --target options are required.</error>')
+            ->shouldBeCalledOnce();
+        $this->fileLocator->locate(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(CopyResourceCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipExistingTargetByDefault(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(false);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+        $this->output->writeln('<comment>Skipped existing resource /project/.editorconfig.</comment>')
+            ->shouldBeCalledOnce();
+        $this->fileDiffer->diff(Argument::cetera())->shouldNotBeCalled();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
     }
@@ -279,6 +340,107 @@ final class CopyResourceCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->output->writeln('<info>Copied resource /project/.editorconfig.</info>')
             ->shouldBeCalledOnce();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenFileWouldChange(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(false);
+        $this->input->getOption('check')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+        $this->fileDiffer->diff('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Changed summary', "@@ -1 +1 @@\n-old\n+new"))
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Changed summary</comment>')
+            ->shouldBeCalledOnce();
+        $this->output->writeln("@@ -1 +1 @@\n-old\n+new")
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(CopyResourceCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessInDryRunModeWhenFileWouldChange(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(false);
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+        $this->fileDiffer->diff('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Changed summary', "@@ -1 +1 @@\n-old\n+new"))
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipReplacingDriftedFileWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('target')
+            ->willReturn('.editorconfig');
+        $this->input->getOption('overwrite')
+            ->willReturn(false);
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+
+        $this->fileLocator->locate('.editorconfig')
+            ->willReturn('/package/.editorconfig');
+        $this->filesystem->getAbsolutePath('.editorconfig')
+            ->willReturn('/project/.editorconfig');
+        $this->filesystem->exists('/project/.editorconfig')
+            ->willReturn(true);
+        $this->fileDiffer->diff('/package/.editorconfig', '/project/.editorconfig')
+            ->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Changed summary', "@@ -1 +1 @@\n-old\n+new"))
+            ->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped replacing /project/.editorconfig.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(CopyResourceCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/FundingCommandTest.php
+++ b/tests/Console/Command/FundingCommandTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Console\Command;
 
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use FastForward\DevTools\Console\Command\FundingCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Funding\ComposerFundingCodec;
@@ -37,6 +38,8 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
@@ -68,6 +71,8 @@ final class FundingCommandTest extends TestCase
 
     private ObjectProphecy $normalizeProcess;
 
+    private ObjectProphecy $questionHelper;
+
     private FundingCommand $command;
 
     /**
@@ -82,6 +87,11 @@ final class FundingCommandTest extends TestCase
         $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->normalizeProcess = $this->prophesize(Process::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
@@ -118,6 +128,9 @@ final class FundingCommandTest extends TestCase
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -316,6 +329,254 @@ final class FundingCommandTest extends TestCase
         )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
         $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
         $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessWhenComposerFileDoesNotExist(): void
+    {
+        $this->filesystem->exists('composer.json')
+            ->willReturn(false);
+        $this->output->writeln('<info>Synchronizing funding metadata...</info>')
+            ->shouldBeCalledOnce();
+        $this->output->writeln(
+            '<comment>Composer file composer.json does not exist. Skipping funding synchronization.</comment>'
+        )->shouldBeCalledOnce();
+        $this->filesystem->readFile(Argument::cetera())->shouldNotBeCalled();
+        $this->fileDiffer->diffContents(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenComposerFileWouldChange(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\n";
+
+        $this->input->getOption('check')
+            ->willReturn(true);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillNotWriteManagedFilesDuringDryRun(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\n";
+
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipComposerWriteWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\n";
+
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class)
+        )
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating composer.json.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureWhenComposerNormalizeFails(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\n";
+
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::FAILURE)->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(
+            'composer.json',
+            Argument::that(static fn(string $contents): bool => str_contains($contents, '"funding"')),
+        )->shouldBeCalledOnce();
+        $this->output->writeln('<info>Updated funding metadata in composer.json.</info>')
+            ->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillPassWorkingDirectoryAndAlternateManifestToComposerNormalize(): void
+    {
+        $composerFile = 'build/custom/composer.alt.json';
+        $composerContents = '{"name":"example/package"}';
+        $fundingYaml = "github: foo\n";
+
+        $this->input->getOption('composer-file')
+            ->willReturn($composerFile);
+        $this->filesystem->exists($composerFile)
+            ->willReturn(true);
+        $this->filesystem->readFile($composerFile)
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(true);
+        $this->filesystem->readFile('.github/FUNDING.yml')
+            ->willReturn($fundingYaml);
+        $this->filesystem->dirname($composerFile)
+            ->willReturn('build/custom');
+        $this->filesystem->basename($composerFile)
+            ->willReturn('composer.alt.json');
+        $this->processBuilder->withArgument('--working-dir', 'build/custom')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--file', 'composer.alt.json')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            $composerFile,
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file build/custom/composer.alt.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_CHANGED, 'Composer changed'))->shouldBeCalledOnce();
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            '.github/FUNDING.yml',
+            Argument::type('string'),
+            $fundingYaml,
+            'Updating managed file .github/FUNDING.yml from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Funding unchanged'))->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(
+            $composerFile,
+            Argument::that(static fn(string $contents): bool => str_contains($contents, '"funding"')),
+        )->shouldBeCalledOnce();
 
         self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/FundingCommandTest.php
+++ b/tests/Console/Command/FundingCommandTest.php
@@ -599,6 +599,75 @@ final class FundingCommandTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipFundingFileSynchronizationWhenNoSupportedFundingMetadataExists(): void
+    {
+        $composerContents = '{"name":"example/package"}';
+
+        $this->filesystem->exists('composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('composer.json')
+            ->willReturn($composerContents);
+        $this->filesystem->exists('.github/FUNDING.yml')
+            ->willReturn(false);
+        $this->fileDiffer->diffContents(
+            'generated funding metadata synchronization',
+            'composer.json',
+            Argument::type('string'),
+            $composerContents,
+            'Updating managed file composer.json from generated funding metadata synchronization.',
+        )->willReturn(new FileDiff(FileDiff::STATUS_UNCHANGED, 'Composer unchanged'))->shouldBeCalledOnce();
+        $this->output->writeln(
+            '<comment>No supported funding metadata found. Skipping .github/FUNDING.yml synchronization.</comment>'
+        )->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(FundingCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function privateHelpersWillPromptAndNormalizeComposerFileArguments(): void
+    {
+        $shouldWriteManagedFile = new ReflectionMethod($this->command, 'shouldWriteManagedFile');
+        $normalizeComposerFile = new ReflectionMethod($this->command, 'normalizeComposerFile');
+
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->filesystem->dirname('composer.alt.json')
+            ->willReturn('.');
+        $this->filesystem->basename('composer.alt.json')
+            ->willReturn('composer.alt.json');
+        $this->processBuilder->withArgument('--file', 'composer.alt.json')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->normalizeProcess->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+
+        self::assertTrue($shouldWriteManagedFile->invoke(
+            $this->command,
+            $this->input->reveal(),
+            $this->output->reveal(),
+            'composer.alt.json',
+        ));
+        self::assertSame(
+            ProcessQueueInterface::SUCCESS,
+            $normalizeComposerFile->invoke($this->command, 'composer.alt.json', $this->output->reveal()),
+        );
+    }
+
+    /**
      * @return int
      */
     private function executeCommand(): int

--- a/tests/Console/Command/GitAttributesCommandTest.php
+++ b/tests/Console/Command/GitAttributesCommandTest.php
@@ -38,8 +38,11 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use function Safe\getcwd;
 
@@ -104,6 +107,8 @@ final class GitAttributesCommandTest extends TestCase
      */
     private ObjectProphecy $fileDiffer;
 
+    private ObjectProphecy $questionHelper;
+
     private GitAttributesCommand $command;
 
     /**
@@ -122,16 +127,23 @@ final class GitAttributesCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
         $this->input->getOption('dry-run')
             ->willReturn(false);
         $this->input->getOption('check')
             ->willReturn(false);
         $this->input->getOption('interactive')
+            ->willReturn(false);
+        $this->input->isInteractive()
             ->willReturn(false);
 
         $this->composerJson->getExtra('gitattributes')
@@ -148,6 +160,9 @@ final class GitAttributesCommandTest extends TestCase
             $this->filesystem->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -314,6 +329,165 @@ final class GitAttributesCommandTest extends TestCase
             ->shouldBeCalled();
 
         self::assertSame(GitAttributesCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenGitattributesWouldChange(): void
+    {
+        $entries = ['/docs/'];
+        $gitattributesPath = getcwd() . '/.gitattributes';
+
+        $this->input->getOption('check')
+            ->willReturn(true);
+        $this->candidateProvider->folders()
+            ->willReturn($entries);
+        $this->candidateProvider->files()
+            ->willReturn([]);
+        $this->exportIgnoreFilter->filter($entries, [])
+            ->willReturn($entries);
+        $this->exportIgnoreFilter->filter([], [])
+            ->willReturn([]);
+        $this->existenceChecker->filterExisting(getcwd(), $entries)
+            ->willReturn($entries);
+        $this->existenceChecker->filterExisting(getcwd(), [])
+            ->willReturn([]);
+        $this->filesystem->getAbsolutePath('.gitattributes')
+            ->willReturn($gitattributesPath);
+        $this->reader->read($gitattributesPath)
+            ->willReturn('');
+        $this->merger->merge('', $entries, [])
+            ->willReturn('/docs/ export-ignore');
+        $this->writer->render('/docs/ export-ignore')
+            ->willReturn("/docs/ export-ignore\n");
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'Managed file needs update.',
+                '@@ diff @@',
+            ))->shouldBeCalledOnce();
+        $this->fileDiffer->formatForConsole('@@ diff @@', false)
+            ->willReturn('@@ diff @@')
+            ->shouldBeCalledOnce();
+        $this->output->writeln('@@ diff @@')
+            ->shouldBeCalledOnce();
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitAttributesCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessInDryRunModeWhenGitattributesWouldChange(): void
+    {
+        $entries = ['/docs/'];
+        $gitattributesPath = getcwd() . '/.gitattributes';
+
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+        $this->candidateProvider->folders()
+            ->willReturn($entries);
+        $this->candidateProvider->files()
+            ->willReturn([]);
+        $this->exportIgnoreFilter->filter($entries, [])
+            ->willReturn($entries);
+        $this->exportIgnoreFilter->filter([], [])
+            ->willReturn([]);
+        $this->existenceChecker->filterExisting(getcwd(), $entries)
+            ->willReturn($entries);
+        $this->existenceChecker->filterExisting(getcwd(), [])
+            ->willReturn([]);
+        $this->filesystem->getAbsolutePath('.gitattributes')
+            ->willReturn($gitattributesPath);
+        $this->reader->read($gitattributesPath)
+            ->willReturn('');
+        $this->merger->merge('', $entries, [])
+            ->willReturn('/docs/ export-ignore');
+        $this->writer->render('/docs/ export-ignore')
+            ->willReturn("/docs/ export-ignore\n");
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'Managed file needs update.',
+            ))->shouldBeCalledOnce();
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitAttributesCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWritingWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $entries = ['/docs/'];
+        $gitattributesPath = getcwd() . '/.gitattributes';
+
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->candidateProvider->folders()
+            ->willReturn($entries);
+        $this->candidateProvider->files()
+            ->willReturn([]);
+        $this->exportIgnoreFilter->filter($entries, [])
+            ->willReturn($entries);
+        $this->exportIgnoreFilter->filter([], [])
+            ->willReturn([]);
+        $this->existenceChecker->filterExisting(getcwd(), $entries)
+            ->willReturn($entries);
+        $this->existenceChecker->filterExisting(getcwd(), [])
+            ->willReturn([]);
+        $this->filesystem->getAbsolutePath('.gitattributes')
+            ->willReturn($gitattributesPath);
+        $this->reader->read($gitattributesPath)
+            ->willReturn('');
+        $this->merger->merge('', $entries, [])
+            ->willReturn('/docs/ export-ignore');
+        $this->writer->render('/docs/ export-ignore')
+            ->willReturn("/docs/ export-ignore\n");
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'Managed file needs update.',
+            ))->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating ' . $gitattributesPath . '.</comment>')
+            ->shouldBeCalledOnce();
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitAttributesCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configuredKeepInExportPathsWillMergePrimaryAndCompatibilityKeys(): void
+    {
+        $reflectionMethod = new ReflectionMethod($this->command, 'configuredKeepInExportPaths');
+
+        $this->composerJson->getExtra('gitattributes')
+            ->willReturn([
+                'keep-in-export' => ['/README.md', '/docs/'],
+                'no-export-ignore' => ['/README.md', '/AGENTS.md'],
+            ]);
+
+        self::assertSame(
+            ['/README.md', '/docs/', '/AGENTS.md'],
+            array_values($reflectionMethod->invoke($this->command)),
+        );
     }
 
     /**

--- a/tests/Console/Command/GitHooksCommandTest.php
+++ b/tests/Console/Command/GitHooksCommandTest.php
@@ -19,20 +19,25 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Console\Command;
 
+use FastForward\DevTools\Resource\FileDiff;
 use FastForward\DevTools\Console\Command\GitHooksCommand;
 use FastForward\DevTools\Filesystem\FinderFactoryInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Resource\FileDiffer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Finder\Finder;
 
 use function Safe\mkdir;
@@ -41,6 +46,7 @@ use function Safe\unlink;
 use function Safe\rmdir;
 
 #[CoversClass(GitHooksCommand::class)]
+#[UsesClass(FileDiff::class)]
 final class GitHooksCommandTest extends TestCase
 {
     use ProphecyTrait;
@@ -56,6 +62,8 @@ final class GitHooksCommandTest extends TestCase
     private ObjectProphecy $output;
 
     private ObjectProphecy $fileDiffer;
+
+    private ObjectProphecy $questionHelper;
 
     private GitHooksCommand $command;
 
@@ -76,16 +84,23 @@ final class GitHooksCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
         $this->input->getOption('dry-run')
             ->willReturn(false);
         $this->input->getOption('check')
             ->willReturn(false);
         $this->input->getOption('interactive')
+            ->willReturn(false);
+        $this->input->isInteractive()
             ->willReturn(false);
 
         $this->command = new GitHooksCommand(
@@ -94,6 +109,9 @@ final class GitHooksCommandTest extends TestCase
             $this->finderFactory->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -147,6 +165,125 @@ final class GitHooksCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->filesystem->chmod('/app/.git/hooks/post-merge', 755, 0o755)
             ->shouldBeCalledOnce();
+
+        self::assertSame(GitHooksCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipExistingHooksWhenNoOverwriteIsRequested(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('resources/git-hooks');
+        $this->input->getOption('target')
+            ->willReturn('.git/hooks');
+        $this->input->getOption('no-overwrite')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('resources/git-hooks')
+            ->willReturn($this->sourceDirectory);
+        $this->finderFactory->create()
+            ->willReturn(new Finder())
+            ->shouldBeCalledOnce();
+        $this->filesystem->getAbsolutePath('.git/hooks')
+            ->willReturn('/app/.git/hooks');
+        $this->filesystem->exists('/app/.git/hooks/post-merge')
+            ->willReturn(true);
+        $this->output->writeln('<comment>Skipped existing post-merge hook.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitHooksCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenHookWouldChange(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('resources/git-hooks');
+        $this->input->getOption('target')
+            ->willReturn('.git/hooks');
+        $this->input->getOption('no-overwrite')
+            ->willReturn(false);
+        $this->input->getOption('check')
+            ->willReturn(true);
+
+        $this->fileLocator->locate('resources/git-hooks')
+            ->willReturn($this->sourceDirectory);
+        $this->finderFactory->create()
+            ->willReturn(new Finder())
+            ->shouldBeCalledOnce();
+        $this->filesystem->getAbsolutePath('.git/hooks')
+            ->willReturn('/app/.git/hooks');
+        $this->filesystem->exists('/app/.git/hooks/post-merge')
+            ->willReturn(true);
+        $this->fileDiffer->diff(Argument::containingString('/post-merge'), '/app/.git/hooks/post-merge')
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'Changed summary',
+                "@@ -1 +1 @@\n-old\n+new",
+            ))->shouldBeCalledOnce();
+        $this->fileDiffer->formatForConsole("@@ -1 +1 @@\n-old\n+new", false)
+            ->willReturn("@@ -1 +1 @@\n-old\n+new")
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Changed summary</comment>')
+            ->shouldBeCalledOnce();
+        $this->output->writeln("@@ -1 +1 @@\n-old\n+new")
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitHooksCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipReplacingHookWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('resources/git-hooks');
+        $this->input->getOption('target')
+            ->willReturn('.git/hooks');
+        $this->input->getOption('no-overwrite')
+            ->willReturn(false);
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+
+        $this->fileLocator->locate('resources/git-hooks')
+            ->willReturn($this->sourceDirectory);
+        $this->finderFactory->create()
+            ->willReturn(new Finder())
+            ->shouldBeCalledOnce();
+        $this->filesystem->getAbsolutePath('.git/hooks')
+            ->willReturn('/app/.git/hooks');
+        $this->filesystem->exists('/app/.git/hooks/post-merge')
+            ->willReturn(true);
+        $this->fileDiffer->diff(Argument::containingString('/post-merge'), '/app/.git/hooks/post-merge')
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'Changed summary',
+                "@@ -1 +1 @@\n-old\n+new",
+            ))->shouldBeCalledOnce();
+        $this->fileDiffer->formatForConsole("@@ -1 +1 @@\n-old\n+new", false)
+            ->willReturn("@@ -1 +1 @@\n-old\n+new")
+            ->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped replacing /app/.git/hooks/post-merge.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->copy(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(GitHooksCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/GitIgnoreCommandTest.php
+++ b/tests/Console/Command/GitIgnoreCommandTest.php
@@ -35,8 +35,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 #[CoversClass(GitIgnoreCommand::class)]
 #[UsesClass(FileDiff::class)]
@@ -80,6 +83,11 @@ final class GitIgnoreCommandTest extends TestCase
     private ObjectProphecy $fileDiffer;
 
     /**
+     * @var ObjectProphecy<QuestionHelper>
+     */
+    private ObjectProphecy $questionHelper;
+
+    /**
      * @var ObjectProphecy<GitIgnoreInterface>
      */
     private ObjectProphecy $gitIgnoreSource;
@@ -115,11 +123,16 @@ final class GitIgnoreCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
 
         $this->gitIgnoreSource = $this->prophesize(GitIgnoreInterface::class);
         $this->gitIgnoreTarget = $this->prophesize(GitIgnoreInterface::class);
@@ -134,6 +147,8 @@ final class GitIgnoreCommandTest extends TestCase
         $this->input->getOption('check')
             ->willReturn(false);
         $this->input->getOption('interactive')
+            ->willReturn(false);
+        $this->input->isInteractive()
             ->willReturn(false);
 
         $this->reader->read(self::SOURCE_PATH)
@@ -168,6 +183,9 @@ final class GitIgnoreCommandTest extends TestCase
             $this->fileLocator->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -213,6 +231,79 @@ final class GitIgnoreCommandTest extends TestCase
         $result = $this->executeCommand();
 
         self::assertSame(GitIgnoreCommand::SUCCESS, $result);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessWhenGitIgnoreIsAlreadySynchronized(): void
+    {
+        $this->fileDiffer->diffContents(
+            'generated .gitignore synchronization',
+            self::TARGET_PATH,
+            "vendor/\n",
+            '',
+            'Updating managed file /path/to/target/.gitignore from generated .gitignore synchronization.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_UNCHANGED,
+            'Target /path/to/target/.gitignore already matches source generated .gitignore synchronization; overwrite skipped.',
+        ));
+
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitIgnoreCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenDriftIsDetected(): void
+    {
+        $this->input->getOption('check')
+            ->willReturn(true);
+
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitIgnoreCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessInDryRunModeWhenDriftIsDetected(): void
+    {
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitIgnoreCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWritingWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating /path/to/target/.gitignore.</comment>')
+            ->shouldBeCalledOnce();
+        $this->writer->write(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(GitIgnoreCommand::SUCCESS, $this->executeCommand());
     }
 
     /**

--- a/tests/Console/Command/LicenseCommandTest.php
+++ b/tests/Console/Command/LicenseCommandTest.php
@@ -34,8 +34,11 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use function Safe\getcwd;
 
@@ -72,6 +75,11 @@ final class LicenseCommandTest extends TestCase
      */
     private ObjectProphecy $fileDiffer;
 
+    /**
+     * @var ObjectProphecy<QuestionHelper>
+     */
+    private ObjectProphecy $questionHelper;
+
     private LicenseCommand $command;
 
     /**
@@ -86,6 +94,7 @@ final class LicenseCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
@@ -95,14 +104,23 @@ final class LicenseCommandTest extends TestCase
             ->willReturn(false);
         $this->input->getOption('interactive')
             ->willReturn(false);
+        $this->input->isInteractive()
+            ->willReturn(false);
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
 
         $this->command = new LicenseCommand(
             $this->generator->reveal(),
             $this->filesystem->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -215,6 +233,121 @@ final class LicenseCommandTest extends TestCase
         $this->output->writeln(
             Argument::containingString('No supported license found in composer.json')
         )->shouldBeCalled();
+
+        self::assertSame(LicenseCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenLicenseWouldChange(): void
+    {
+        $targetPath = getcwd() . '/LICENSE';
+
+        $this->input->getOption('target')
+            ->willReturn('LICENSE');
+        $this->input->getOption('check')
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('LICENSE')
+            ->willReturn($targetPath);
+        $this->filesystem->exists($targetPath)
+            ->willReturn(true);
+        $this->filesystem->readFile($targetPath)
+            ->willReturn('Old license');
+        $this->generator->generateContent()
+            ->willReturn('New license');
+        $this->fileDiffer->diffContents(
+            'generated LICENSE content',
+            $targetPath,
+            'New license',
+            'Old license',
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        ))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(LicenseCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessInDryRunModeWhenLicenseWouldChange(): void
+    {
+        $targetPath = getcwd() . '/LICENSE';
+
+        $this->input->getOption('target')
+            ->willReturn('LICENSE');
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('LICENSE')
+            ->willReturn($targetPath);
+        $this->filesystem->exists($targetPath)
+            ->willReturn(true);
+        $this->filesystem->readFile($targetPath)
+            ->willReturn('Old license');
+        $this->generator->generateContent()
+            ->willReturn('New license');
+        $this->fileDiffer->diffContents(
+            'generated LICENSE content',
+            $targetPath,
+            'New license',
+            'Old license',
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        ))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(LicenseCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWritingWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $targetPath = getcwd() . '/LICENSE';
+
+        $this->input->getOption('target')
+            ->willReturn('LICENSE');
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->filesystem->getAbsolutePath('LICENSE')
+            ->willReturn($targetPath);
+        $this->filesystem->exists($targetPath)
+            ->willReturn(true);
+        $this->filesystem->readFile($targetPath)
+            ->willReturn('Old license');
+        $this->generator->generateContent()
+            ->willReturn('New license');
+        $this->fileDiffer->diffContents(
+            'generated LICENSE content',
+            $targetPath,
+            'New license',
+            'Old license',
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        )->willReturn(new FileDiff(
+            FileDiff::STATUS_CHANGED,
+            'Updating managed file ' . $targetPath . ' from generated LICENSE content.',
+        ))->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating ' . $targetPath . '.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(LicenseCommand::SUCCESS, $this->invokeExecute());
     }

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -26,6 +26,7 @@ use FastForward\DevTools\PhpUnit\Coverage\CoverageSummary;
 use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessQueueInterface;
+use RuntimeException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -332,6 +333,23 @@ final class TestsCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function executeWithFilterWillForwardTheFilterToPhpUnit(): void
+    {
+        $this->willQueueProcessMatching(static fn(Process $process): bool => str_contains(
+            $process->getCommandLine(),
+            '--filter=TestsCommandTest',
+        ));
+
+        $this->input->getOption('filter')
+            ->willReturn('TestsCommandTest');
+
+        $this->invokeExecute();
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWithInvalidMinCoverageWillReturnFailure(): void
     {
         $this->output->writeln(Argument::type('string'))
@@ -341,6 +359,50 @@ final class TestsCommandTest extends TestCase
 
         $this->input->getOption('min-coverage')
             ->willReturn('abc');
+
+        self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWithOutOfRangeMinCoverageWillReturnFailure(): void
+    {
+        $this->output->writeln(Argument::type('string'))
+            ->will(static function (): void {});
+        $this->output->writeln(Argument::containingString('between 0 and 100'))
+            ->shouldBeCalled();
+
+        $this->input->getOption('min-coverage')
+            ->willReturn('101');
+
+        self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureWhenCoverageSummaryCannotBeLoaded(): void
+    {
+        $coverageReportPath = getcwd() . '/tmp/cache/phpunit/coverage.php';
+
+        $this->willQueueProcessMatching(static fn(Process $process): bool => str_contains(
+            $process->getCommandLine(),
+            '--coverage-php=' . $coverageReportPath,
+        ));
+
+        $this->output->writeln(Argument::type('string'))
+            ->will(static function (): void {});
+        $this->output->writeln('<error>coverage report missing</error>')
+            ->shouldBeCalledOnce();
+
+        $this->coverageSummaryLoader->load($coverageReportPath)
+            ->willThrow(new RuntimeException('coverage report missing'));
+
+        $this->input->getOption('min-coverage')
+            ->willReturn('80');
 
         self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
     }

--- a/tests/Console/Command/UpdateComposerJsonCommandTest.php
+++ b/tests/Console/Command/UpdateComposerJsonCommandTest.php
@@ -33,8 +33,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use function Safe\json_decode;
 
@@ -56,6 +59,8 @@ final class UpdateComposerJsonCommandTest extends TestCase
 
     private ObjectProphecy $fileDiffer;
 
+    private ObjectProphecy $questionHelper;
+
     private UpdateComposerJsonCommand $command;
 
     /**
@@ -69,16 +74,23 @@ final class UpdateComposerJsonCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->fileDiffer = $this->prophesize(FileDiffer::class);
+        $this->questionHelper = $this->prophesize(QuestionHelper::class);
         $this->output->isDecorated()
             ->willReturn(false);
         $this->output->writeln(Argument::any());
         $this->fileDiffer->formatForConsole(Argument::cetera())
             ->willReturn(null);
+        $this->questionHelper->getName()
+            ->willReturn('question');
+        $this->questionHelper->setHelperSet(Argument::type(HelperSet::class))
+            ->shouldBeCalled();
         $this->input->getOption('dry-run')
             ->willReturn(false);
         $this->input->getOption('check')
             ->willReturn(false);
         $this->input->getOption('interactive')
+            ->willReturn(false);
+        $this->input->isInteractive()
             ->willReturn(false);
 
         $this->command = new UpdateComposerJsonCommand(
@@ -87,6 +99,9 @@ final class UpdateComposerJsonCommandTest extends TestCase
             $this->fileLocator->reveal(),
             $this->fileDiffer->reveal(),
         );
+        $this->command->setHelperSet(new HelperSet([
+            'question' => $this->questionHelper->reveal(),
+        ]));
     }
 
     /**
@@ -260,6 +275,155 @@ final class UpdateComposerJsonCommandTest extends TestCase
                 return ! \array_key_exists('readme', $composerJson);
             }),
         )->shouldBeCalledOnce();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessWhenComposerFileDoesNotExist(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(false);
+        $this->filesystem->readFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessWithoutWritingWhenComparisonIsUnchanged(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_UNCHANGED,
+                'composer.json is already synchronized.',
+            ))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnFailureInCheckModeWhenComposerJsonWouldChange(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->input->getOption('check')
+            ->willReturn(true);
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'composer.json must be updated.',
+                '@@ diff @@',
+            ))->shouldBeCalledOnce();
+        $this->fileDiffer->formatForConsole('@@ diff @@', false)
+            ->willReturn('@@ diff @@')
+            ->shouldBeCalledOnce();
+        $this->output->writeln('@@ diff @@')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(UpdateComposerJsonCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillReturnSuccessInDryRunModeWhenComposerJsonWouldChange(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->input->getOption('dry-run')
+            ->willReturn(true);
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'composer.json must be updated.',
+            ))->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWritingWhenInteractiveConfirmationIsDeclined(): void
+    {
+        $this->input->getOption('file')
+            ->willReturn('/app/composer.json');
+        $this->input->getOption('interactive')
+            ->willReturn(true);
+        $this->input->isInteractive()
+            ->willReturn(true);
+        $this->filesystem->exists('/app/composer.json')
+            ->willReturn(true);
+        $this->filesystem->readFile('/app/composer.json')
+            ->willReturn('{"name":"example/package"}');
+        $this->composer->getReadme()
+            ->willReturn('');
+        $this->filesystem->exists('README.md', '/app')
+            ->willReturn(false);
+        $this->fileLocator->locate('grumphp.yml', Argument::type('string'))
+            ->willReturn('/app/vendor/fast-forward/dev-tools/grumphp.yml');
+        $this->fileDiffer->diffContents(Argument::cetera())
+            ->willReturn(new FileDiff(
+                FileDiff::STATUS_CHANGED,
+                'composer.json must be updated.',
+            ))->shouldBeCalledOnce();
+        $this->questionHelper->ask(
+            $this->input->reveal(),
+            $this->output->reveal(),
+            Argument::type(ConfirmationQuestion::class),
+        )->willReturn(false)
+            ->shouldBeCalledOnce();
+        $this->output->writeln('<comment>Skipped updating /app/composer.json.</comment>')
+            ->shouldBeCalledOnce();
+        $this->filesystem->dumpFile(Argument::cetera())->shouldNotBeCalled();
 
         self::assertSame(UpdateComposerJsonCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -35,6 +35,9 @@ use ReflectionMethod;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Filesystem\Path;
+
+use function Safe\getcwd;
 
 #[CoversClass(WikiCommand::class)]
 final class WikiCommandTest extends TestCase
@@ -237,6 +240,77 @@ final class WikiCommandTest extends TestCase
 
         $this->output->writeln(Argument::containingString('already exists'))
             ->shouldBeCalled();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWithInitWillAddWikiSubmoduleWhenTargetDoesNotExist(): void
+    {
+        $wikiSubmodulePath = '/app/.github/wiki';
+        $expectedRelativePath = Path::makeRelative($wikiSubmodulePath, getcwd());
+
+        $this->input->getOption('target')
+            ->willReturn('.github/wiki');
+        $this->input->getOption('init')
+            ->willReturn(true);
+
+        $this->filesystem->getAbsolutePath('.github/wiki')
+            ->willReturn($wikiSubmodulePath);
+        $this->filesystem->exists($wikiSubmodulePath)
+            ->willReturn(false);
+        $this->gitClient->getConfig('remote.origin.url', getcwd())
+            ->willReturn('git@github.com:php-fast-forward/dev-tools.git')
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('submodule')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('add')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('git@github.com:php-fast-forward/dev-tools.wiki.git')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument($expectedRelativePath)
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('git')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipDefaultPackageNameWhenPsr4AutoloadIsEmpty(): void
+    {
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([]);
+        $this->input->getOption('target')
+            ->willReturn('.github/wiki');
+        $this->input->getOption('cache-dir')
+            ->willReturn('tmp/cache/phpdoc');
+        $this->input->getOption('init')
+            ->willReturn(false);
+
+        $this->processBuilder->withArgument('--defaultpackagename', Argument::any())
+            ->shouldNotBeCalled();
+        $this->processQueue->add($this->process->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run()
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
 
         self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/CommandLoader/DevToolsCommandLoaderTest.php
+++ b/tests/Console/CommandLoader/DevToolsCommandLoaderTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Finder\Finder;
@@ -41,6 +42,31 @@ final class DevToolsCommandLoaderTest extends TestCase
     use ProphecyTrait;
 
     /**
+     * @var ObjectProphecy<FinderFactoryInterface>
+     */
+    private ObjectProphecy $finderFactory;
+
+    /**
+     * @var ObjectProphecy<Finder>
+     */
+    private ObjectProphecy $finder;
+
+    /**
+     * @var ObjectProphecy<ContainerInterface>
+     */
+    private ObjectProphecy $container;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->finderFactory = $this->prophesize(FinderFactoryInterface::class);
+        $this->finder = $this->prophesize(Finder::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    /**
      * @return void
      */
     #[Test]
@@ -49,30 +75,89 @@ final class DevToolsCommandLoaderTest extends TestCase
         $commandDirectory = \dirname(__DIR__, 3) . '/src/Console/Command';
         $command = $this->prophesize(Command::class);
 
-        $finderFactory = $this->prophesize(FinderFactoryInterface::class);
-        $finder = $this->prophesize(Finder::class);
-        $finderFactory->create()
-            ->willReturn($finder->reveal())
+        $this->finderFactory->create()
+            ->willReturn($this->finder->reveal())
             ->shouldBeCalledOnce();
-        $finder->files()
-            ->willReturn($finder->reveal())
+        $this->finder->files()
+            ->willReturn($this->finder->reveal())
             ->shouldBeCalled();
-        $finder->in(Argument::type('string'))->willReturn($finder->reveal())->shouldBeCalled();
-        $finder->name('*.php')
-            ->willReturn($finder->reveal())
+        $this->finder->in(Argument::type('string'))->willReturn($this->finder->reveal())->shouldBeCalled();
+        $this->finder->name('*.php')
+            ->willReturn($this->finder->reveal())
             ->shouldBeCalled();
-        $finder->getIterator()
+        $this->finder->getIterator()
             ->willReturn(new ArrayIterator([
                 new SplFileInfo($commandDirectory . '/CodeStyleCommand.php', '', 'CodeStyleCommand.php'),
             ]))->shouldBeCalled();
 
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has(CodeStyleCommand::class)->willReturn(true)->shouldBeCalled();
-        $container->get(CodeStyleCommand::class)->willReturn($command->reveal())->shouldBeCalled();
+        $this->container->has(CodeStyleCommand::class)->willReturn(true)->shouldBeCalled();
+        $this->container->get(CodeStyleCommand::class)->willReturn($command->reveal())->shouldBeCalled();
 
-        $loader = new DevToolsCommandLoader($finderFactory->reveal(), $container->reveal());
+        $loader = new DevToolsCommandLoader($this->finderFactory->reveal(), $this->container->reveal());
 
         self::assertTrue($loader->has('code-style'));
         self::assertSame($command->reveal(), $loader->get('code-style'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function constructorWillSkipClassesWithoutAsCommandAttribute(): void
+    {
+        $commandDirectory = \dirname(__DIR__, 3) . '/src/Console/Command';
+
+        $this->finderFactory->create()
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalledOnce();
+        $this->finder->files()
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalled();
+        $this->finder->in(Argument::type('string'))->willReturn($this->finder->reveal())->shouldBeCalled();
+        $this->finder->name('*.php')
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalled();
+        $this->finder->getIterator()
+            ->willReturn(new ArrayIterator([
+                new SplFileInfo($commandDirectory . '/FixtureWithoutAsCommand.php', '', 'FixtureWithoutAsCommand.php'),
+            ]))->shouldBeCalled();
+
+        $loader = new DevToolsCommandLoader($this->finderFactory->reveal(), $this->container->reveal());
+
+        self::assertFalse($loader->has('abstract'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function constructorWillSkipNonInstantiableAndNonCommandClasses(): void
+    {
+        $commandDirectory = \dirname(__DIR__, 3) . '/src/Console/Command';
+
+        $this->finderFactory->create()
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalledOnce();
+        $this->finder->files()
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalled();
+        $this->finder->in(Argument::type('string'))->willReturn($this->finder->reveal())->shouldBeCalled();
+        $this->finder->name('*.php')
+            ->willReturn($this->finder->reveal())
+            ->shouldBeCalled();
+        $this->finder->getIterator()
+            ->willReturn(new ArrayIterator([
+                new SplFileInfo($commandDirectory . '/FixtureAbstractCommand.php', '', 'FixtureAbstractCommand.php'),
+                new SplFileInfo(
+                    $commandDirectory . '/FixtureWithoutCommandParent.php',
+                    '',
+                    'FixtureWithoutCommandParent.php'
+                ),
+            ]))->shouldBeCalled();
+
+        $loader = new DevToolsCommandLoader($this->finderFactory->reveal(), $this->container->reveal());
+
+        self::assertFalse($loader->has('fixture-abstract'));
+        self::assertFalse($loader->has('fixture-without-command-parent'));
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -25,9 +25,13 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Path;
 
+use function Safe\fileperms;
 use function Safe\file_put_contents;
 use function Safe\getcwd;
+use function Safe\mkdir;
 use function Safe\realpath;
+use function Safe\chmod;
+use function decoct;
 
 #[CoversClass(Filesystem::class)]
 final class FilesystemTest extends TestCase
@@ -87,6 +91,18 @@ final class FilesystemTest extends TestCase
     {
         $basePath = '/var/www';
         $expected = Path::makeAbsolute('test.php', $basePath);
+
+        self::assertSame($expected, $this->filesystem->getAbsolutePath('test.php', $basePath));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function getAbsolutePathWillResolveRelativeBasePathsAgainstCurrentWorkingDirectory(): void
+    {
+        $basePath = 'var/www';
+        $expected = Path::makeAbsolute('test.php', Path::makeAbsolute($basePath, getcwd()));
 
         self::assertSame($expected, $this->filesystem->getAbsolutePath('test.php', $basePath));
     }
@@ -182,5 +198,48 @@ final class FilesystemTest extends TestCase
         $this->filesystem->symlink($origin, $target);
 
         self::assertSame(realpath($origin), $this->filesystem->readlink($target, true));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function copyWillDuplicateFilesUsingAbsolutePaths(): void
+    {
+        $origin = $this->tempDir . '/origin.txt';
+        $target = $this->tempDir . '/target.txt';
+        file_put_contents($origin, 'copied content');
+
+        $this->filesystem->copy($origin, $target);
+
+        self::assertSame('copied content', $this->filesystem->readFile($target));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function chmodWillApplyPermissionsToResolvedPaths(): void
+    {
+        $filename = $this->tempDir . '/permissions.txt';
+        file_put_contents($filename, 'permission check');
+        chmod($filename, 0o644);
+
+        $this->filesystem->chmod($filename, 0o600);
+
+        self::assertStringEndsWith('600', decoct(fileperms($filename) & 0o777));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function existsWillAcceptIterablesOfRelativePaths(): void
+    {
+        mkdir($this->tempDir . '/iterable');
+        file_put_contents($this->tempDir . '/iterable/a.txt', 'A');
+        file_put_contents($this->tempDir . '/iterable/b.txt', 'B');
+
+        self::assertTrue($this->filesystem->exists(['iterable/a.txt', 'iterable/b.txt'], $this->tempDir));
     }
 }

--- a/tests/Fixtures/Console/Command/FixtureAbstractCommand.php
+++ b/tests/Fixtures/Console/Command/FixtureAbstractCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class FixtureAbstractCommand extends Command {}

--- a/tests/Fixtures/Console/Command/FixtureWithoutAsCommand.php
+++ b/tests/Fixtures/Console/Command/FixtureWithoutAsCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+final class FixtureWithoutAsCommand extends Command {}

--- a/tests/Fixtures/Console/Command/FixtureWithoutCommandParent.php
+++ b/tests/Fixtures/Console/Command/FixtureWithoutCommandParent.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Console\Command;
+
+final class FixtureWithoutCommandParent {}

--- a/tests/Funding/ComposerFundingCodecTest.php
+++ b/tests/Funding/ComposerFundingCodecTest.php
@@ -135,8 +135,13 @@ final class ComposerFundingCodecTest extends TestCase
                     'type' => 'github',
                     'url' => 'https://github.com/foo',
                 ],
-                ['type' => 'patreon', 'url' => ''],
-                ['type' => 'other'],
+                [
+                    'type' => 'patreon',
+                    'url' => '',
+                ],
+                [
+                    'type' => 'other',
+                ],
             ],
             $profile->getUnsupportedComposerEntries(),
         );

--- a/tests/Funding/ComposerFundingCodecTest.php
+++ b/tests/Funding/ComposerFundingCodecTest.php
@@ -165,6 +165,33 @@ final class ComposerFundingCodecTest extends TestCase
      * @return void
      */
     #[Test]
+    public function parseWillTreatGithubEntriesWithoutParsableUrlPartsAsUnsupported(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $profile = $codec->parse(<<<'JSON'
+            {
+              "name": "example/package",
+              "funding": [
+                {"type": "github", "url": "mailto:team@example.com"}
+              ]
+            }
+            JSON);
+
+        self::assertSame([], $profile->getGithubSponsors());
+        self::assertSame(
+            [[
+                'type' => 'github',
+                'url' => 'mailto:team@example.com',
+            ]],
+            $profile->getUnsupportedComposerEntries(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function dumpWillRemoveFundingWhenTheProfileHasNoEntries(): void
     {
         $codec = new ComposerFundingCodec();

--- a/tests/Funding/ComposerFundingCodecTest.php
+++ b/tests/Funding/ComposerFundingCodecTest.php
@@ -102,4 +102,94 @@ final class ComposerFundingCodecTest extends TestCase
             $decoded['funding'],
         );
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillIgnoreInvalidEntriesAndDeduplicateSupportedValues(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $profile = $codec->parse(<<<'JSON'
+            {
+              "name": "example/package",
+              "funding": [
+                "invalid",
+                {"type": "github", "url": "https://github.com/sponsors/foo"},
+                {"type": "github", "url": "https://www.github.com/sponsors/foo"},
+                {"type": "github", "url": "https://github.com/foo"},
+                {"type": "custom", "url": " https://example.com/support "},
+                {"type": "custom", "url": "https://example.com/support"},
+                {"type": "patreon", "url": ""},
+                {"type": "other"}
+              ]
+            }
+            JSON);
+
+        self::assertSame(['foo'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+        self::assertSame(
+            [
+                [
+                    'type' => 'github',
+                    'url' => 'https://github.com/foo',
+                ],
+                ['type' => 'patreon', 'url' => ''],
+                ['type' => 'other'],
+            ],
+            $profile->getUnsupportedComposerEntries(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillReturnEmptyProfileWhenFundingIsNotAnArray(): void
+    {
+        $codec = new ComposerFundingCodec();
+        $profile = $codec->parse('{"name":"example/package","funding":"nope"}');
+
+        self::assertSame([], $profile->getGithubSponsors());
+        self::assertSame([], $profile->getCustomUrls());
+        self::assertSame([], $profile->getUnsupportedComposerEntries());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function dumpWillRemoveFundingWhenTheProfileHasNoEntries(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $contents = $codec->dump(
+            '{"name":"example/package","funding":[{"type":"github","url":"https://github.com/sponsors/foo"}]}',
+            new FundingProfile(),
+        );
+
+        $decoded = json_decode($contents, true);
+
+        self::assertArrayNotHasKey('funding', $decoded);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function dumpWillInsertFundingImmediatelyAfterSupportWhenPresent(): void
+    {
+        $codec = new ComposerFundingCodec();
+
+        $contents = $codec->dump(
+            '{"name":"example/package","support":{"docs":"https://example.com/docs"},"autoload":{"psr-4":{"App\\\\":"src/"}}}',
+            new FundingProfile(['fast-forward']),
+        );
+
+        self::assertStringContainsString(
+            "\"support\": {\n        \"docs\": \"https://example.com/docs\"\n    },\n    \"funding\": [",
+            $contents,
+        );
+    }
 }

--- a/tests/Funding/FundingProfileTest.php
+++ b/tests/Funding/FundingProfileTest.php
@@ -36,15 +36,25 @@ final class FundingProfileTest extends TestCase
         $profile = new FundingProfile(
             ['fast-forward'],
             ['https://example.com/support'],
-            ['ko_fi' => 'fastforward'],
-            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            [
+                'ko_fi' => 'fastforward',
+            ],
+            [[
+                'type' => 'patreon',
+                'url' => 'https://patreon.com/example',
+            ]],
         );
 
         self::assertSame(['fast-forward'], $profile->getGithubSponsors());
         self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
-        self::assertSame(['ko_fi' => 'fastforward'], $profile->getUnsupportedYamlEntries());
+        self::assertSame([
+            'ko_fi' => 'fastforward',
+        ], $profile->getUnsupportedYamlEntries());
         self::assertSame(
-            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            [[
+                'type' => 'patreon',
+                'url' => 'https://patreon.com/example',
+            ]],
             $profile->getUnsupportedComposerEntries(),
         );
     }
@@ -58,6 +68,8 @@ final class FundingProfileTest extends TestCase
         self::assertFalse((new FundingProfile())->hasYamlContent());
         self::assertTrue((new FundingProfile(['fast-forward']))->hasYamlContent());
         self::assertTrue((new FundingProfile(customUrls: ['https://example.com/support']))->hasYamlContent());
-        self::assertTrue((new FundingProfile(unsupportedYamlEntries: ['ko_fi' => 'fastforward']))->hasYamlContent());
+        self::assertTrue((new FundingProfile(unsupportedYamlEntries: [
+            'ko_fi' => 'fastforward',
+        ]))->hasYamlContent());
     }
 }

--- a/tests/Funding/FundingProfileTest.php
+++ b/tests/Funding/FundingProfileTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Funding;
+
+use FastForward\DevTools\Funding\FundingProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FundingProfile::class)]
+final class FundingProfileTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function accessorsWillReturnNormalizedProfileValues(): void
+    {
+        $profile = new FundingProfile(
+            ['fast-forward'],
+            ['https://example.com/support'],
+            ['ko_fi' => 'fastforward'],
+            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+        );
+
+        self::assertSame(['fast-forward'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+        self::assertSame(['ko_fi' => 'fastforward'], $profile->getUnsupportedYamlEntries());
+        self::assertSame(
+            [['type' => 'patreon', 'url' => 'https://patreon.com/example']],
+            $profile->getUnsupportedComposerEntries(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasYamlContentWillReportWhetherYamlShouldExist(): void
+    {
+        self::assertFalse((new FundingProfile())->hasYamlContent());
+        self::assertTrue((new FundingProfile(['fast-forward']))->hasYamlContent());
+        self::assertTrue((new FundingProfile(customUrls: ['https://example.com/support']))->hasYamlContent());
+        self::assertTrue((new FundingProfile(unsupportedYamlEntries: ['ko_fi' => 'fastforward']))->hasYamlContent());
+    }
+}

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -110,6 +110,7 @@ final class FundingYamlCodecTest extends TestCase
         self::assertSame([], $codec->parse(" \n")->getCustomUrls());
         self::assertSame([], $codec->parse('true')->getGithubSponsors());
         self::assertSame(['just-a-list'], $codec->parse('- just-a-list')->getUnsupportedYamlEntries());
+        self::assertSame([], $codec->parse('42')->getGithubSponsors());
     }
 
     /**
@@ -162,7 +163,7 @@ final class FundingYamlCodecTest extends TestCase
         $contents = $codec->dump(new FundingProfile(['foo']));
 
         self::assertSame([
-                'github' => 'foo',
-            ], Yaml::parse($contents),);
+            'github' => 'foo',
+        ], Yaml::parse($contents),);
     }
 }

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -97,4 +97,72 @@ final class FundingYamlCodecTest extends TestCase
             Yaml::parse($contents),
         );
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillReturnEmptyProfileForMissingOrInvalidYamlPayloads(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        self::assertSame([], $codec->parse(null)->getGithubSponsors());
+        self::assertSame([], $codec->parse(" \n")->getCustomUrls());
+        self::assertSame([], $codec->parse('true')->getGithubSponsors());
+        self::assertSame(['just-a-list'], $codec->parse('- just-a-list')->getUnsupportedYamlEntries());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillNormalizeListsAndDiscardBlankEntries(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $profile = $codec->parse(<<<'YAML'
+            github:
+              - foo
+              - " "
+              - bar
+            custom:
+              - https://example.com/support
+              - ""
+            YAML);
+
+        self::assertSame(['foo', 'bar'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function parseWillNormalizeScalarGithubAndCustomValues(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $profile = $codec->parse(<<<'YAML'
+            github: foo
+            custom: https://example.com/support
+            YAML);
+
+        self::assertSame(['foo'], $profile->getGithubSponsors());
+        self::assertSame(['https://example.com/support'], $profile->getCustomUrls());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function dumpWillCollapseSingleGithubSponsorToScalar(): void
+    {
+        $codec = new FundingYamlCodec();
+
+        $contents = $codec->dump(new FundingProfile(['foo']));
+
+        self::assertSame([
+                'github' => 'foo',
+            ], Yaml::parse($contents),);
+    }
 }

--- a/tests/Funding/FundingYamlCodecTest.php
+++ b/tests/Funding/FundingYamlCodecTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use Symfony\Component\Yaml\Yaml;
 
 #[CoversClass(FundingYamlCodec::class)]
@@ -165,5 +166,21 @@ final class FundingYamlCodecTest extends TestCase
         self::assertSame([
             'github' => 'foo',
         ], Yaml::parse($contents),);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function privateListHelpersWillNormalizeAndDenormalizeValues(): void
+    {
+        $codec = new FundingYamlCodec();
+        $normalizeList = new ReflectionMethod($codec, 'normalizeList');
+        $denormalizeList = new ReflectionMethod($codec, 'denormalizeList');
+
+        self::assertSame(['foo'], $normalizeList->invoke($codec, ' foo '));
+        self::assertSame([], $normalizeList->invoke($codec, 42));
+        self::assertSame('foo', $denormalizeList->invoke($codec, ['foo']));
+        self::assertSame(['foo', 'bar'], $denormalizeList->invoke($codec, ['foo', 'bar']));
     }
 }

--- a/tests/GitAttributes/MergerTest.php
+++ b/tests/GitAttributes/MergerTest.php
@@ -23,6 +23,7 @@ use FastForward\DevTools\GitAttributes\Merger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 #[CoversClass(Merger::class)]
 final class MergerTest extends TestCase
@@ -273,5 +274,44 @@ final class MergerTest extends TestCase
         $result = $this->merger->merge($existingContent, []);
 
         self::assertStringContainsString('* text=auto', $result);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function privateHelpersWillNormalizeAndFilterPathMetadataConsistently(): void
+    {
+        $parseExistingLines = new ReflectionMethod($this->merger, 'parseExistingLines');
+        $keepInExportLookup = new ReflectionMethod($this->merger, 'keepInExportLookup');
+        $generatedDirectoryLookup = new ReflectionMethod($this->merger, 'generatedDirectoryLookup');
+        $normalizeLine = new ReflectionMethod($this->merger, 'normalizeLine');
+        $extractExportIgnorePathSpec = new ReflectionMethod($this->merger, 'extractExportIgnorePathSpec');
+        $sortKey = new ReflectionMethod($this->merger, 'sortKey');
+        $normalizePathKey = new ReflectionMethod($this->merger, 'normalizePathKey');
+        $isLiteralPathSpec = new ReflectionMethod($this->merger, 'isLiteralPathSpec');
+
+        self::assertSame(
+            ['/docs/ export-ignore', '# comment'],
+            $parseExistingLines->invoke($this->merger, "\n/docs/ export-ignore\n\n# comment\n"),
+        );
+        self::assertSame([
+                'docs' => true,
+            ], $keepInExportLookup->invoke($this->merger, [' ', '/docs/']),);
+        self::assertSame(
+            [
+                'docs' => true,
+            ],
+            $generatedDirectoryLookup->invoke($this->merger, [' /docs/ ', '/README.md']),
+        );
+        self::assertSame('# comment', $normalizeLine->invoke($this->merger, '  # comment  '));
+        self::assertSame(
+            'docs\\ path export-ignore',
+            $normalizeLine->invoke($this->merger, "docs\\ path\texport-ignore")
+        );
+        self::assertNull($extractExportIgnorePathSpec->invoke($this->merger, '*.zip -diff'));
+        self::assertSame('docs/file.txt', $sortKey->invoke($this->merger, '///docs//file.txt'));
+        self::assertSame('/*.md', $normalizePathKey->invoke($this->merger, '/*.md'));
+        self::assertFalse($isLiteralPathSpec->invoke($this->merger, '/*.md'));
     }
 }

--- a/tests/Process/ProcessQueueTest.php
+++ b/tests/Process/ProcessQueueTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Process;
 
+use ReflectionProperty;
 use Closure;
 use FastForward\DevTools\Process\ProcessQueue;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -29,6 +30,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
+use ReflectionMethod;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessStartFailedException;
@@ -498,5 +500,66 @@ final class ProcessQueueTest extends TestCase
         $this->queue->wait(null);
 
         self::assertTrue(true);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function privateHelpersWillHandleStartupFailuresAndStreamBuffers(): void
+    {
+        $startDetachedProcess = new ReflectionMethod($this->queue, 'startDetachedProcess');
+        $runBlockingProcess = new ReflectionMethod($this->queue, 'runBlockingProcess');
+        $drainDetachedProcessesOutput = new ReflectionMethod($this->queue, 'drainDetachedProcessesOutput');
+
+        $failingDetachedProcess = $this->prophesize(Process::class);
+        $failingDetachedProcess->getCommandLine()
+            ->willReturn('php artisan');
+        $failingDetachedProcess->getWorkingDirectory()
+            ->willReturn('/tmp');
+        $failingDetachedProcess->isStarted()
+            ->willReturn(false);
+        $failingDetachedProcess->start(Argument::any())
+            ->willThrow(new ProcessStartFailedException($failingDetachedProcess->reveal(), 'failed'));
+
+        self::assertSame(
+            ProcessQueueInterface::FAILURE,
+            $startDetachedProcess->invoke($this->queue, $failingDetachedProcess->reveal(), $this->output->reveal()),
+        );
+
+        $failingBlockingProcess = $this->prophesize(Process::class);
+        $failingBlockingProcess->getCommandLine()
+            ->willReturn('php artisan');
+        $failingBlockingProcess->getWorkingDirectory()
+            ->willReturn('/tmp');
+        $failingBlockingProcess->isStarted()
+            ->willReturn(false);
+        $failingBlockingProcess->run(Argument::any())
+            ->willThrow(new ProcessStartFailedException($failingBlockingProcess->reveal(), 'failed'));
+
+        self::assertSame(
+            ProcessQueueInterface::FAILURE,
+            $runBlockingProcess->invoke($this->queue, $failingBlockingProcess->reveal(), $this->output->reveal()),
+        );
+
+        $detachedProcess = $this->prophesize(Process::class);
+        $detachedProcess->getIncrementalOutput()
+            ->willReturn('', 'late stdout');
+        $detachedProcess->getIncrementalErrorOutput()
+            ->willReturn('', 'late stderr');
+        $detachedProcess->isRunning()
+            ->willReturn(false);
+
+        $runningDetachedProcesses = new ReflectionProperty($this->queue, 'runningDetachedProcesses');
+        $runningDetachedProcesses->setValue($this->queue, [$detachedProcess->reveal()]);
+
+        $this->output->write('late stdout')
+            ->shouldBeCalledOnce();
+        $this->output->write('late stderr')
+            ->shouldBeCalledOnce();
+
+        $drainDetachedProcessesOutput->invoke($this->queue, $this->output->reveal(), true);
+
+        self::assertSame([], $runningDetachedProcesses->getValue($this->queue));
     }
 }

--- a/tests/Process/ProcessQueueTest.php
+++ b/tests/Process/ProcessQueueTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use RuntimeException;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessStartFailedException;
 use Symfony\Component\Process\Process;
@@ -373,6 +375,128 @@ final class ProcessQueueTest extends TestCase
         $this->queue->wait($this->output->reveal());
 
         // The assertion simply verifies the test completes and doesn't run infinitely.
+        self::assertTrue(true);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function addWillIgnorePtyFailuresAndStillQueueTheProcess(): void
+    {
+        $process = $this->prophesize(Process::class);
+        $process->setPty(true)
+            ->willThrow(new RuntimeException('PTY unsupported'))
+            ->shouldBeCalled();
+        $process->run(Argument::any())
+            ->willReturn(ProcessQueueInterface::SUCCESS);
+        $process->getExitCode()
+            ->willReturn(ProcessQueueInterface::SUCCESS);
+        $process->getIncrementalOutput()
+            ->willReturn('');
+        $process->getIncrementalErrorOutput()
+            ->willReturn('');
+        $process->isRunning()
+            ->willReturn(false);
+        $process->isStarted()
+            ->willReturn(false);
+
+        $this->queue->add($process->reveal());
+
+        self::assertSame(ProcessQueueInterface::SUCCESS, $this->queue->run($this->output->reveal()));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function runWillWriteErrorOutputToConsoleErrorStream(): void
+    {
+        $capturedCallback = null;
+        $consoleOutput = $this->prophesize(ConsoleOutputInterface::class);
+        $errorOutput = $this->prophesize(OutputInterface::class);
+        $process = $this->prophesize(Process::class);
+
+        $process->setPty(true)
+            ->shouldBeCalled();
+        $process->run(Argument::that(function ($callback) use (&$capturedCallback): bool {
+            $capturedCallback = $callback;
+
+            return $callback instanceof Closure;
+        }))->will(function () use (&$capturedCallback): int {
+            $capturedCallback(Process::OUT, 'stdout output');
+            $capturedCallback(Process::ERR, 'stderr output');
+
+            return ProcessQueueInterface::SUCCESS;
+        });
+        $process->getExitCode()
+            ->willReturn(ProcessQueueInterface::SUCCESS);
+        $process->getIncrementalOutput()
+            ->willReturn('');
+        $process->getIncrementalErrorOutput()
+            ->willReturn('');
+        $process->isRunning()
+            ->willReturn(false);
+        $process->isStarted()
+            ->willReturn(false);
+
+        $consoleOutput->write('stdout output')
+            ->shouldBeCalledOnce();
+        $consoleOutput->getErrorOutput()
+            ->willReturn($errorOutput->reveal())
+            ->shouldBeCalledOnce();
+        $errorOutput->write('stderr output')
+            ->shouldBeCalledOnce();
+
+        $this->queue->add($process->reveal());
+
+        self::assertSame(ProcessQueueInterface::SUCCESS, $this->queue->run($consoleOutput->reveal()));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function runWillFlushRemainingDetachedOutputWhenProcessFinishes(): void
+    {
+        $process = $this->prophesize(Process::class);
+        $process->setPty(true)
+            ->shouldBeCalled();
+        $process->start(Argument::any())
+            ->shouldBeCalledOnce();
+        $process->getIncrementalOutput()
+            ->willReturn('', 'remaining stdout');
+        $process->getIncrementalErrorOutput()
+            ->willReturn('', 'remaining stderr');
+        $process->isRunning()
+            ->willReturn(false);
+        $process->isStarted()
+            ->willReturn(true);
+
+        $this->output->write('remaining stdout')
+            ->shouldBeCalledOnce();
+        $this->output->write('remaining stderr')
+            ->shouldBeCalledOnce();
+
+        $this->queue->add($process->reveal(), false, true);
+
+        self::assertSame(ProcessQueueInterface::SUCCESS, $this->queue->run($this->output->reveal()));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function waitWillAcceptNullOutput(): void
+    {
+        $detachedProcess = $this->createDetachedProcessMock();
+        $detachedProcess->isRunning()
+            ->willReturn(true, false);
+
+        $this->queue->add($detachedProcess->reveal(), false, true);
+        $this->queue->run($this->output->reveal());
+        $this->queue->wait(null);
+
         self::assertTrue(true);
     }
 }

--- a/tests/Rector/AddMissingMethodPhpDocRectorTest.php
+++ b/tests/Rector/AddMissingMethodPhpDocRectorTest.php
@@ -23,6 +23,7 @@ use ReflectionClass;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeAnalyzer\CallAnalyzer;
 use Rector\Rector\AbstractRector;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\NullableType;
@@ -268,5 +269,42 @@ final class AddMissingMethodPhpDocRectorTest extends TestCase
         $doc = $result->getDocComment()
             ->getText();
         self::assertStringContainsString('@param ArrayAccess&Countable $p', $doc);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function refactorWillSkipReturnTagForConstructorsAndRespectOriginalTypeNames(): void
+    {
+        $node = new ClassMethod('__construct');
+        $param = new Param(new Variable('dependency'));
+        $param->type = new FullyQualified('Acme\\Contract');
+        $param->type->setAttribute('originalName', new Name('ContractAlias'));
+
+        $node->params = [$param];
+        $node->stmts = [new Expression(new Throw_(new New_(new FullyQualified('DomainException'))))];
+
+        $result = $this->rector->refactor($node);
+        $doc = $result->getDocComment();
+        self::assertNotNull($doc);
+        $text = $doc->getText();
+        self::assertStringContainsString('@param ContractAlias $dependency', $text);
+        self::assertStringContainsString('@throws DomainException', $text);
+        self::assertStringNotContainsString('@return', $text);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function refactorWillReturnOriginalNodeWhenNoTagsCanBeGenerated(): void
+    {
+        $node = new ClassMethod('__construct');
+        $node->params = [new Param(new ArrayDimFetch(new Variable('items')))];
+        $node->stmts = null;
+
+        self::assertSame($node, $this->rector->refactor($node));
+        self::assertNull($node->getDocComment());
     }
 }

--- a/tests/Rector/RemoveEmptyDocBlockRectorTest.php
+++ b/tests/Rector/RemoveEmptyDocBlockRectorTest.php
@@ -33,6 +33,7 @@ use PhpParser\Node\Stmt\Function_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 #[CoversClass(RemoveEmptyDocBlockRector::class)]
 final class RemoveEmptyDocBlockRectorTest extends TestCase
@@ -187,5 +188,17 @@ final class RemoveEmptyDocBlockRectorTest extends TestCase
     {
         $node = new Variable('var');
         self::assertNull($this->rector->refactor($node));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function isEmptyDocBlockWillDetectContentAfterNormalization(): void
+    {
+        $reflectionMethod = new ReflectionMethod($this->rector, 'isEmptyDocBlock');
+
+        self::assertTrue($reflectionMethod->invoke($this->rector, "/**\n *\n */"));
+        self::assertFalse($reflectionMethod->invoke($this->rector, "/**\n * Content\n */"));
     }
 }

--- a/tests/Resource/FileDiffTest.php
+++ b/tests/Resource/FileDiffTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Resource;
+
+use FastForward\DevTools\Resource\FileDiff;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileDiff::class)]
+final class FileDiffTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function accessorsAndStatusHelpersWillReflectTheDiffState(): void
+    {
+        $changed = new FileDiff(FileDiff::STATUS_CHANGED, 'Changed summary', 'diff body');
+        $unchanged = new FileDiff(FileDiff::STATUS_UNCHANGED, 'Unchanged summary');
+
+        self::assertSame(FileDiff::STATUS_CHANGED, $changed->getStatus());
+        self::assertSame('Changed summary', $changed->getSummary());
+        self::assertSame('diff body', $changed->getDiff());
+        self::assertTrue($changed->isChanged());
+        self::assertFalse($changed->isUnchanged());
+
+        self::assertSame(FileDiff::STATUS_UNCHANGED, $unchanged->getStatus());
+        self::assertSame('Unchanged summary', $unchanged->getSummary());
+        self::assertNull($unchanged->getDiff());
+        self::assertFalse($unchanged->isChanged());
+        self::assertTrue($unchanged->isUnchanged());
+    }
+}

--- a/tests/Resource/FileDifferTest.php
+++ b/tests/Resource/FileDifferTest.php
@@ -221,4 +221,38 @@ final class FileDifferTest extends TestCase
         self::assertStringContainsString('<fg=green>+new</>', $colorized);
         self::assertStringContainsString(' unchanged', $colorized);
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function formatForConsoleWillReturnNullWhenDiffIsMissing(): void
+    {
+        self::assertNull($this->renderer->formatForConsole(null, true));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function formatForConsoleWillReturnPlainDiffWhenOutputIsNotDecorated(): void
+    {
+        $diff = "@@ -1 +1 @@\n-old\n+new";
+
+        self::assertSame($diff, $this->renderer->formatForConsole($diff, false));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function formatForConsoleWillReturnColorizedDiffWhenOutputIsDecorated(): void
+    {
+        $diff = "@@ -1 +1 @@\n-old\n+new";
+
+        self::assertSame(
+            "<fg=yellow>@@ -1 +1 @@</>\n<fg=red>-old</>\n<fg=green>+new</>",
+            $this->renderer->formatForConsole($diff, true),
+        );
+    }
 }

--- a/tests/Resource/UnifiedDifferTest.php
+++ b/tests/Resource/UnifiedDifferTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Resource;
+
+use FastForward\DevTools\Resource\UnifiedDiffer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+
+#[CoversClass(UnifiedDiffer::class)]
+final class UnifiedDifferTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function diffWillReturnTrimmedUnifiedDiffOutput(): void
+    {
+        $differ = new UnifiedDiffer(new Differ(new UnifiedDiffOutputBuilder("--- Current\n+++ New\n")));
+
+        $diff = $differ->diff("old\n", "new\n");
+
+        self::assertStringStartsWith('--- Current', $diff);
+        self::assertStringContainsString('+++ New', $diff);
+        self::assertStringContainsString('-old', $diff);
+        self::assertStringContainsString('+new', $diff);
+        self::assertStringEndsNotWith("\n", $diff);
+    }
+}

--- a/tests/Sync/PackagedDirectorySynchronizerTest.php
+++ b/tests/Sync/PackagedDirectorySynchronizerTest.php
@@ -75,6 +75,29 @@ final class PackagedDirectorySynchronizerTest extends TestCase
      * @return void
      */
     #[Test]
+    public function setLoggerWillReplaceTheActiveLogger(): void
+    {
+        $replacementLogger = $this->prophesize(LoggerInterface::class);
+        $synchronizer = $this->createSynchronizer();
+
+        $this->filesystem->exists('/package/.agents/agents')
+            ->willReturn(false);
+
+        $synchronizer->setLogger($replacementLogger->reveal());
+
+        $replacementLogger->error('No packaged .agents/agents found at: /package/.agents/agents')
+            ->shouldBeCalledOnce();
+
+        $result = $synchronizer
+            ->synchronize('/consumer/.agents/agents', '/package/.agents/agents', '.agents/agents');
+
+        self::assertTrue($result->failed());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function synchronizeWithMissingPackagePathWillReturnFailedResult(): void
     {
         $this->filesystem->exists('/package/.agents/agents')
@@ -273,10 +296,20 @@ final class PackagedDirectorySynchronizerTest extends TestCase
      */
     private function createSynchronizer(): PackagedDirectorySynchronizer
     {
+        return $this->createSynchronizerWithLogger($this->logger->reveal());
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     *
+     * @return PackagedDirectorySynchronizer
+     */
+    private function createSynchronizerWithLogger(LoggerInterface $logger): PackagedDirectorySynchronizer
+    {
         return new PackagedDirectorySynchronizer(
             $this->filesystem->reveal(),
             $this->finderFactory->reveal(),
-            $this->logger->reveal(),
+            $logger,
         );
     }
 }

--- a/tests/Sync/PackagedDirectorySynchronizerTest.php
+++ b/tests/Sync/PackagedDirectorySynchronizerTest.php
@@ -121,6 +121,112 @@ final class PackagedDirectorySynchronizerTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    #[Test]
+    public function synchronizeWillPreserveExistingValidSymlink(): void
+    {
+        $entryPath = '/package/.agents/agents/issue-editor';
+        $targetLink = '/consumer/.agents/agents/issue-editor';
+
+        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+
+        $this->filesystem->exists('/package/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists('/consumer/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists($targetLink)
+            ->willReturn(true);
+        $this->filesystem->readlink($targetLink)
+            ->willReturn($entryPath);
+        $this->filesystem->readlink($targetLink, true)
+            ->willReturn($entryPath);
+        $this->filesystem->exists($entryPath)
+            ->willReturn(true);
+        $this->logger->notice('Preserved existing link: issue-editor')
+            ->shouldBeCalledOnce();
+
+        $result = $this->createSynchronizer()
+            ->synchronize('/consumer/.agents/agents', '/package/.agents/agents', '.agents/agents');
+
+        self::assertFalse($result->failed());
+        self::assertSame([], $result->getCreatedLinks());
+        self::assertSame(['issue-editor'], $result->getPreservedLinks());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function synchronizeWillRepairBrokenSymlink(): void
+    {
+        $entryPath = '/package/.agents/agents/issue-editor';
+        $targetLink = '/consumer/.agents/agents/issue-editor';
+        $brokenPath = '/obsolete/.agents/agents/issue-editor';
+
+        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+
+        $this->filesystem->exists('/package/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists('/consumer/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists($targetLink)
+            ->willReturn(true);
+        $this->filesystem->readlink($targetLink)
+            ->willReturn($brokenPath);
+        $this->filesystem->readlink($targetLink, true)
+            ->willReturn($brokenPath);
+        $this->filesystem->exists($brokenPath)
+            ->willReturn(false);
+        $this->filesystem->remove($targetLink)
+            ->shouldBeCalledOnce();
+        $this->filesystem->symlink($entryPath, $targetLink)
+            ->shouldBeCalledOnce();
+        $this->logger->notice('Existing link is broken: issue-editor (removing and recreating)')
+            ->shouldBeCalledOnce();
+        $this->logger->info('Created link: issue-editor -> ' . $entryPath)
+            ->shouldBeCalledOnce();
+
+        $result = $this->createSynchronizer()
+            ->synchronize('/consumer/.agents/agents', '/package/.agents/agents', '.agents/agents');
+
+        self::assertFalse($result->failed());
+        self::assertSame(['issue-editor'], $result->getCreatedLinks());
+        self::assertSame(['issue-editor'], $result->getRemovedBrokenLinks());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function synchronizeWillPreserveExistingNonSymlinkDirectory(): void
+    {
+        $entryPath = '/package/.agents/agents/issue-editor';
+        $targetLink = '/consumer/.agents/agents/issue-editor';
+
+        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+
+        $this->filesystem->exists('/package/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists('/consumer/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists($targetLink)
+            ->willReturn(true);
+        $this->filesystem->readlink($targetLink)
+            ->willReturn(null);
+        $this->logger->notice(
+            'Existing non-symlink found: issue-editor (keeping as is, skipping link creation)'
+        )->shouldBeCalledOnce();
+
+        $result = $this->createSynchronizer()
+            ->synchronize('/consumer/.agents/agents', '/package/.agents/agents', '.agents/agents');
+
+        self::assertFalse($result->failed());
+        self::assertSame([], $result->getCreatedLinks());
+        self::assertSame(['issue-editor'], $result->getPreservedLinks());
+    }
+
+    /**
      * @param SplFileInfo $directories
      *
      * @return void


### PR DESCRIPTION
## Related Issue

Closes #133

## Motivation / Context

- Start the coverage drive toward 100% PHPUnit coverage with the highest-leverage gaps that can be closed safely without production refactors.

## Changes

- add direct tests for `FundingProfile` and `ChangelogEntryType`
- extend `ComposerFundingCodecTest` to cover unsupported entries, duplicate normalization, empty funding removal, and support-ordered insertion
- extend `ChangelogDocumentTest` to cover additional document and release helper branches
- extend `PackagedDirectorySynchronizerTest` to cover preserved valid links, broken-link repair, and preserved non-symlink directories

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s): `composer dev-tools tests -- --filter='(FundingProfileTest|ComposerFundingCodecTest|ChangelogEntryTypeTest|ChangelogDocumentTest|PackagedDirectorySynchronizerTest)'`
- [x] Manual verification: reviewed the newly covered branches against the current production behavior before updating assertions

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [ ] Generated or synchronized output reviewed

## Changelog

- [ ] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- This is an initial batch for the 100% coverage effort, not the full issue implementation yet.
- The full PHPUnit suite also passes locally with `composer dev-tools tests`.
