### PR TITLE
[Bug]: prevent label-sync failures when no issue is linked (#157)

### DIFF
--- a/.github/actions/label-sync/copy-linked-issue-labels/run.sh
+++ b/.github/actions/label-sync/copy-linked-issue-labels/run.sh
@@ -6,10 +6,8 @@ body="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
 pull_request_number="$(jq -r '.pull_request.number // ""' "${GITHUB_EVENT_PATH}")"
 issue_number="$(
     printf '%s %s\n' "${title}" "${body}" \
-        | grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' \
-        | grep -oE '#[[:digit:]]+' \
-        | head -1 \
-        | tr -d '#'
+        | sed -nE 's/.*(closes|fixes|resolves|addresses)[[:space:]]+#([[:digit:]]+).*/\2/Ip' \
+        | head -1
 )"
 
 if [ -z "${issue_number}" ]; then

--- a/.github/actions/label-sync/copy-linked-issue-labels/run.sh
+++ b/.github/actions/label-sync/copy-linked-issue-labels/run.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 title="$(jq -r '.pull_request.title // ""' "${GITHUB_EVENT_PATH}")"
 body="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
 pull_request_number="$(jq -r '.pull_request.number // ""' "${GITHUB_EVENT_PATH}")"
-issue_number="$(
-    printf '%s %s\n' "${title}" "${body}" \
-        | sed -nE 's/.*(closes|fixes|resolves|addresses)[[:space:]]+#([[:digit:]]+).*/\2/Ip' \
-        | head -1
-)"
+issue_number=''
+
+linked_issue_pattern='(closes|fixes|resolves|addresses)[[:space:]]+#([[:digit:]]+)'
+
+if [[ "${title} ${body}" =~ ${linked_issue_pattern} ]]; then
+    issue_number="${BASH_REMATCH[2]}"
+fi
 
 if [ -z "${issue_number}" ]; then
     echo "No linked issue was found in the pull request title or body."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stabilize logger and process-queue test expectations in CI by making GitHub Actions output detection deterministic during the PHPUnit suite (#33)
 - Restore raw text output for `changelog:next-version` and `changelog:show` so changelog release workflows can keep capturing versions and redirecting release notes safely (#149)
+- Keep the packaged pull-request label-sync action from failing when a PR does not reference any linked issue (#157)
 
 ## [1.16.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the packaged pull-request label-sync action from failing when a PR does not reference any linked issue (#157)
+
 ## [1.17.0] - 2026-04-22
 
 ### Added
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stabilize logger and process-queue test expectations in CI by making GitHub Actions output detection deterministic during the PHPUnit suite (#33)
 - Restore raw text output for `changelog:next-version` and `changelog:show` so changelog release workflows can keep capturing versions and redirecting release notes safely (#149)
-- Keep the packaged pull-request label-sync action from failing when a PR does not reference any linked issue (#157)
 
 ## [1.16.0] - 2026-04-20
 


### PR DESCRIPTION
## Summary

- stop `label-sync` from failing when a PR does not reference any linked issue
- keep the no-linked-issue path as an explicit no-op with a friendly log message
- record the fix in `CHANGELOG.md`

## Root Cause

The action parsed linked issue references with a `grep` pipeline inside command substitution while running under `set -euo pipefail`. When no match existed, `grep` exited with status `1` before the script reached the fallback branch that should have exited successfully.

## Verification

- reproduced the no-linked-issue case locally with a synthetic `GITHUB_EVENT_PATH`
- verified the script now prints `No linked issue was found...` and exits `0`
- verified the linked-issue path still reaches the later no-labels handling path
- `COMPOSER_NO_INTERACTION=1 composer dev-tools:fix`

Closes #157
