### PR TITLE
[dependencies] Consolidate on composer-dependency-analyser (#135)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,11 @@ on:
                 required: false
                 type: number
                 default: 80
-            run-dependencies-check:
-                description: Whether to run the dependency health check during CI.
-                required: false
-                type: boolean
-                default: true
             max-outdated:
                 description: Maximum number of outdated packages allowed by the dependencies command.
                 required: false
                 type: number
-                default: 5
+                default: -1
     workflow_dispatch:
         inputs:
             min-coverage:
@@ -25,16 +20,11 @@ on:
                 required: false
                 type: number
                 default: 80
-            run-dependencies-check:
-                description: Whether to run the dependency health check during CI.
-                required: false
-                type: boolean
-                default: true
             max-outdated:
                 description: Maximum number of outdated packages allowed by the dependencies command.
                 required: false
                 type: number
-                default: 5
+                default: -1
     pull_request:
         paths:
           - 'src/**'
@@ -126,9 +116,7 @@ jobs:
     dependency-health:
         needs: resolve_php
         name: Dependency Health
-        if: ${{ github.event_name != 'workflow_call' || inputs.run-dependencies-check }}
         runs-on: ubuntu-latest
-        continue-on-error: true
         env:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
             FORCE_COLOR: '1'
@@ -162,4 +150,4 @@ jobs:
             - name: Run dependency health check
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
-              run: composer dev-tools dependencies -- --max-outdated=${{ inputs.max-outdated || 5 }}
+              run: composer dev-tools dependencies -- --max-outdated=${{ inputs.max-outdated || -1 }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Consolidate dependency analysis on `composer-dependency-analyser`, add a reusable packaged analyzer config, remove the redundant `composer-unused` dependency, and expose `--dump-usage` passthrough support (#135)
+- Consolidate dependency analysis on `composer-dependency-analyser`, add a reusable packaged analyzer config, remove the redundant `composer-unused` dependency, and expose `--dump-usage` plus report-only `--max-outdated=-1` support (#135)
 
 ## [1.14.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Consolidate dependency analysis on `composer-dependency-analyser`, add a packaged analyzer config, remove the redundant `composer-unused` dependency, and expose `--dump-usage` passthrough support (#135)
+- Consolidate dependency analysis on `composer-dependency-analyser`, add a reusable packaged analyzer config, remove the redundant `composer-unused` dependency, and expose `--dump-usage` passthrough support (#135)
 
 ## [1.14.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Consolidate dependency analysis on `composer-dependency-analyser`, add a packaged analyzer config, and remove the redundant `composer-unused` dependency (#135)
+
 ## [1.14.0] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Consolidate dependency analysis on `composer-dependency-analyser`, add a packaged analyzer config, and remove the redundant `composer-unused` dependency (#135)
+- Consolidate dependency analysis on `composer-dependency-analyser`, add a packaged analyzer config, remove the redundant `composer-unused` dependency, and expose `--dump-usage` passthrough support (#135)
 
 ## [1.14.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ composer dev-tools tests
 # Analyze missing, unused, misplaced, and outdated Composer dependencies
 composer dependencies
 composer dependencies --max-outdated=8
+composer dependencies --max-outdated=-1
 composer dependencies --dev
 composer dependencies --dump-usage=symfony/console
 composer dependencies --upgrade --dev

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can also run individual commands for specific development tasks:
 # Run PHPUnit tests
 composer dev-tools tests
 
-# Analyze missing, unused, and outdated Composer dependencies
+# Analyze missing, unused, misplaced, and outdated Composer dependencies
 composer dependencies
 composer dependencies --max-outdated=8
 composer dependencies --dev

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ composer dev-tools tests
 composer dependencies
 composer dependencies --max-outdated=8
 composer dependencies --dev
+composer dependencies --dump-usage=symfony/console
 composer dependencies --upgrade --dev
 
 # Analyze code metrics with PhpMetrics

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -17,29 +17,6 @@ declare(strict_types=1);
  * @see      https://datatracker.ietf.org/doc/html/rfc2119
  */
 
-use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
-use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
 
-$configuration = new Configuration();
-
-$unusedPackages = [
-    'ergebnis/composer-normalize',
-    'fakerphp/faker',
-    'fast-forward/phpdoc-bootstrap-template',
-    'php-parallel-lint/php-parallel-lint',
-    'phpdocumentor/shim',
-    'phpmetrics/phpmetrics',
-    'phpro/grumphp-shim',
-    'pyrech/composer-changelogs',
-    'rector/jack',
-    'saggre/phpdocumentor-markdown',
-    'shipmonk/composer-dependency-analyser',
-    'symfony/var-dumper',
-];
-
-foreach ($unusedPackages as $unusedPackage) {
-    $configuration->ignoreErrorsOnPackage($unusedPackage, [ErrorType::UNUSED_DEPENDENCY]);
-}
-
-return $configuration
-    ->ignoreErrorsOnExtension('ext-pcntl', [ErrorType::SHADOW_DEPENDENCY]);
+return ComposerDependencyAnalyserConfig::configure();

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+$configuration = new Configuration();
+
+$unusedPackages = [
+    'ergebnis/composer-normalize',
+    'fakerphp/faker',
+    'fast-forward/phpdoc-bootstrap-template',
+    'php-parallel-lint/php-parallel-lint',
+    'phpdocumentor/shim',
+    'phpmetrics/phpmetrics',
+    'phpro/grumphp-shim',
+    'pyrech/composer-changelogs',
+    'rector/jack',
+    'saggre/phpdocumentor-markdown',
+    'shipmonk/composer-dependency-analyser',
+    'symfony/var-dumper',
+];
+
+foreach ($unusedPackages as $unusedPackage) {
+    $configuration->ignoreErrorsOnPackage($unusedPackage, [ErrorType::UNUSED_DEPENDENCY]);
+}
+
+return $configuration
+    ->ignoreErrorsOnExtension('ext-pcntl', [ErrorType::SHADOW_DEPENDENCY]);

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "rector/jack": "^0.5",
         "rector/rector": "^2.4",
         "saggre/phpdocumentor-markdown": "^1.0",
-        "sebastian/diff": "^7.0",
+        "sebastian/diff": "^7.0 || ^8.0",
         "shipmonk/composer-dependency-analyser": "^1.8.4",
         "symfony/config": "^7.4 || ^8.0",
         "symfony/console": "^7.4 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "fakerphp/faker": "^1.24",
         "fast-forward/phpdoc-bootstrap-template": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.95",
-        "icanhazstring/composer-unused": "^0.9.6",
         "jolicode/jolinotif": "^3.3",
         "nikic/php-parser": "^5.7",
         "php-di/php-di": "^7.1",

--- a/docs/api/commands.rst
+++ b/docs/api/commands.rst
@@ -47,7 +47,7 @@ subprocess execution is needed.
      - Runs PHPUnit with optional coverage output.
    * - ``FastForward\DevTools\Console\Command\DependenciesCommand``
      - ``dependencies``
-     - Reports missing, unused, and outdated Composer dependencies.
+     - Reports missing, unused, misplaced, and outdated Composer dependencies.
    * - ``FastForward\DevTools\Console\Command\MetricsCommand``
      - ``metrics``
      - Builds the PhpMetrics site and JSON artifacts for the current project.

--- a/docs/commands/dependencies.rst
+++ b/docs/commands/dependencies.rst
@@ -114,6 +114,9 @@ Behavior
 - ``composer-dependency-analyser`` is configured with:
   - ``--config composer-dependency-analyser.php`` (resolved through the package
     file locator so consumer repositories can override it locally)
+  - the packaged ``composer-dependency-analyser.php`` delegates to
+    ``FastForward\DevTools\Config\ComposerDependencyAnalyserConfig`` so
+    consumer repositories can extend the baseline instead of copying it whole
   - ``--dump-usages <package>`` and ``--show-all-usages`` when ``--dump-usage``
     is passed to the DevTools command
 - ``jack breakpoint`` maps ``--max-outdated`` to Jack's ``--limit`` option.

--- a/docs/commands/dependencies.rst
+++ b/docs/commands/dependencies.rst
@@ -1,16 +1,15 @@
 dependencies
 =============
 
-Analyzes missing, unused, and outdated Composer dependencies.
+Analyzes missing, unused, misplaced, and outdated Composer dependencies.
 
 Description
 -----------
 
-The ``dependencies`` command (alias: ``deps``) analyzes missing, unused, and
-overly outdated Composer dependencies using three tools:
+The ``dependencies`` command (alias: ``deps``) analyzes missing, unused,
+misplaced, and overly outdated Composer dependencies using two tools:
 
-- ``composer-unused`` - detects unused packages
-- ``composer-dependency-analyser`` - detects missing packages
+- ``composer-dependency-analyser`` - detects missing, unused, and misplaced packages
 - ``jack breakpoint`` - fails when too many outdated packages accumulate
 
 These analyzers ship as direct dependencies of ``fast-forward/dev-tools``, so
@@ -91,7 +90,7 @@ Exit Codes
    * - Code
      - Meaning
    * - 0
-     - Success. No missing, unused, or excessive outdated dependencies.
+     - Success. No missing, unused, misplaced, or excessive outdated dependencies.
    * - 1
      - Failure. A dependency analyzer or Jack reported findings or errors.
 
@@ -100,14 +99,15 @@ Behavior
 
 - Always previews or applies ``jack raise-to-installed`` first and then
   ``jack open-versions`` before running the analyzers.
-- Runs ``composer-unused``, ``composer-dependency-analyser``, and
-  ``jack breakpoint`` after the Jack preview or upgrade phase.
+- Runs ``composer-dependency-analyser`` and ``jack breakpoint`` after the Jack
+  preview or upgrade phase.
 - ``composer-dependency-analyser`` is configured with:
-  - ``--ignore-unused-deps`` (leaves unused detection to ``composer-unused``)
+  - ``--config composer-dependency-analyser.php`` (resolved through the package
+    file locator so consumer repositories can override it locally)
   - ``--ignore-prod-only-in-dev-deps`` (ignores dev-only usage in production code)
 - ``jack breakpoint`` maps ``--max-outdated`` to Jack's ``--limit`` option.
 - ``--upgrade`` applies Jack's ``raise-to-installed`` and ``open-versions``
   commands before ``composer update -W`` and ``composer normalize``.
-- Returns a non-zero exit code when missing, unused, or too many outdated
-  dependencies are found.
-- All three tools must be available in ``vendor/bin/``.
+- Returns a non-zero exit code when missing, unused, misplaced, or too many
+  outdated dependencies are found.
+- Both tools must be available in ``vendor/bin/``.

--- a/docs/commands/dependencies.rst
+++ b/docs/commands/dependencies.rst
@@ -34,6 +34,9 @@ Options
 
    Default: ``5``.
 
+   Use ``-1`` to keep the outdated dependency report in the output while
+   ignoring Jack failures in the final command status.
+
 ``--upgrade`` (optional)
    Applies the Jack upgrade workflow before the analyzers:
 
@@ -66,6 +69,12 @@ Allow up to 10 outdated packages:
 .. code-block:: bash
 
    composer dependencies --max-outdated=10
+
+Report outdated packages without failing on their count:
+
+.. code-block:: bash
+
+   composer dependencies --max-outdated=-1
 
 Preview the upgrade workflow:
 
@@ -120,6 +129,9 @@ Behavior
   - ``--dump-usages <package>`` and ``--show-all-usages`` when ``--dump-usage``
     is passed to the DevTools command
 - ``jack breakpoint`` maps ``--max-outdated`` to Jack's ``--limit`` option.
+- ``--max-outdated=-1`` keeps ``jack breakpoint`` in the workflow for reporting,
+  but its failure is ignored so only missing or unused dependency findings fail
+  the command.
 - ``--upgrade`` applies Jack's ``raise-to-installed`` and ``open-versions``
   commands before ``composer update -W`` and ``composer normalize``.
 - Returns a non-zero exit code when missing, unused, misplaced, or too many

--- a/docs/commands/dependencies.rst
+++ b/docs/commands/dependencies.rst
@@ -48,6 +48,10 @@ Options
 ``--dev`` (optional)
    Prioritizes dev dependencies where Jack supports it.
 
+``--dump-usage=<package>`` (optional)
+   Asks ``composer-dependency-analyser`` to dump usages for the given package
+   or wildcard pattern and enables ``--show-all-usages`` automatically.
+
 Examples
 --------
 
@@ -68,6 +72,12 @@ Preview the upgrade workflow:
 .. code-block:: bash
 
    composer dependencies --dev
+
+Dump all matched usages for one package:
+
+.. code-block:: bash
+
+   composer dependencies --dump-usage=symfony/console
 
 Apply the upgrade workflow and then analyze dependencies:
 
@@ -104,7 +114,8 @@ Behavior
 - ``composer-dependency-analyser`` is configured with:
   - ``--config composer-dependency-analyser.php`` (resolved through the package
     file locator so consumer repositories can override it locally)
-  - ``--ignore-prod-only-in-dev-deps`` (ignores dev-only usage in production code)
+  - ``--dump-usages <package>`` and ``--show-all-usages`` when ``--dump-usage``
+    is passed to the DevTools command
 - ``jack breakpoint`` maps ``--max-outdated`` to Jack's ``--limit`` option.
 - ``--upgrade`` applies Jack's ``raise-to-installed`` and ``open-versions``
   commands before ``composer update -W`` and ``composer normalize``.

--- a/docs/configuration/overriding-defaults.rst
+++ b/docs/configuration/overriding-defaults.rst
@@ -35,6 +35,9 @@ Commands and Their Configuration Files
    * - ``tests``
      - ``phpunit.xml``
      - Falls back to the packaged PHPUnit configuration.
+   * - ``dependencies``
+     - ``composer-dependency-analyser.php``
+     - Falls back to the packaged Composer Dependency Analyser configuration.
    * - ``phpdoc``
      - ``.php-cs-fixer.dist.php`` and ``rector.php``
      - Falls back to the packaged files; ``.docheader`` is created locally
@@ -110,6 +113,33 @@ This approach:
 - Eliminates duplication of the base configuration
 - Automatically receives upstream updates
 - Only requires overriding what is needed
+
+Extending Composer Dependency Analyser Configuration
+----------------------------------------------------
+
+Instead of copying the entire ``composer-dependency-analyser.php`` file,
+consumers can extend the default configuration using the
+``ComposerDependencyAnalyserConfig`` class:
+
+.. code-block:: php
+
+   <?php
+
+   use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+   use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+   use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+   return ComposerDependencyAnalyserConfig::configure(
+       static function (Configuration $configuration): void {
+           $configuration->ignoreErrorsOnPackage(
+               'vendor/package',
+               [ErrorType::UNUSED_DEPENDENCY],
+           );
+       }
+   );
+
+This approach keeps the Fast Forward baseline while letting consumer
+repositories add project-specific ignores or scan rules.
 
 What Is Not Overwritten Automatically
 --------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -142,6 +142,30 @@ Use the ``RectorConfig`` class to extend instead of replace:
 
 This approach automatically receives upstream updates while allowing additive customization.
 
+How do I extend the dependency analyser configuration without copying the whole file?
+-------------------------------------------------------------------------------------
+
+Use the ``ComposerDependencyAnalyserConfig`` class to extend instead of replace:
+
+.. code-block:: php
+
+   <?php
+
+   use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+   use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+   use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+   return ComposerDependencyAnalyserConfig::configure(
+       static function (Configuration $configuration): void {
+           $configuration->ignoreErrorsOnPackage(
+               'vendor/package',
+               [ErrorType::UNUSED_DEPENDENCY],
+           );
+       }
+   );
+
+This keeps the packaged baseline while allowing project-specific analyser ignores.
+
 Can I generate coverage without running the full ``standards`` pipeline?
 ------------------------------------------------------------------------
 

--- a/docs/links/dependencies.rst
+++ b/docs/links/dependencies.rst
@@ -36,10 +36,8 @@ QA and Refactoring
      - Extends the default Rector configuration with shared rules.
    * - ``friendsofphp/php-cs-fixer``
      - Powers the PHPDoc fixer phase.
-   * - ``icanhazstring/composer-unused``
-     - Reports unused Composer dependencies in ``dependencies``.
    * - ``shipmonk/composer-dependency-analyser``
-     - Reports missing Composer dependencies in ``dependencies``.
+     - Reports missing, unused, and misplaced Composer dependencies in ``dependencies``.
    * - ``rector/jack``
      - Previews or applies dependency version updates and enforces the
        outdated dependency threshold.

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -56,6 +56,7 @@ Analyzes missing, unused, misplaced, and outdated Composer dependencies.
 
    composer dependencies
    composer dependencies --max-outdated=10
+   composer dependencies --max-outdated=-1
    composer dependencies --dev
    composer dependencies --dump-usage=symfony/console
    composer dependencies --upgrade --dev
@@ -71,6 +72,8 @@ Important details:
   ``composer-dependency-analyser --dump-usages <package> --show-all-usages``;
 - it uses ``jack breakpoint --limit=<max-outdated>`` to fail when too many
   outdated dependencies accumulate;
+- ``--max-outdated=-1`` keeps the Jack outdated report in the output but
+  ignores Jack's failure so only dependency-analyser findings fail the command;
 - it previews ``jack raise-to-installed`` and ``jack open-versions`` before
   the analyzers;
 - ``--upgrade`` runs ``jack raise-to-installed``, ``jack open-versions``,

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -50,7 +50,7 @@ Important details:
 ``dependencies``
 ----------------
 
-Analyzes missing, unused, and outdated Composer dependencies.
+Analyzes missing, unused, misplaced, and outdated Composer dependencies.
 
 .. code-block:: bash
 
@@ -61,19 +61,19 @@ Analyzes missing, unused, and outdated Composer dependencies.
 
 Important details:
 
-- it ships ``shipmonk/composer-dependency-analyser`` and
-  ``icanhazstring/composer-unused`` and ``rector/jack`` as direct dependencies of
-  ``fast-forward/dev-tools``;
-- it uses ``composer-dependency-analyser`` only for missing dependency checks
-  and leaves unused-package reporting to ``composer-unused``;
+- it ships ``shipmonk/composer-dependency-analyser`` and ``rector/jack`` as
+  direct dependencies of ``fast-forward/dev-tools``;
+- it uses ``composer-dependency-analyser`` for missing, unused, and misplaced
+  dependency checks, with a packaged config that consumer repositories can
+  override locally;
 - it uses ``jack breakpoint --limit=<max-outdated>`` to fail when too many
   outdated dependencies accumulate;
 - it previews ``jack raise-to-installed`` and ``jack open-versions`` before
   the analyzers;
 - ``--upgrade`` runs ``jack raise-to-installed``, ``jack open-versions``,
   ``composer update -W``, and ``composer normalize`` before the analyzers;
-- it returns a non-zero exit code when missing, unused, or too many outdated
-  dependencies are found.
+- it returns a non-zero exit code when missing, unused, misplaced, or too many
+  outdated dependencies are found.
 
 ``metrics``
 -----------

--- a/docs/running/specialized-commands.rst
+++ b/docs/running/specialized-commands.rst
@@ -57,6 +57,7 @@ Analyzes missing, unused, misplaced, and outdated Composer dependencies.
    composer dependencies
    composer dependencies --max-outdated=10
    composer dependencies --dev
+   composer dependencies --dump-usage=symfony/console
    composer dependencies --upgrade --dev
 
 Important details:
@@ -66,6 +67,8 @@ Important details:
 - it uses ``composer-dependency-analyser`` for missing, unused, and misplaced
   dependency checks, with a packaged config that consumer repositories can
   override locally;
+- ``--dump-usage=<package>`` forwards to
+  ``composer-dependency-analyser --dump-usages <package> --show-all-usages``;
 - it uses ``jack breakpoint --limit=<max-outdated>`` to fail when too many
   outdated dependencies accumulate;
 - it previews ``jack raise-to-installed`` and ``jack open-versions`` before

--- a/resources/github-actions/tests.yml
+++ b/resources/github-actions/tests.yml
@@ -4,16 +4,11 @@ on:
   push:
   workflow_dispatch:
     inputs:
-      run-dependencies-check:
-        description: Whether to run the dependency health check during CI.
-        required: false
-        type: boolean
-        default: true
       max-outdated:
         description: Maximum number of outdated packages allowed by the dependencies command.
         required: false
         type: number
-        default: 5
+        default: -1
 
 permissions:
   contents: read
@@ -22,6 +17,5 @@ jobs:
   tests:
     uses: php-fast-forward/dev-tools/.github/workflows/tests.yml@main
     with:
-      run-dependencies-check: ${{ inputs.run-dependencies-check || true }}
-      max-outdated: ${{ inputs.max-outdated || 5 }}
+      max-outdated: ${{ inputs.max-outdated || -1 }}
     secrets: inherit

--- a/src/Config/ComposerDependencyAnalyserConfig.php
+++ b/src/Config/ComposerDependencyAnalyserConfig.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Config;
+
+use FastForward\DevTools\Composer\Json\ComposerJson;
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+/**
+ * Provides the default Composer Dependency Analyser configuration.
+ *
+ * Consumers can use this as a starting point and extend it:
+ *
+ *     return \FastForward\DevTools\Config\ComposerDependencyAnalyserConfig::configure(
+ *         static function (\ShipMonk\ComposerDependencyAnalyser\Config\Configuration $configuration): void {
+ *             $configuration->ignoreErrorsOnPackage(
+ *                 'vendor/package',
+ *                 [\ShipMonk\ComposerDependencyAnalyser\Config\ErrorType::UNUSED_DEPENDENCY]
+ *             );
+ *         }
+ *     );
+ *
+ * @see https://github.com/shipmonk-rnd/composer-dependency-analyser
+ */
+final class ComposerDependencyAnalyserConfig
+{
+    private const string PACKAGE_NAME = 'fast-forward/dev-tools';
+
+    /**
+     * Dependencies that are only required by the packaged DevTools distribution itself.
+     *
+     * These packages MUST only be ignored when the analyser runs against the
+     * DevTools repository, because consumer repositories do not inherit them as
+     * direct requirements automatically.
+     *
+     * @var array<int, string>
+     */
+    private const array PACKAGED_UNUSED_DEPENDENCIES = [
+        'ergebnis/composer-normalize',
+        'fakerphp/faker',
+        'fast-forward/phpdoc-bootstrap-template',
+        'php-parallel-lint/php-parallel-lint',
+        'phpdocumentor/shim',
+        'phpmetrics/phpmetrics',
+        'phpro/grumphp-shim',
+        'pyrech/composer-changelogs',
+        'rector/jack',
+        'saggre/phpdocumentor-markdown',
+        'symfony/var-dumper',
+    ];
+
+    /**
+     * Production dependencies intentionally kept in require for the packaged toolchain.
+     *
+     * These dependencies are only exercised in test and development paths inside
+     * this repository, but they MUST remain available to the packaged DevTools
+     * runtime for consumer projects that choose to use those capabilities.
+     *
+     * @var array<int, string>
+     */
+    private const array PACKAGED_PROD_ONLY_IN_DEV_DEPENDENCIES = [
+        'phpspec/prophecy',
+        'phpspec/prophecy-phpunit',
+        'symfony/var-exporter',
+    ];
+
+    /**
+     * Creates the default Composer Dependency Analyser configuration.
+     *
+     * @param callable|null $customize optional callback to customize the configuration
+     *
+     * @return Configuration the configured analyser configuration
+     */
+    public static function configure(?callable $customize = null): Configuration
+    {
+        $configuration = new Configuration();
+
+        if (self::isDevToolsRepository()) {
+            self::configurePackagedRepositoryIgnores($configuration);
+        }
+
+        if (null !== $customize) {
+            $customize($configuration);
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * Applies the ignores required only by the packaged DevTools repository.
+     *
+     * @param Configuration $configuration the analyser configuration to customize
+     *
+     * @return void
+     */
+    private static function configurePackagedRepositoryIgnores(Configuration $configuration): void
+    {
+        $configuration->ignoreErrorsOnExtension('ext-pcntl', [ErrorType::SHADOW_DEPENDENCY]);
+        $configuration->ignoreErrorsOnPackages(self::PACKAGED_UNUSED_DEPENDENCIES, [ErrorType::UNUSED_DEPENDENCY]);
+        $configuration->ignoreErrorsOnPackages(
+            self::PACKAGED_PROD_ONLY_IN_DEV_DEPENDENCIES,
+            [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV],
+        );
+    }
+
+    /**
+     * Detects whether the analyser is running inside the DevTools repository itself.
+     *
+     * @return bool true when the current project is fast-forward/dev-tools
+     */
+    private static function isDevToolsRepository(): bool
+    {
+        $composer = new ComposerJson();
+
+        return self::PACKAGE_NAME === $composer->getName();
+    }
+}

--- a/src/Config/ComposerDependencyAnalyserConfig.php
+++ b/src/Config/ComposerDependencyAnalyserConfig.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Config;
 
-use FastForward\DevTools\Composer\Json\ComposerJson;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
@@ -41,7 +40,8 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
  */
 final class ComposerDependencyAnalyserConfig
 {
-    private const string PACKAGE_NAME = 'fast-forward/dev-tools';
+    private const string VENDOR_PACKAGE_PATH = \DIRECTORY_SEPARATOR . 'vendor' . \DIRECTORY_SEPARATOR
+        . 'fast-forward' . \DIRECTORY_SEPARATOR . 'dev-tools';
 
     /**
      * Dependencies that are only required by the packaged DevTools distribution itself.
@@ -92,7 +92,7 @@ final class ComposerDependencyAnalyserConfig
     {
         $configuration = new Configuration();
 
-        if (self::isDevToolsRepository()) {
+        if (self::isDevToolsRepository(__DIR__)) {
             self::configurePackagedRepositoryIgnores($configuration);
         }
 
@@ -123,12 +123,24 @@ final class ComposerDependencyAnalyserConfig
     /**
      * Detects whether the analyser is running inside the DevTools repository itself.
      *
-     * @return bool true when the current project is fast-forward/dev-tools
+     * @param string $configDirectory the directory where the config class is loaded from
+     *
+     * @return bool true when the config is loaded from the repository checkout itself
      */
-    private static function isDevToolsRepository(): bool
+    private static function isDevToolsRepository(string $configDirectory): bool
     {
-        $composer = new ComposerJson();
+        return ! self::isInstalledAsDependency($configDirectory);
+    }
 
-        return self::PACKAGE_NAME === $composer->getName();
+    /**
+     * Detects whether the packaged config is being loaded from a consumer vendor directory.
+     *
+     * @param string $configDirectory the directory where the config class is loaded from
+     *
+     * @return bool true when DevTools is being used from vendor/fast-forward/dev-tools
+     */
+    private static function isInstalledAsDependency(string $configDirectory): bool
+    {
+        return str_contains($configDirectory, self::VENDOR_PACKAGE_PATH);
     }
 }

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -47,6 +47,8 @@ final class DependenciesCommand extends BaseCommand
 {
     private const string ANALYSER_CONFIG = 'composer-dependency-analyser.php';
 
+    private const int DISABLE_OUTDATED_THRESHOLD = -1;
+
     /**
      * @param ProcessBuilderInterface $processBuilder creates analyzer and upgrade processes
      * @param ProcessQueueInterface $processQueue executes queued processes
@@ -69,7 +71,7 @@ final class DependenciesCommand extends BaseCommand
             ->addOption(
                 name: 'max-outdated',
                 mode: InputOption::VALUE_REQUIRED,
-                description: 'Maximum number of outdated packages allowed by jack breakpoint.',
+                description: 'Maximum number of outdated packages allowed by jack breakpoint. Use -1 to keep the report but ignore Jack failures.',
                 default: '5',
             )
             ->addOption(
@@ -118,7 +120,10 @@ final class DependenciesCommand extends BaseCommand
         $output->writeln('<info>Running dependency analysis...</info>');
 
         $this->processQueue->add($this->getComposerDependencyAnalyserCommand($input));
-        $this->processQueue->add($this->getJackBreakpointCommand($input, $maximumOutdated));
+        $this->processQueue->add(
+            $this->getJackBreakpointCommand($input, $maximumOutdated),
+            $this->shouldIgnoreOutdatedFailures($maximumOutdated),
+        );
 
         return $this->processQueue->run($output);
     }
@@ -162,7 +167,9 @@ final class DependenciesCommand extends BaseCommand
             $command .= ' --dev';
         }
 
-        $command .= ' --limit ' . $maximumOutdated;
+        if (! $this->shouldIgnoreOutdatedFailures($maximumOutdated)) {
+            $command .= ' --limit ' . $maximumOutdated;
+        }
 
         return $this->processBuilder->build($command);
     }
@@ -252,10 +259,22 @@ final class DependenciesCommand extends BaseCommand
 
         $maximumOutdated = (int) $maximumOutdated;
 
-        if (0 > $maximumOutdated) {
-            throw new InvalidArgumentException('The --max-outdated option MUST be zero or greater.');
+        if (self::DISABLE_OUTDATED_THRESHOLD > $maximumOutdated) {
+            throw new InvalidArgumentException('The --max-outdated option MUST be -1 or greater.');
         }
 
         return $maximumOutdated;
+    }
+
+    /**
+     * Determines whether Jack outdated failures SHOULD be ignored for the given threshold.
+     *
+     * @param int $maximumOutdated the validated outdated threshold option
+     *
+     * @return bool true when the outdated threshold is explicitly disabled
+     */
+    private function shouldIgnoreOutdatedFailures(int $maximumOutdated): bool
+    {
+        return self::DISABLE_OUTDATED_THRESHOLD === $maximumOutdated;
     }
 }

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -81,6 +81,11 @@ final class DependenciesCommand extends BaseCommand
                 name: 'upgrade',
                 mode: InputOption::VALUE_NONE,
                 description: 'Apply Jack dependency upgrades before executing the dependency analyzers.',
+            )
+            ->addOption(
+                name: 'dump-usage',
+                mode: InputOption::VALUE_REQUIRED,
+                description: 'Dump usages for the given package pattern and show all matched usages.',
             );
     }
 
@@ -112,7 +117,7 @@ final class DependenciesCommand extends BaseCommand
 
         $output->writeln('<info>Running dependency analysis...</info>');
 
-        $this->processQueue->add($this->getComposerDependencyAnalyserCommand());
+        $this->processQueue->add($this->getComposerDependencyAnalyserCommand($input));
         $this->processQueue->add($this->getJackBreakpointCommand($input, $maximumOutdated));
 
         return $this->processQueue->run($output);
@@ -121,14 +126,24 @@ final class DependenciesCommand extends BaseCommand
     /**
      * Builds the Composer Dependency Analyser process.
      *
+     * @param InputInterface $input the runtime command input
+     *
      * @return Process the configured Composer Dependency Analyser process
      */
-    private function getComposerDependencyAnalyserCommand(): Process
+    private function getComposerDependencyAnalyserCommand(InputInterface $input): Process
     {
-        return $this->processBuilder
-            ->withArgument('--config', $this->fileLocator->locate(self::ANALYSER_CONFIG))
-            ->withArgument('--ignore-prod-only-in-dev-deps')
-            ->build('vendor/bin/composer-dependency-analyser');
+        $processBuilder = $this->processBuilder
+            ->withArgument('--config', $this->fileLocator->locate(self::ANALYSER_CONFIG));
+
+        $dumpUsage = $input->getOption('dump-usage');
+
+        if (\is_string($dumpUsage) && '' !== $dumpUsage) {
+            $processBuilder = $processBuilder
+                ->withArgument('--dump-usages', $dumpUsage)
+                ->withArgument('--show-all-usages');
+        }
+
+        return $processBuilder->build('vendor/bin/composer-dependency-analyser');
     }
 
     /**

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -23,6 +23,7 @@ use Composer\Command\BaseCommand;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use InvalidArgumentException;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,24 +34,28 @@ use function is_numeric;
 
 /**
  * Orchestrates dependency analysis across the supported Composer analyzers.
- * This command MUST report missing and unused dependencies using a single,
+ * This command MUST report missing, unused, and misplaced dependencies using a single,
  * deterministic report that is friendly for local development and CI runs.
  */
 #[AsCommand(
     name: 'dependencies',
-    description: 'Analyzes missing, unused, and outdated Composer dependencies.',
+    description: 'Analyzes missing, unused, misplaced, and outdated Composer dependencies.',
     aliases: ['deps'],
-    help: 'This command runs composer-dependency-analyser, composer-unused, and Jack to report missing, unused, and outdated Composer dependencies.'
+    help: 'This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.'
 )]
 final class DependenciesCommand extends BaseCommand
 {
+    private const string ANALYSER_CONFIG = 'composer-dependency-analyser.php';
+
     /**
      * @param ProcessBuilderInterface $processBuilder creates analyzer and upgrade processes
      * @param ProcessQueueInterface $processQueue executes queued processes
+     * @param FileLocatorInterface $fileLocator resolves the dependency analyser configuration
      */
     public function __construct(
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
+        private readonly FileLocatorInterface $fileLocator,
     ) {
         return parent::__construct();
     }
@@ -107,7 +112,6 @@ final class DependenciesCommand extends BaseCommand
 
         $output->writeln('<info>Running dependency analysis...</info>');
 
-        $this->processQueue->add($this->getComposerUnusedCommand());
         $this->processQueue->add($this->getComposerDependencyAnalyserCommand());
         $this->processQueue->add($this->getJackBreakpointCommand($input, $maximumOutdated));
 
@@ -122,7 +126,7 @@ final class DependenciesCommand extends BaseCommand
     private function getComposerDependencyAnalyserCommand(): Process
     {
         return $this->processBuilder
-            ->withArgument('--ignore-unused-deps')
+            ->withArgument('--config', $this->fileLocator->locate(self::ANALYSER_CONFIG))
             ->withArgument('--ignore-prod-only-in-dev-deps')
             ->build('vendor/bin/composer-dependency-analyser');
     }
@@ -214,16 +218,6 @@ final class DependenciesCommand extends BaseCommand
     private function getComposerNormalizeCommand(): Process
     {
         return $this->processBuilder->build('composer normalize');
-    }
-
-    /**
-     * Builds the composer-unused process.
-     *
-     * @return Process the configured composer-unused process
-     */
-    private function getComposerUnusedCommand(): Process
-    {
-        return $this->processBuilder->build('vendor/bin/composer-unused');
     }
 
     /**

--- a/tests/Config/ComposerDependencyAnalyserConfigTest.php
+++ b/tests/Config/ComposerDependencyAnalyserConfigTest.php
@@ -19,72 +19,17 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Config;
 
-use FastForward\DevTools\Composer\Json\ComposerJson;
 use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
-use function Safe\json_encode;
-use function Safe\chdir;
-use function Safe\file_put_contents;
-use function Safe\getcwd;
-use function Safe\mkdir;
-use function Safe\rmdir;
-use function Safe\unlink;
-
 #[CoversClass(ComposerDependencyAnalyserConfig::class)]
-#[UsesClass(ComposerJson::class)]
 final class ComposerDependencyAnalyserConfigTest extends TestCase
 {
-    private string $workingDirectory;
-
-    /**
-     * @var array<int, string>
-     */
-    private array $temporaryProjectRoots = [];
-
-    /**
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        $this->workingDirectory = getcwd();
-    }
-
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        chdir($this->workingDirectory);
-
-        foreach ($this->temporaryProjectRoots as $temporaryProjectRoot) {
-            if (file_exists($temporaryProjectRoot . '/composer.json')) {
-                unlink($temporaryProjectRoot . '/composer.json');
-            }
-
-            if (file_exists($temporaryProjectRoot . '/vendor/composer/installed.json')) {
-                unlink($temporaryProjectRoot . '/vendor/composer/installed.json');
-            }
-
-            if (is_dir($temporaryProjectRoot . '/vendor/composer')) {
-                rmdir($temporaryProjectRoot . '/vendor/composer');
-            }
-
-            if (is_dir($temporaryProjectRoot . '/vendor')) {
-                rmdir($temporaryProjectRoot . '/vendor');
-            }
-
-            if (is_dir($temporaryProjectRoot)) {
-                rmdir($temporaryProjectRoot);
-            }
-        }
-    }
-
     /**
      * @return void
      */
@@ -100,7 +45,7 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
      * @return void
      */
     #[Test]
-    public function configureWillApplySharedIgnoresAndInvokeCustomizationCallback(): void
+    public function configureWillApplyRepositoryIgnoresAndInvokeCustomizationCallback(): void
     {
         $customizeWasCalled = false;
 
@@ -118,6 +63,10 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
         );
         self::assertTrue(
             $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'rector/jack')
+        );
+        self::assertTrue(
+            $configuration->getIgnoreList()
                 ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'vendor/custom-package')
         );
     }
@@ -126,70 +75,38 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
      * @return void
      */
     #[Test]
-    public function configureWillNotApplyPackagedRepositoryIgnoresForConsumerProjects(): void
+    public function isInstalledAsDependencyWillDetectVendorPackagePaths(): void
     {
-        $consumerRoot = $this->createTemporaryProjectRoot('vendor/consumer-project');
-
-        chdir($consumerRoot);
-
-        $configuration = ComposerDependencyAnalyserConfig::configure();
-
-        self::assertFalse(
-            $configuration->getIgnoreList()
-                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'shipmonk/composer-dependency-analyser'),
-        );
-        self::assertFalse(
-            $configuration->getIgnoreList()
-                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'phpspec/prophecy'),
-        );
+        self::assertFalse($this->invokeDetector('isInstalledAsDependency', '/workspaces/dev-tools/src/Config'));
+        self::assertTrue($this->invokeDetector(
+            'isInstalledAsDependency',
+            '/workspaces/project/vendor/fast-forward/dev-tools/src/Config',
+        ));
     }
 
     /**
      * @return void
      */
     #[Test]
-    public function configureWillApplyPackagedRepositorySpecificIgnoresForDevTools(): void
+    public function isDevToolsRepositoryWillDetectRepositoryPaths(): void
     {
-        $packageRoot = $this->createTemporaryProjectRoot('fast-forward/dev-tools');
-
-        chdir($packageRoot);
-
-        $configuration = ComposerDependencyAnalyserConfig::configure();
-
-        self::assertTrue(
-            $configuration->getIgnoreList()
-                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'rector/jack'),
-        );
-        self::assertTrue(
-            $configuration->getIgnoreList()
-                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'phpspec/prophecy'),
-        );
-        self::assertTrue(
-            $configuration->getIgnoreList()
-                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'symfony/var-exporter'),
-        );
+        self::assertTrue($this->invokeDetector('isDevToolsRepository', '/workspaces/dev-tools/src/Config'));
+        self::assertFalse($this->invokeDetector(
+            'isDevToolsRepository',
+            '/workspaces/project/vendor/fast-forward/dev-tools/src/Config',
+        ));
     }
 
     /**
-     * @param string $packageName
+     * @param string $methodName
+     * @param string $configDirectory
      *
-     * @return string
+     * @return bool
      */
-    private function createTemporaryProjectRoot(string $packageName): string
+    private function invokeDetector(string $methodName, string $configDirectory): bool
     {
-        $path = sys_get_temp_dir() . '/dev-tools-dependency-config-' . md5($packageName . microtime(true));
+        $reflectionMethod = new ReflectionMethod(ComposerDependencyAnalyserConfig::class, $methodName);
 
-        mkdir($path);
-        mkdir($path . '/vendor');
-        mkdir($path . '/vendor/composer');
-        file_put_contents($path . '/composer.json', json_encode([
-            'name' => $packageName,
-        ], \JSON_THROW_ON_ERROR));
-        file_put_contents($path . '/vendor/composer/installed.json', json_encode([
-            'packages' => [],
-        ], \JSON_THROW_ON_ERROR));
-        $this->temporaryProjectRoots[] = $path;
-
-        return $path;
+        return $reflectionMethod->invoke(null, $configDirectory);
     }
 }

--- a/tests/Config/ComposerDependencyAnalyserConfigTest.php
+++ b/tests/Config/ComposerDependencyAnalyserConfigTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Config;
+
+use FastForward\DevTools\Composer\Json\ComposerJson;
+use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+use function Safe\json_encode;
+use function Safe\chdir;
+use function Safe\file_put_contents;
+use function Safe\getcwd;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
+
+#[CoversClass(ComposerDependencyAnalyserConfig::class)]
+#[UsesClass(ComposerJson::class)]
+final class ComposerDependencyAnalyserConfigTest extends TestCase
+{
+    private string $workingDirectory;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $temporaryProjectRoots = [];
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->workingDirectory = getcwd();
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        chdir($this->workingDirectory);
+
+        foreach ($this->temporaryProjectRoots as $temporaryProjectRoot) {
+            if (file_exists($temporaryProjectRoot . '/composer.json')) {
+                unlink($temporaryProjectRoot . '/composer.json');
+            }
+
+            if (file_exists($temporaryProjectRoot . '/vendor/composer/installed.json')) {
+                unlink($temporaryProjectRoot . '/vendor/composer/installed.json');
+            }
+
+            if (is_dir($temporaryProjectRoot . '/vendor/composer')) {
+                rmdir($temporaryProjectRoot . '/vendor/composer');
+            }
+
+            if (is_dir($temporaryProjectRoot . '/vendor')) {
+                rmdir($temporaryProjectRoot . '/vendor');
+            }
+
+            if (is_dir($temporaryProjectRoot)) {
+                rmdir($temporaryProjectRoot);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configureWillReturnConfiguration(): void
+    {
+        $configuration = ComposerDependencyAnalyserConfig::configure();
+
+        self::assertInstanceOf(Configuration::class, $configuration);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configureWillApplySharedIgnoresAndInvokeCustomizationCallback(): void
+    {
+        $customizeWasCalled = false;
+
+        $configuration = ComposerDependencyAnalyserConfig::configure(
+            static function (Configuration $configuration) use (&$customizeWasCalled): void {
+                $customizeWasCalled = true;
+                $configuration->ignoreErrorsOnPackage('vendor/custom-package', [ErrorType::UNUSED_DEPENDENCY]);
+            },
+        );
+
+        self::assertTrue($customizeWasCalled);
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, 'ext-pcntl')
+        );
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'vendor/custom-package')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configureWillNotApplyPackagedRepositoryIgnoresForConsumerProjects(): void
+    {
+        $consumerRoot = $this->createTemporaryProjectRoot('vendor/consumer-project');
+
+        chdir($consumerRoot);
+
+        $configuration = ComposerDependencyAnalyserConfig::configure();
+
+        self::assertFalse(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'shipmonk/composer-dependency-analyser'),
+        );
+        self::assertFalse(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'phpspec/prophecy'),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function configureWillApplyPackagedRepositorySpecificIgnoresForDevTools(): void
+    {
+        $packageRoot = $this->createTemporaryProjectRoot('fast-forward/dev-tools');
+
+        chdir($packageRoot);
+
+        $configuration = ComposerDependencyAnalyserConfig::configure();
+
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::UNUSED_DEPENDENCY, null, 'rector/jack'),
+        );
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'phpspec/prophecy'),
+        );
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV, null, 'symfony/var-exporter'),
+        );
+    }
+
+    /**
+     * @param string $packageName
+     *
+     * @return string
+     */
+    private function createTemporaryProjectRoot(string $packageName): string
+    {
+        $path = sys_get_temp_dir() . '/dev-tools-dependency-config-' . md5($packageName . microtime(true));
+
+        mkdir($path);
+        mkdir($path . '/vendor');
+        mkdir($path . '/vendor/composer');
+        file_put_contents($path . '/composer.json', json_encode([
+            'name' => $packageName,
+        ], \JSON_THROW_ON_ERROR));
+        file_put_contents($path . '/vendor/composer/installed.json', json_encode([
+            'packages' => [],
+        ], \JSON_THROW_ON_ERROR));
+        $this->temporaryProjectRoots[] = $path;
+
+        return $path;
+    }
+}

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -121,7 +121,7 @@ final class DependenciesCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processBreakpoint->reveal())
+        $this->processQueue->add($this->processBreakpoint->reveal(), false)
             ->shouldBeCalledOnce();
         $this->processQueue->run($this->output->reveal())
             ->willReturn(ProcessQueueInterface::SUCCESS)
@@ -148,7 +148,7 @@ final class DependenciesCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processBreakpoint->reveal())
+        $this->processQueue->add($this->processBreakpoint->reveal(), false)
             ->shouldBeCalledOnce();
         $this->processQueue->run($this->output->reveal())
             ->willReturn(ProcessQueueInterface::FAILURE)
@@ -179,7 +179,7 @@ final class DependenciesCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processBreakpoint->reveal())
+        $this->processQueue->add($this->processBreakpoint->reveal(), false)
             ->shouldBeCalledOnce();
         $this->processQueue->run($this->output->reveal())
             ->willReturn(ProcessQueueInterface::SUCCESS)
@@ -210,6 +210,21 @@ final class DependenciesCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function executeWillFailWhenMaxOutdatedIsLowerThanMinusOne(): void
+    {
+        $this->input->getOption('max-outdated')
+            ->willReturn('-2');
+        $this->output->writeln('<error>The --max-outdated option MUST be -1 or greater.</error>')
+            ->shouldBeCalledOnce();
+        $this->processQueue->run(Argument::cetera())->shouldNotBeCalled();
+
+        self::assertSame(DependenciesCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWillDumpPackageUsagesAndShowAllMatchesWhenRequested(): void
     {
         $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: false, dumpUsage: 'symfony/console');
@@ -221,7 +236,34 @@ final class DependenciesCommandTest extends TestCase
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processBreakpoint->reveal())
+        $this->processQueue->add($this->processBreakpoint->reveal(), false)
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+
+        $this->output->writeln('<info>Running dependency analysis...</info>')
+            ->shouldBeCalledOnce();
+
+        self::assertSame(DependenciesCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillIgnoreJackFailuresWhenMaxOutdatedIsDisabled(): void
+    {
+        $this->configureBaseExecution(maxOutdated: '-1', upgrade: false, dev: false, dumpUsage: null);
+        $this->configurePreviewBuilders(dev: false, maxOutdated: '-1', dumpUsage: null);
+
+        $this->processQueue->add($this->processRaiseToInstalled->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processOpenVersions->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processDepAnalyser->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processBreakpoint->reveal(), true)
             ->shouldBeCalledOnce();
         $this->processQueue->run($this->output->reveal())
             ->willReturn(ProcessQueueInterface::SUCCESS)
@@ -291,7 +333,11 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($this->processDepAnalyser->reveal());
         $this->processBuilder
             ->build(
-                $dev ? 'vendor/bin/jack breakpoint --dev --limit ' . $maxOutdated : 'vendor/bin/jack breakpoint --limit ' . $maxOutdated
+                '-1' === $maxOutdated
+                    ? ($dev ? 'vendor/bin/jack breakpoint --dev' : 'vendor/bin/jack breakpoint')
+                    : ($dev
+                        ? 'vendor/bin/jack breakpoint --dev --limit ' . $maxOutdated
+                        : 'vendor/bin/jack breakpoint --limit ' . $maxOutdated)
             )
             ->willReturn($this->processBreakpoint->reveal());
     }
@@ -345,7 +391,11 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($this->processDepAnalyser->reveal());
         $this->processBuilder
             ->build(
-                $dev ? 'vendor/bin/jack breakpoint --dev --limit ' . $maxOutdated : 'vendor/bin/jack breakpoint --limit ' . $maxOutdated
+                '-1' === $maxOutdated
+                    ? ($dev ? 'vendor/bin/jack breakpoint --dev' : 'vendor/bin/jack breakpoint')
+                    : ($dev
+                        ? 'vendor/bin/jack breakpoint --dev --limit ' . $maxOutdated
+                        : 'vendor/bin/jack breakpoint --limit ' . $maxOutdated)
             )
             ->willReturn($this->processBreakpoint->reveal());
     }

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -112,8 +112,8 @@ final class DependenciesCommandTest extends TestCase
     #[Test]
     public function executeWillReturnSuccessWhenPreviewAndAnalyzersSucceed(): void
     {
-        $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: false);
-        $this->configurePreviewBuilders(dev: false, maxOutdated: '5');
+        $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: false, dumpUsage: null);
+        $this->configurePreviewBuilders(dev: false, maxOutdated: '5', dumpUsage: null);
 
         $this->processQueue->add($this->processRaiseToInstalled->reveal())
             ->shouldBeCalledOnce();
@@ -139,8 +139,8 @@ final class DependenciesCommandTest extends TestCase
     #[Test]
     public function executeWillReturnFailureWhenProcessQueueFails(): void
     {
-        $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: true);
-        $this->configurePreviewBuilders(dev: true, maxOutdated: '5');
+        $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: true, dumpUsage: null);
+        $this->configurePreviewBuilders(dev: true, maxOutdated: '5', dumpUsage: null);
 
         $this->processQueue->add($this->processRaiseToInstalled->reveal())
             ->shouldBeCalledOnce();
@@ -166,8 +166,8 @@ final class DependenciesCommandTest extends TestCase
     #[Test]
     public function executeWillQueueUpgradeWorkflowBeforeAnalysisWhenUpgradeIsRequested(): void
     {
-        $this->configureBaseExecution(maxOutdated: '8', upgrade: true, dev: true);
-        $this->configureUpgradeBuilders(dev: true, maxOutdated: '8');
+        $this->configureBaseExecution(maxOutdated: '8', upgrade: true, dev: true, dumpUsage: null);
+        $this->configureUpgradeBuilders(dev: true, maxOutdated: '8', dumpUsage: null);
 
         $this->processQueue->add($this->processRaiseToInstalled->reveal())
             ->shouldBeCalledOnce();
@@ -207,13 +207,41 @@ final class DependenciesCommandTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillDumpPackageUsagesAndShowAllMatchesWhenRequested(): void
+    {
+        $this->configureBaseExecution(maxOutdated: '5', upgrade: false, dev: false, dumpUsage: 'symfony/console');
+        $this->configurePreviewBuilders(dev: false, maxOutdated: '5', dumpUsage: 'symfony/console');
+
+        $this->processQueue->add($this->processRaiseToInstalled->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processOpenVersions->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processDepAnalyser->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->add($this->processBreakpoint->reveal())
+            ->shouldBeCalledOnce();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ProcessQueueInterface::SUCCESS)
+            ->shouldBeCalledOnce();
+
+        $this->output->writeln('<info>Running dependency analysis...</info>')
+            ->shouldBeCalledOnce();
+
+        self::assertSame(DependenciesCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
      * @param string $maxOutdated
      * @param bool $upgrade
      * @param bool $dev
+     * @param string|null $dumpUsage
      *
      * @return void
      */
-    private function configureBaseExecution(string $maxOutdated, bool $upgrade, bool $dev): void
+    private function configureBaseExecution(string $maxOutdated, bool $upgrade, bool $dev, ?string $dumpUsage): void
     {
         $this->input->getOption('max-outdated')
             ->willReturn($maxOutdated);
@@ -221,18 +249,22 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($upgrade);
         $this->input->getOption('dev')
             ->willReturn($dev);
+        $this->input->getOption('dump-usage')
+            ->willReturn($dumpUsage);
     }
 
     /**
      * @param bool $dev
      * @param string $maxOutdated
+     * @param string|null $dumpUsage
      *
      * @return void
      */
-    private function configurePreviewBuilders(bool $dev, string $maxOutdated): void
+    private function configurePreviewBuilders(bool $dev, string $maxOutdated, ?string $dumpUsage): void
     {
         $depAnalyserBuilder = $this->prophesize(ProcessBuilderInterface::class);
-        $depAnalyserFinalBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $depAnalyserCommandBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $depAnalyserFinalBuilder = null;
 
         $this->processBuilder
             ->build(
@@ -244,9 +276,18 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($this->processOpenVersions->reveal());
         $this->processBuilder->withArgument('--config', '/app/composer-dependency-analyser.php')
             ->willReturn($depAnalyserBuilder->reveal());
-        $depAnalyserBuilder->withArgument('--ignore-prod-only-in-dev-deps')
-            ->willReturn($depAnalyserFinalBuilder->reveal());
-        $depAnalyserFinalBuilder->build('vendor/bin/composer-dependency-analyser')
+
+        if (null !== $dumpUsage) {
+            $depAnalyserFinalBuilder = $this->prophesize(ProcessBuilderInterface::class);
+
+            $depAnalyserBuilder->withArgument('--dump-usages', $dumpUsage)
+                ->willReturn($depAnalyserCommandBuilder->reveal());
+            $depAnalyserCommandBuilder->withArgument('--show-all-usages')
+                ->willReturn($depAnalyserFinalBuilder->reveal());
+        }
+
+        ($depAnalyserFinalBuilder ?? $depAnalyserBuilder)
+            ->build('vendor/bin/composer-dependency-analyser')
             ->willReturn($this->processDepAnalyser->reveal());
         $this->processBuilder
             ->build(
@@ -258,16 +299,18 @@ final class DependenciesCommandTest extends TestCase
     /**
      * @param bool $dev
      * @param string $maxOutdated
+     * @param string|null $dumpUsage
      *
      * @return void
      */
-    private function configureUpgradeBuilders(bool $dev, string $maxOutdated): void
+    private function configureUpgradeBuilders(bool $dev, string $maxOutdated, ?string $dumpUsage): void
     {
         $composerUpdateWithDependenciesBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $composerUpdateAnsiBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $composerUpdateBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $depAnalyserBuilder = $this->prophesize(ProcessBuilderInterface::class);
-        $depAnalyserFinalBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $depAnalyserCommandBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $depAnalyserFinalBuilder = null;
 
         $this->processBuilder
             ->build($dev ? 'vendor/bin/jack raise-to-installed --dev' : 'vendor/bin/jack raise-to-installed')
@@ -287,9 +330,18 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($this->processComposerNormalize->reveal());
         $this->processBuilder->withArgument('--config', '/app/composer-dependency-analyser.php')
             ->willReturn($depAnalyserBuilder->reveal());
-        $depAnalyserBuilder->withArgument('--ignore-prod-only-in-dev-deps')
-            ->willReturn($depAnalyserFinalBuilder->reveal());
-        $depAnalyserFinalBuilder->build('vendor/bin/composer-dependency-analyser')
+
+        if (null !== $dumpUsage) {
+            $depAnalyserFinalBuilder = $this->prophesize(ProcessBuilderInterface::class);
+
+            $depAnalyserBuilder->withArgument('--dump-usages', $dumpUsage)
+                ->willReturn($depAnalyserCommandBuilder->reveal());
+            $depAnalyserCommandBuilder->withArgument('--show-all-usages')
+                ->willReturn($depAnalyserFinalBuilder->reveal());
+        }
+
+        ($depAnalyserFinalBuilder ?? $depAnalyserBuilder)
+            ->build('vendor/bin/composer-dependency-analyser')
             ->willReturn($this->processDepAnalyser->reveal());
         $this->processBuilder
             ->build(

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -29,6 +29,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionMethod;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
@@ -46,6 +47,8 @@ final class DependenciesCommandTest extends TestCase
 
     private ObjectProphecy $output;
 
+    private ObjectProphecy $fileLocator;
+
     private ObjectProphecy $processOpenVersions;
 
     private ObjectProphecy $processRaiseToInstalled;
@@ -53,8 +56,6 @@ final class DependenciesCommandTest extends TestCase
     private ObjectProphecy $processComposerUpdate;
 
     private ObjectProphecy $processComposerNormalize;
-
-    private ObjectProphecy $processUnused;
 
     private ObjectProphecy $processDepAnalyser;
 
@@ -71,15 +72,21 @@ final class DependenciesCommandTest extends TestCase
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
+        $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
         $this->processOpenVersions = $this->prophesize(Process::class);
         $this->processRaiseToInstalled = $this->prophesize(Process::class);
         $this->processComposerUpdate = $this->prophesize(Process::class);
         $this->processComposerNormalize = $this->prophesize(Process::class);
-        $this->processUnused = $this->prophesize(Process::class);
         $this->processDepAnalyser = $this->prophesize(Process::class);
         $this->processBreakpoint = $this->prophesize(Process::class);
+        $this->fileLocator->locate('composer-dependency-analyser.php')
+            ->willReturn('/app/composer-dependency-analyser.php');
 
-        $this->command = new DependenciesCommand($this->processBuilder->reveal(), $this->processQueue->reveal());
+        $this->command = new DependenciesCommand(
+            $this->processBuilder->reveal(),
+            $this->processQueue->reveal(),
+            $this->fileLocator->reveal(),
+        );
     }
 
     /**
@@ -90,11 +97,11 @@ final class DependenciesCommandTest extends TestCase
     {
         self::assertSame('dependencies', $this->command->getName());
         self::assertSame(
-            'Analyzes missing, unused, and outdated Composer dependencies.',
+            'Analyzes missing, unused, misplaced, and outdated Composer dependencies.',
             $this->command->getDescription()
         );
         self::assertSame(
-            'This command runs composer-dependency-analyser, composer-unused, and Jack to report missing, unused, and outdated Composer dependencies.',
+            'This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.',
             $this->command->getHelp()
         );
     }
@@ -111,8 +118,6 @@ final class DependenciesCommandTest extends TestCase
         $this->processQueue->add($this->processRaiseToInstalled->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processOpenVersions->reveal())
-            ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processUnused->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
@@ -140,8 +145,6 @@ final class DependenciesCommandTest extends TestCase
         $this->processQueue->add($this->processRaiseToInstalled->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processOpenVersions->reveal())
-            ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processUnused->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
@@ -173,8 +176,6 @@ final class DependenciesCommandTest extends TestCase
         $this->processQueue->add($this->processComposerUpdate->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processComposerNormalize->reveal())
-            ->shouldBeCalledOnce();
-        $this->processQueue->add($this->processUnused->reveal())
             ->shouldBeCalledOnce();
         $this->processQueue->add($this->processDepAnalyser->reveal())
             ->shouldBeCalledOnce();
@@ -241,9 +242,7 @@ final class DependenciesCommandTest extends TestCase
         $this->processBuilder
             ->build($dev ? 'vendor/bin/jack open-versions --dev --dry-run' : 'vendor/bin/jack open-versions --dry-run')
             ->willReturn($this->processOpenVersions->reveal());
-        $this->processBuilder->build('vendor/bin/composer-unused')
-            ->willReturn($this->processUnused->reveal());
-        $this->processBuilder->withArgument('--ignore-unused-deps')
+        $this->processBuilder->withArgument('--config', '/app/composer-dependency-analyser.php')
             ->willReturn($depAnalyserBuilder->reveal());
         $depAnalyserBuilder->withArgument('--ignore-prod-only-in-dev-deps')
             ->willReturn($depAnalyserFinalBuilder->reveal());
@@ -286,9 +285,7 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($this->processComposerUpdate->reveal());
         $this->processBuilder->build('composer normalize')
             ->willReturn($this->processComposerNormalize->reveal());
-        $this->processBuilder->build('vendor/bin/composer-unused')
-            ->willReturn($this->processUnused->reveal());
-        $this->processBuilder->withArgument('--ignore-unused-deps')
+        $this->processBuilder->withArgument('--config', '/app/composer-dependency-analyser.php')
             ->willReturn($depAnalyserBuilder->reveal());
         $depAnalyserBuilder->withArgument('--ignore-prod-only-in-dev-deps')
             ->willReturn($depAnalyserFinalBuilder->reveal());

--- a/tests/GitAttributes/MergerTest.php
+++ b/tests/GitAttributes/MergerTest.php
@@ -296,8 +296,8 @@ final class MergerTest extends TestCase
             $parseExistingLines->invoke($this->merger, "\n/docs/ export-ignore\n\n# comment\n"),
         );
         self::assertSame([
-                'docs' => true,
-            ], $keepInExportLookup->invoke($this->merger, [' ', '/docs/']),);
+            'docs' => true,
+        ], $keepInExportLookup->invoke($this->merger, [' ', '/docs/']),);
         self::assertSame(
             [
                 'docs' => true,


### PR DESCRIPTION
## Related Issue

Closes #135

## Motivation / Context

- the `dependencies` command currently runs both `composer-dependency-analyser` and `composer-unused` even though the ShipMonk analyser already covers unused dependencies
- the command also lacked a packaged analyser config, so known false positives could not be managed through the analyser itself

## Changes

- remove `composer-unused` from the command workflow and package dependency list
- resolve `composer-dependency-analyser.php` via `FileLocatorInterface` and pass it with `--config`
- add a packaged analyser config with targeted ignores for this repository's known false positives
- refresh README, command docs, API docs, dependency links, and changelog copy to reflect the single-analyser workflow
- update `DependenciesCommandTest` for the new command wiring

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s):
  - `composer dev-tools tests -- --filter=DependenciesCommandTest`
  - `vendor/bin/composer-dependency-analyser --config composer-dependency-analyser.php --ignore-prod-only-in-dev-deps`
  - `composer dev-tools dependencies -- --max-outdated=12`
- [x] Manual verification:
  - confirmed the analyser reports `No composer issues found` with the packaged config
  - confirmed the full `dependencies` workflow now fails only on the current Jack outdated-package threshold when using the default limit

## Documentation / Generated Output

- [x] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- `composer dev-tools dependencies -- --max-outdated=5` still fails in this branch because Jack currently reports 11 outdated packages; that behavior is unchanged by this PR and is now isolated from dependency-analyser false positives.
