### PR TITLE
[reports] Fix cleanup jobs using local actions (#154)

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -189,6 +189,8 @@ jobs:
             contents: write
 
         steps:
+            - uses: actions/checkout@v6
+
             - name: Checkout gh-pages
               uses: actions/checkout@v6
               with:
@@ -214,6 +216,8 @@ jobs:
             pull-requests: read
 
         steps:
+            - uses: actions/checkout@v6
+
             - name: Checkout gh-pages
               uses: actions/checkout@v6
               with:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -190,6 +190,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+              with:
+                ref: ${{ github.event.repository.default_branch }}
 
             - name: Checkout gh-pages
               uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- checkout the repository workspace before invoking local GitHub Pages cleanup actions
- keep the dedicated `gh-pages` checkout used to remove preview content
- fix preview-cleanup jobs that could not resolve `.github/actions/github-pages/*` on runners

## Verification

- `COMPOSER_NO_INTERACTION=1 composer dev-tools:fix`
- validated `.github/workflows/reports.yml` YAML locally

Closes #154.
