### PR TITLE
[changelog] Restore plain text workflow outputs (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stabilize logger and process-queue test expectations in CI by making GitHub Actions output detection deterministic during the PHPUnit suite (#33)
+- Restore raw text output for `changelog:next-version` and `changelog:show` so changelog release workflows can keep capturing versions and redirecting release notes safely (#149)
 
 ## [1.16.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,9 @@ the same structured payload indented for manual inspection in a terminal.
 `--pretty-json` also implies JSON output, so there is no need to pass both
 flags together. In agent environments, DevTools can also switch to JSON
 automatically when the runtime is detected as agent-driven. For
-`changelog:show`, the default text mode still prints the raw release-notes
-body so release workflows can keep piping it directly into GitHub releases.
+`changelog:next-version` and `changelog:show`, the default text mode still
+prints raw values so release workflows can keep capturing semantic versions
+and piping rendered release notes directly into GitHub releases.
 
 Progress output is disabled by default on the commands that support transient
 rendering, and `--progress` re-enables it for human-readable terminal runs.

--- a/docs/commands/changelog.rst
+++ b/docs/commands/changelog.rst
@@ -124,6 +124,8 @@ Behavior
 - ``changelog:next-version --json`` emits the inferred semantic version
   as the ``message`` plus structured context describing the inspected changelog
   path and optional current version;
+- ``changelog:next-version`` prints only the inferred semantic version in text
+  mode so workflows can capture it safely in shell variables;
 - ``changelog:next-version`` uses ``Removed`` or ``Deprecated`` entries for a
   major bump, ``Added`` or ``Changed`` entries for a minor bump, and otherwise
   falls back to a patch bump;

--- a/src/Console/Command/ChangelogNextVersionCommand.php
+++ b/src/Console/Command/ChangelogNextVersionCommand.php
@@ -89,6 +89,14 @@ final class ChangelogNextVersionCommand extends BaseCommand implements LoggerAwa
             $currentVersion = $input->getOption('current-version');
             $nextVersion = $this->changelogManager->inferNextVersion($path, $currentVersion);
 
+            // This command is consumed via shell capture in changelog.yml, so
+            // plain-text mode MUST keep emitting the raw version string.
+            if (! $this->isJsonOutput($input)) {
+                $output->writeln($nextVersion);
+
+                return self::SUCCESS;
+            }
+
             return $this->success(
                 $nextVersion,
                 $input,

--- a/src/Console/Command/ChangelogShowCommand.php
+++ b/src/Console/Command/ChangelogShowCommand.php
@@ -93,6 +93,14 @@ final class ChangelogShowCommand extends BaseCommand implements LoggerAwareComma
                 $version,
             );
 
+            // This command feeds redirected release-notes files in changelog.yml,
+            // so plain-text mode MUST keep writing the rendered body directly.
+            if (! $this->isJsonOutput($input)) {
+                $output->write($releaseNotes);
+
+                return self::SUCCESS;
+            }
+
             return $this->success(
                 $releaseNotes,
                 $input,

--- a/tests/Console/Command/ChangelogNextVersionCommandTest.php
+++ b/tests/Console/Command/ChangelogNextVersionCommandTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use ReflectionMethod;
@@ -77,6 +78,10 @@ final class ChangelogNextVersionCommandTest extends TestCase
             ->willReturn('CHANGELOG.md');
         $this->input->getOption('current-version')
             ->willReturn(null);
+        $this->input->getOption('json')
+            ->willReturn(false);
+        $this->input->getOption('pretty-json')
+            ->willReturn(false);
         $this->filesystem->getAbsolutePath('CHANGELOG.md')
             ->willReturn('/repo/CHANGELOG.md');
 
@@ -91,8 +96,26 @@ final class ChangelogNextVersionCommandTest extends TestCase
      * @return void
      */
     #[Test]
-    public function executeWillReturnSuccessWithTheInferredVersion(): void
+    public function executeWillWriteTheInferredVersionToOutputInPlainTextMode(): void
     {
+        $this->changelogManager->inferNextVersion('/repo/CHANGELOG.md', null)
+            ->willReturn('1.3.0');
+        $this->output->writeln('1.3.0')
+            ->shouldBeCalled();
+        $this->logger->log(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        self::assertSame(ChangelogNextVersionCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillLogTheInferredVersionWhenJsonOutputIsRequested(): void
+    {
+        $this->input->getOption('json')
+            ->willReturn(true);
         $this->changelogManager->inferNextVersion('/repo/CHANGELOG.md', null)
             ->willReturn('1.3.0');
         $this->logger->log(
@@ -112,21 +135,16 @@ final class ChangelogNextVersionCommandTest extends TestCase
      * @return void
      */
     #[Test]
-    public function executeWillPassTheExplicitCurrentVersionToInference(): void
+    public function executeWillPassTheExplicitCurrentVersionToInferenceInPlainTextMode(): void
     {
         $this->input->getOption('current-version')
             ->willReturn('1.2.3');
         $this->changelogManager->inferNextVersion('/repo/CHANGELOG.md', '1.2.3')
             ->willReturn('2.0.0');
-        $this->logger->log(
-            'info',
-            '2.0.0',
-            [
-                'input' => $this->input->reveal(),
-                'current_version' => '1.2.3',
-                'next_version' => '2.0.0',
-            ],
-        )->shouldBeCalled();
+        $this->output->writeln('2.0.0')
+            ->shouldBeCalled();
+        $this->logger->log(Argument::cetera())
+            ->shouldNotBeCalled();
 
         self::assertSame(ChangelogNextVersionCommand::SUCCESS, $this->invokeExecute());
     }

--- a/tests/Console/Command/ChangelogShowCommandTest.php
+++ b/tests/Console/Command/ChangelogShowCommandTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use ReflectionMethod;
@@ -66,6 +67,10 @@ final class ChangelogShowCommandTest extends TestCase
 
         $this->input->getOption('file')
             ->willReturn('CHANGELOG.md');
+        $this->input->getOption('json')
+            ->willReturn(false);
+        $this->input->getOption('pretty-json')
+            ->willReturn(false);
         $this->input->getArgument('version')
             ->willReturn('1.2.0');
         $this->filesystem->getAbsolutePath('CHANGELOG.md')
@@ -82,10 +87,31 @@ final class ChangelogShowCommandTest extends TestCase
      * @return void
      */
     #[Test]
-    public function executeWillLogReleaseNotes(): void
+    public function executeWillWriteReleaseNotesToOutputInPlainTextMode(): void
     {
         $releaseNotes = "### Added\n\n- Ship it\n";
 
+        $this->changelogManager->renderReleaseNotes('/repo/CHANGELOG.md', '1.2.0')
+            ->willReturn($releaseNotes)
+            ->shouldBeCalled();
+        $this->output->write($releaseNotes)
+            ->shouldBeCalled();
+        $this->logger->log(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        self::assertSame(ChangelogShowCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillLogReleaseNotesWhenJsonOutputIsRequested(): void
+    {
+        $releaseNotes = "### Added\n\n- Ship it\n";
+
+        $this->input->getOption('json')
+            ->willReturn(true);
         $this->changelogManager->renderReleaseNotes('/repo/CHANGELOG.md', '1.2.0')
             ->willReturn($releaseNotes)
             ->shouldBeCalled();


### PR DESCRIPTION
## Related Issue

Closes #149

## Motivation / Context

- the changelog workflow started capturing formatted logger output instead of raw command payloads
- `changelog:next-version` and `changelog:show` are consumed by shell capture and redirection in `changelog.yml`
- release preparation and release publication were failing because the workflow stopped receiving plain-text values

## Changes

- restore raw plain-text output for `changelog:next-version` in non-JSON mode
- restore raw plain-text output for `changelog:show` in non-JSON mode
- preserve structured logger output when `--json` or `--pretty-json` is explicitly requested
- add focused PHPUnit coverage for both plain-text and JSON paths
- document the special plain-text contract in README, changelog docs, and `CHANGELOG.md`

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s):
  - `composer dev-tools tests -- --filter='(ChangelogNextVersionCommandTest|ChangelogShowCommandTest)'`
  - `version="$(composer dev-tools changelog:next-version -- --file=CHANGELOG.md)"`
  - reproduced the workflow sequence locally with `changelog:next-version`, `changelog:promote`, and `changelog:show`
- [x] Manual verification:
  - confirmed `changelog:next-version` returns the raw semantic version in text mode
  - confirmed `changelog:show` writes raw release notes in text mode
  - confirmed the reproduced release-notes workflow sequence writes a valid `.dev-tools/release-notes.md`

## Documentation / Generated Output

- [x] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- no new interfaces or logger abstractions were introduced for this fix; the special handling stays local to the two changelog commands that act as workflow data producers
