### PR TITLE
[Bug]: revert #158 and fix label-sync issue parsing (#157)

### DIFF
--- a/.github/actions/label-sync/copy-linked-issue-labels/run.sh
+++ b/.github/actions/label-sync/copy-linked-issue-labels/run.sh
@@ -4,13 +4,13 @@ set -euo pipefail
 title="$(jq -r '.pull_request.title // ""' "${GITHUB_EVENT_PATH}")"
 body="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
 pull_request_number="$(jq -r '.pull_request.number // ""' "${GITHUB_EVENT_PATH}")"
-issue_number=''
-
-linked_issue_pattern='(closes|fixes|resolves|addresses)[[:space:]]+#([[:digit:]]+)'
-
-if [[ "${title} ${body}" =~ ${linked_issue_pattern} ]]; then
-    issue_number="${BASH_REMATCH[2]}"
-fi
+issue_number="$(
+    printf '%s %s\n' "${title}" "${body}" \
+        | grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' \
+        | grep -oE '#[[:digit:]]+' \
+        | head -1 \
+        | tr -d '#'
+)"
 
 if [ -z "${issue_number}" ]; then
     echo "No linked issue was found in the pull request title or body."

--- a/.github/actions/label-sync/copy-linked-issue-labels/run.sh
+++ b/.github/actions/label-sync/copy-linked-issue-labels/run.sh
@@ -4,13 +4,13 @@ set -euo pipefail
 title="$(jq -r '.pull_request.title // ""' "${GITHUB_EVENT_PATH}")"
 body="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
 pull_request_number="$(jq -r '.pull_request.number // ""' "${GITHUB_EVENT_PATH}")"
-issue_number="$(
-    printf '%s %s\n' "${title}" "${body}" \
-        | grep -oiE '(closes|fixes|resolves|addresses)\s+#[[:digit:]]+' \
-        | grep -oE '#[[:digit:]]+' \
-        | head -1 \
-        | tr -d '#'
-)"
+issue_number="$(jq -rn \
+    --arg title "${title}" \
+    --arg body "${body}" '
+        [$title, $body]
+        | join(" ")
+        | try (capture("(?i)(closes|fixes|resolves|addresses)\\s+#(?<issue>[0-9]+)") | .issue) catch ""
+    ')"
 
 if [ -z "${issue_number}" ]; then
     echo "No linked issue was found in the pull request title or body."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the packaged pull-request label-sync action from failing when a PR does not reference any linked issue (#157)
+
 ## [1.17.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Keep the packaged pull-request label-sync action from failing when a PR does not reference any linked issue (#157)
-
 ## [1.17.0] - 2026-04-22
 
 ### Added


### PR DESCRIPTION
## Summary

- revert the merged change from `#158`
- fix linked-issue parsing in `label-sync` with a safe `jq`-based extractor
- keep the bug entry under `Unreleased`

## Why This Replaces `#158`

`#158` was merged, but the diagnosis was wrong. The real failure path was still the original one: pull requests without a linked issue reference were still causing the action to exit early in the legacy shell pipeline.

This branch reopens `#157`, reverts the merged change, and replaces it with a parser that:

- returns an empty string instead of failing when no issue is linked
- preserves case-insensitive matching for references such as `Closes #157`
- avoids `grep`/pipeline exit-code traps under `set -euo pipefail`

## Verification

- reproduced the no-linked-issue case locally and verified `exit 0`
- reproduced a `Closes #157` case locally and verified extraction still works
- `COMPOSER_NO_INTERACTION=1 composer dev-tools:fix`
