### PR TITLE
[agents] Add rigorous pull-request review workflow (#147)

### DIFF
--- a/.agents/agents/review-guardian.md
+++ b/.agents/agents/review-guardian.md
@@ -1,0 +1,53 @@
+---
+name: review-guardian
+description: Review Fast Forward pull requests with a rigorous, findings-first contract before or during human review.
+primary-skill: pull-request-review
+supporting-skills:
+  - phpunit-tests
+  - sphinx-docs
+  - package-readme
+---
+
+# review-guardian
+
+## Purpose
+
+Provide a repeatable, high-signal pull-request review pass that helps
+maintainers catch regressions, missing coverage, stale docs, workflow risks,
+and generated-output drift before human review time is spent.
+
+## Responsibilities
+
+- Review ready pull requests with findings first and summaries second.
+- Prioritize bugs, regressions, missing tests, missing documentation, CI or
+  workflow risk, generated-output drift, and consumer-sync side effects.
+- Reference repository files whenever possible so maintainers can move quickly.
+- Treat packaged skills, project agents, workflow wrappers, local actions,
+  changelog entries, wiki output, and generated reports as first-class review
+  surfaces when touched.
+- Stay reusable across this repository and consumer repositories that
+  synchronize DevTools assets.
+
+## Use When
+
+- A pull request has just transitioned from draft to ready for review.
+- A maintainer wants a fresh rigorous review pass on an existing pull request.
+- A change touches workflows, generated outputs, synchronized assets, or other
+  surfaces where a generic summary would miss important risk.
+
+## Boundaries
+
+- Do not replace human review or branch protection.
+- Do not drift into implementation or patch authoring unless explicitly asked.
+- Do not weaken the findings-first contract with generic praise or summary
+  text before the actual issues.
+
+## Primary Skill
+
+- `pull-request-review`
+
+## Supporting Skills
+
+- `phpunit-tests`
+- `sphinx-docs`
+- `package-readme`

--- a/.agents/skills/pull-request-review/SKILL.md
+++ b/.agents/skills/pull-request-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: pull-request-review
+description: Review Fast Forward pull requests with a findings-first contract that prioritizes bugs, regressions, missing tests, missing docs, generated-output drift, and workflow risk over general summaries.
+---
+
+# Fast Forward Pull Request Review
+
+Use this skill when a pull request is ready for review and maintainers need a
+repeatable, high-signal review pass. The review MUST lead with concrete
+findings, ordered by severity, with repository file references whenever
+possible.
+
+## Workflow
+
+1. Resolve the pull request context, touched files, and highest-risk surfaces.
+   Read [references/surface-priorities.md](references/surface-priorities.md).
+2. Inspect behavior before style. Start with source, workflows, generated
+   outputs, synchronized assets, tests, and documentation that can change
+   release or automation behavior.
+3. Produce the review using the findings-first contract. Read
+   [references/review-contract.md](references/review-contract.md).
+4. Call out missing or weak tests, missing docs, changelog gaps, generated
+   artifact drift, and consumer-sync impacts whenever the changed surfaces make
+   them relevant.
+5. Only after the findings, add a brief summary or note residual risk. If no
+   issues are found, say that clearly and mention any remaining verification
+   gaps.
+
+## Fast Forward Defaults
+
+- Findings come first. Summaries are secondary.
+- Prioritize bugs, regressions, missing coverage, missing documentation,
+  workflow or CI risks, generated-output drift, and sync side effects over
+  stylistic nits.
+- Treat ``.github/workflows``, ``resources/github-actions``, ``.github/actions``,
+  ``.agents/skills``, ``.agents/agents``, ``README.md``, ``docs/``,
+  ``CHANGELOG.md``, and ``.github/wiki`` as high-signal review surfaces.
+- Prefer precise repository file references in every finding.
+- Review what changed, but reason about downstream consumer impact when the PR
+  touches packaged assets or synchronized defaults.
+- Do not dilute the review with praise or generic narrative before the
+  findings.
+
+## Reference Guide
+
+| Need | Reference |
+|------|-----------|
+| Decide which changed surfaces deserve the closest scrutiny | [references/surface-priorities.md](references/surface-priorities.md) |
+| Format the review output in the expected findings-first shape | [references/review-contract.md](references/review-contract.md) |
+
+## Anti-patterns
+
+- Do not lead with a summary before the findings.
+- Do not spend the review budget on low-value formatting commentary when
+  behavioral or workflow risk exists.
+- Do not ignore generated files, synced assets, or workflow wrappers when the
+  pull request touched their sources.
+- Do not claim a pull request is clean without mentioning the verification
+  scope or any residual gaps.

--- a/.agents/skills/pull-request-review/agents/openai.yaml
+++ b/.agents/skills/pull-request-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fast Forward Rigorous Review"
+  short_description: "Review Fast Forward pull requests with a findings-first contract"
+  default_prompt: "Use $pull-request-review to perform a rigorous findings-first review of this Fast Forward pull request."

--- a/.agents/skills/pull-request-review/references/review-contract.md
+++ b/.agents/skills/pull-request-review/references/review-contract.md
@@ -1,0 +1,37 @@
+Review Contract
+===============
+
+Every rigorous review produced from this skill MUST follow this contract:
+
+1. Findings first.
+2. Findings ordered by severity.
+3. Each finding anchored to a repository file reference whenever possible.
+4. Open questions or assumptions after the findings, not before them.
+5. A short summary only after the findings, and only when it adds value.
+
+Expected output shape:
+
+- Findings
+  - ``High`` / ``Medium`` / ``Low`` severity labels when helpful.
+  - One issue per bullet or short paragraph.
+  - Explain the concrete risk or regression, not just the changed code.
+  - Include the most relevant file path for each finding.
+- Open Questions / Assumptions
+  - Use only when uncertainty affects confidence in the findings.
+- Summary
+  - Briefly describe the net result after the findings.
+
+Required review themes:
+
+- Bugs and regressions.
+- Missing or weak tests.
+- Missing or stale documentation.
+- Generated-output drift.
+- Workflow, CI, or release automation risk.
+- Consumer-sync or packaged-asset side effects.
+
+If no issues are found:
+
+- State that clearly.
+- Mention the scope that was reviewed.
+- Call out any remaining test or verification gaps.

--- a/.agents/skills/pull-request-review/references/surface-priorities.md
+++ b/.agents/skills/pull-request-review/references/surface-priorities.md
@@ -1,0 +1,37 @@
+Surface Priorities
+==================
+
+When a pull request is ready for review, inspect the highest-risk surfaces
+first.
+
+Highest priority
+----------------
+
+- ``src/`` when public behavior, orchestration, dependency injection, or
+  compatibility may have changed.
+- ``tests/`` when behavior changed but coverage may be missing or weakened.
+- ``.github/workflows/`` and ``.github/actions/`` when permissions, triggers,
+  release behavior, or CI guarantees may have changed.
+- ``resources/github-actions/`` when a repository-facing workflow wrapper can
+  drift from the reusable workflow implementation.
+- ``.agents/skills/`` and ``.agents/agents/`` when packaged prompts or
+  consumer-synchronized capabilities changed.
+
+Additional Fast Forward review surfaces
+--------------------------------------
+
+- ``README.md`` and ``docs/`` for onboarding, command, or workflow drift.
+- ``CHANGELOG.md`` for notable user-facing or automation-facing changes.
+- ``.github/wiki`` when generated wiki output is touched.
+- ``resources/`` when synchronized templates or packaged defaults changed.
+
+Typical review questions
+------------------------
+
+- Did the implementation change behavior without matching tests?
+- Did the workflow wrapper stay aligned with the reusable workflow?
+- Did packaged assets change without explaining the consumer impact?
+- Did docs, README, changelog, or generated outputs remain consistent with the
+  implementation?
+- Did the pull request alter release automation, sync flows, or CI permissions
+  in a risky way?

--- a/.github/actions/review/render-request/action.yml
+++ b/.github/actions/review/render-request/action.yml
@@ -1,0 +1,30 @@
+name: Render Rigorous Review Request
+description: Render a deterministic review brief for a pull request that is ready for rigorous review.
+
+inputs:
+  pull-request-number:
+    description: Pull request number to review.
+    required: false
+    default: ''
+
+outputs:
+  pull-request-number:
+    description: Resolved pull request number.
+    value: ${{ steps.render.outputs.pull-request-number }}
+  comment:
+    description: Sticky pull-request comment body.
+    value: ${{ steps.render.outputs.comment }}
+  summary:
+    description: GitHub Actions step summary body.
+    value: ${{ steps.render.outputs.summary }}
+
+runs:
+  using: composite
+  steps:
+    - id: render
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          const run = require(`${process.env.GITHUB_ACTION_PATH}/run.cjs`);
+          await run({github, context, core});

--- a/.github/actions/review/render-request/run.cjs
+++ b/.github/actions/review/render-request/run.cjs
@@ -1,0 +1,149 @@
+const MAX_LISTED_FILES = 12;
+
+function classifyTouchedSurfaces(files) {
+  const checks = [
+    [
+      'Source behavior or orchestration changed; verify regressions, contracts, and dependency boundaries.',
+      (file) => file.startsWith('src/'),
+    ],
+    [
+      'Tests changed; confirm assertions still cover the touched behavior and edge cases.',
+      (file) => file.startsWith('tests/'),
+    ],
+    [
+      'Docs or README changed; verify commands, examples, and generated outputs stayed aligned.',
+      (file) => file === 'README.md' || file.startsWith('docs/'),
+    ],
+    [
+      'Workflow or local GitHub Action logic changed; scrutinize permissions, triggers, release flow, and CI side effects.',
+      (file) => file.startsWith('.github/workflows/') || file.startsWith('.github/actions/'),
+    ],
+    [
+      'Consumer workflow wrappers changed; verify they still mirror the reusable workflow contract safely.',
+      (file) => file.startsWith('resources/github-actions/'),
+    ],
+    [
+      'Packaged agent surfaces changed; verify prompts, sync behavior, and inherited guidance.',
+      (file) => file.startsWith('.agents/skills/') || file.startsWith('.agents/agents/') || file === 'AGENTS.md',
+    ],
+    [
+      'Changelog changed; verify notable behavior and automation changes are documented accurately.',
+      (file) => file === 'CHANGELOG.md',
+    ],
+    [
+      'Wiki output changed; confirm generated content updates are intentional and consistent with the source.',
+      (file) => file.startsWith('.github/wiki'),
+    ],
+    [
+      'Packaged resources changed; verify consumer repositories inherit the right defaults and generated artifacts.',
+      (file) => file.startsWith('resources/'),
+    ],
+  ];
+
+  return checks
+    .filter(([, matcher]) => files.some(matcher))
+    .map(([message]) => message);
+}
+
+function renderComment({pull, files, focusAreas}) {
+  const listedFiles = files.slice(0, MAX_LISTED_FILES);
+  const remainingCount = Math.max(0, files.length - listedFiles.length);
+  const touchedSurfaces = focusAreas.length > 0
+    ? focusAreas
+    : ['No special review surface was inferred beyond the normal findings-first review contract.'];
+
+  const lines = [
+    '## Rigorous review requested',
+    '',
+    'This pull request is ready for the dedicated `review-guardian` pass powered by `$pull-request-review`.',
+    '',
+    `- PR: #${pull.number} — ${pull.title}`,
+    `- Author: @${pull.user.login}`,
+    `- Base: \`${pull.base.ref}\``,
+    `- Head: \`${pull.head.ref}\` @ \`${pull.head.sha.slice(0, 7)}\``,
+    '',
+    '### Review focus',
+    ...touchedSurfaces.map((item) => `- ${item}`),
+    '',
+    '### Sample changed files',
+    ...listedFiles.map((file) => `- \`${file}\``),
+  ];
+
+  if (remainingCount > 0) {
+    lines.push(`- ...and ${remainingCount} more files.`);
+  }
+
+  lines.push(
+    '',
+    '### Suggested prompt',
+    '```text',
+    `Use $pull-request-review with the review-guardian agent to review PR #${pull.number} (${pull.html_url}).`,
+    'Lead with findings ordered by severity. Include repository file references whenever possible.',
+    'Prioritize bugs, regressions, missing tests, missing docs, generated-output drift, and workflow or CI impacts.',
+    `Base: ${pull.base.ref}`,
+    `Head: ${pull.head.ref} @ ${pull.head.sha.slice(0, 7)}`,
+    '```',
+  );
+
+  return lines.join('\n');
+}
+
+function renderSummary({pull, focusAreas}) {
+  const lines = [
+    '## Rigorous review requested',
+    '',
+    `- Pull request: [#${pull.number}](${pull.html_url})`,
+    '- Agent: `review-guardian`',
+    '- Skill: `$pull-request-review`',
+    '',
+    '### Findings-first expectations',
+    '- Lead with bugs, regressions, missing tests, missing docs, generated-output drift, and workflow or CI risk.',
+    '- Include repository file references whenever possible.',
+  ];
+
+  if (focusAreas.length > 0) {
+    lines.push('', '### Inferred high-signal surfaces', ...focusAreas.map((item) => `- ${item}`));
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = async function run({github, context, core}) {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const input = core.getInput('pull-request-number').trim();
+  const inferredNumber = String(context.payload.pull_request?.number || '').trim();
+  const pullRequestNumber = input || inferredNumber;
+
+  if (pullRequestNumber === '') {
+    core.setFailed('Unable to resolve a pull request number for the rigorous review workflow.');
+    return;
+  }
+
+  const pull_number = Number.parseInt(pullRequestNumber, 10);
+
+  if (Number.isNaN(pull_number)) {
+    core.setFailed(`Invalid pull request number: ${pullRequestNumber}`);
+    return;
+  }
+
+  const {data: pull} = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number,
+  });
+
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number,
+    per_page: 100,
+  });
+
+  const changedFiles = files.map((file) => file.filename);
+  const focusAreas = classifyTouchedSurfaces(changedFiles);
+
+  core.setOutput('pull-request-number', String(pull.number));
+  core.setOutput('comment', renderComment({pull, files: changedFiles, focusAreas}));
+  core.setOutput('summary', renderSummary({pull, focusAreas}));
+};

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,47 @@
+name: Rigorous Pull Request Review
+
+on:
+  workflow_call:
+    inputs:
+      pull-request-number:
+        description: Pull request number to review when the workflow is called manually or through a consumer wrapper.
+        required: false
+        type: string
+        default: ''
+  pull_request_target:
+    types: [ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pull-request-number:
+        description: Pull request number to review manually.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  request-rigorous-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: render
+        uses: ./.github/actions/review/render-request
+        with:
+          pull-request-number: ${{ inputs.pull-request-number || github.event.inputs.pull-request-number || github.event.pull_request.number || '' }}
+
+      - name: Write step summary
+        env:
+          REVIEW_SUMMARY: ${{ steps.render.outputs.summary }}
+        run: |
+          printf '%s\n' "$REVIEW_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment review request on pull request
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.render.outputs.pull-request-number }}
+          header: rigorous-review
+          message: ${{ steps.render.outputs.comment }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,8 @@ composer dev-tools
 - `README.md`: high-level command surface, architecture overview, and consumer-facing context
 - `docs/commands/`: command-specific behavior and option details
 - `docs/usage/` and `docs/internals/`: workflow, reporting, release, and implementation notes
-- `.github/workflows/`: CI and release automation truth, especially `tests.yml`, `reports.yml`, `wiki.yml`, `wiki-preview.yml`, `wiki-maintenance.yml`, `changelog.yml`, `auto-assign.yml`, and `label-sync.yml`
-- `.github/actions/`: shared workflow building blocks for `php`, `project-board`, `github-pages`, `wiki`, `changelog`, and `label-sync`
+- `.github/workflows/`: CI and release automation truth, especially `tests.yml`, `reports.yml`, `review.yml`, `wiki.yml`, `wiki-preview.yml`, `wiki-maintenance.yml`, `changelog.yml`, `auto-assign.yml`, and `label-sync.yml`
+- `.github/actions/`: shared workflow building blocks for `php`, `project-board`, `github-pages`, `review`, `wiki`, `changelog`, and `label-sync`
 - `resources/github-actions/`: consumer-facing workflow wrappers synchronized by `dev-tools:sync`
 - `.github/pull_request_template.md`: expected PR structure and reviewer checklist
 - `src/Sync/`: shared packaged-directory synchronization primitives used by `skills` and `agents`
@@ -200,6 +200,7 @@ composer dev-tools
 - **Updating PHPDoc / PHP Style**: Use skill `phpdoc-code-style` in `.agents/skills/phpdoc-code-style/` for PHPDoc cleanup and repository-specific PHP formatting
 - **Drafting / Publishing GitHub Issues**: Use skill `github-issues` in `.agents/skills/github-issues/` to transform a short feature description into a complete, production-ready GitHub issue and create or update it on GitHub when needed
 - **Implementing Issues & PRs**: Use skill `github-pull-request` in `.agents/skills/github-pull-request/` to iterate through open GitHub issues and implement them one by one with branching, testing, documentation, and pull requests
+- **Reviewing Pull Requests**: Use skill `pull-request-review` in `.agents/skills/pull-request-review/` for findings-first Fast Forward pull-request review focused on regressions, missing tests, missing docs, workflow risk, and generated-output drift
 
 ## Project Agents
 
@@ -217,4 +218,5 @@ remains the procedural source of truth.
 - Delegate to `docs-writer` when `docs/` must be created or updated.
 - Delegate to `consumer-sync-auditor` when packaged skills, packaged agents, sync assets, wiki, workflow wrappers, local GitHub actions, or consumer bootstrap behavior change.
 - Delegate to `quality-pipeline-auditor` when a task changes command orchestration, verification flow, or quality gates.
+- Delegate to `review-guardian` when a pull request needs a rigorous findings-first review before or during human review.
 - Delegate to `changelog-maintainer` when a task needs changelog authoring, changelog validation for PRs, release promotion, or release-note export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Package a rigorous pull-request review skill, review-guardian agent, and ready-for-review workflow brief for repositories and synchronized consumers (#147)
+
 ### Changed
 
 - Require GitHub issue write readback verification in the github-issues skill (#165)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ across Fast Forward libraries.
   version inference, release promotion, and release-note rendering commands
 - Ships shared workflow stubs, `.editorconfig`, Dependabot configuration, and
   other onboarding defaults for consumer repositories
+- Packages a rigorous pull-request review skill, matching `review-guardian`
+  project agent, and ready-for-review workflow brief for high-signal review
+  intake
 - Generates `.github/CODEOWNERS` files from local project metadata instead of
   shipping repository-specific owners into consumers
 - Synchronizes packaged skills and project-agent prompts into consumer
@@ -217,17 +220,24 @@ The `skills` command keeps `.agents/skills` aligned with the packaged Fast
 Forward skill set. It creates missing links, repairs broken links, and
 preserves existing non-symlink directories. The `dev-tools:sync` command calls
 `skills` automatically after refreshing the rest of the consumer-facing
-automation assets.
+automation assets. The packaged skills include reusable flows for GitHub issue
+authoring, issue implementation, changelog maintenance, and rigorous pull
+request review.
 
 The `agents` command keeps `.agents/agents` aligned with the packaged Fast
 Forward project-agent prompt set. It follows the same symlink-preservation and
 broken-link-repair safety model as the packaged skill synchronization flow, and
-`dev-tools:sync` calls it automatically in normal synchronization mode.
+`dev-tools:sync` calls it automatically in normal synchronization mode. The
+packaged agent set includes role prompts such as `issue-implementer`,
+`docs-writer`, `test-guardian`, `readme-maintainer`, `review-guardian`, and
+`changelog-maintainer`.
 
 The packaged workflow stubs synchronized by `dev-tools:sync` now also include
 changelog automation for pull-request validation and release preparation, so
 consumer repositories can adopt the same changelog-driven release flow without
-copying workflow logic by hand.
+copying workflow logic by hand. They also include a rigorous review intake
+workflow that reacts when a pull request becomes ready for review and posts a
+deterministic brief for the dedicated review agent.
 
 The release workflow is intentionally two-step: `workflow_dispatch` prepares a
 `release/v...` pull request, and merging that release pull request publishes
@@ -271,8 +281,9 @@ keeps the same command vocabulary when you prefer running tools directly from
 `vendor/bin/dev-tools`. The consumer sync flow also refreshes `.agents/skills`
 and `.agents/agents` so agents can discover the packaged skills and packaged
 role prompts shipped with this repository, including workflows for GitHub
-issue/PR handling, changelog maintenance, PHP quality tasks, Sphinx docs,
-README generation, and repository `AGENTS.md` authoring.
+issue/PR handling, changelog maintenance, rigorous pull-request review, PHP
+quality tasks, Sphinx docs, README generation, and repository `AGENTS.md`
+authoring.
 
 ## 🏗️ Architecture
 

--- a/docs/advanced/consumer-automation.rst
+++ b/docs/advanced/consumer-automation.rst
@@ -42,6 +42,9 @@ implementation in this repository is increasingly composed from local actions in
      - Reusable project-automation actions for resolving the target board,
        inferring review status, syncing linked metadata, and transitioning
        items through repository delivery states.
+   * - ``.github/actions/review/*``
+     - Reusable helpers that render deterministic rigorous-review briefs for
+       pull requests that just became ready for review.
    * - ``.github/actions/wiki/*``
      - Wiki-specific helpers for preparing preview branches, promoting preview
        content to ``master``, validating publication, and cleaning stale
@@ -103,6 +106,10 @@ How Changelog and Project Automation Fit In
   release branches, publishes GitHub releases from merged release branches, and
   can transition the configured GitHub Project item state alongside those
   lifecycle events.
+- ``.github/workflows/review.yml`` composes its ready-for-review intake from
+  ``.github/actions/review/*`` and posts a deterministic brief that points
+  maintainers to the packaged ``review-guardian`` agent and
+  ``pull-request-review`` skill.
 - Project-board automation is no longer just an inline workflow concern; it is
   a reusable local action group shared by issue, pull-request, review, and
   release automation.

--- a/docs/usage/common-workflows.rst
+++ b/docs/usage/common-workflows.rst
@@ -32,6 +32,10 @@ Most day-to-day work falls into one of the flows below.
    * - Refresh packaged project agents only
      - ``composer agents``
      - Creates or repairs symlinks in ``.agents/agents``.
+   * - Trigger a rigorous review pass for a ready pull request
+     - Mark the pull request ready for review or run ``review.yml`` manually
+     - Posts a deterministic review brief that points maintainers to the
+       ``review-guardian`` agent and ``pull-request-review`` skill.
    * - Prepare a release from the current changelog
      - ``composer changelog:next-version`` then ``composer changelog:promote``
      - Infers the next semantic version, publishes ``Unreleased``, and leaves

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -42,6 +42,7 @@ The packaged wrappers currently include:
 
 *   ``tests.yml``
 *   ``reports.yml``
+*   ``review.yml``
 *   ``changelog.yml``
 *   ``wiki.yml`` for pull-request wiki previews
 *   ``wiki-maintenance.yml`` for merged-publication and cleanup work
@@ -175,6 +176,41 @@ wrapper in ``resources/github-actions/changelog.yml``.
 
 .. note::
    Branch protection is not what blocks the release-preparation workflow from opening a pull request. Branch protection affects the merge of the ``release/v...`` pull request later in the flow. The gray or disabled workflow-permission controls come from repository permissions or organization policy.
+
+Fast Forward Rigorous Review
+----------------------------
+
+The ``review.yml`` workflow standardizes how Fast Forward repositories request
+high-signal pull-request review when a branch is no longer a draft.
+
+**Triggers:**
+*   Pull Request Target (ready_for_review).
+*   Manual trigger (workflow_dispatch).
+
+**Behavior:**
+*   Resolves the target pull request from the lifecycle event or manual input.
+*   Inspects the changed file list and infers high-signal review surfaces such
+    as workflows, local actions, packaged skills, packaged agents, docs,
+    changelog, wiki output, and source or test changes.
+*   Writes a GitHub Actions step summary that points maintainers to the
+    packaged ``review-guardian`` project agent and ``pull-request-review``
+    skill.
+*   Posts or updates a sticky pull-request comment with a deterministic review
+    brief, sample changed files, and a ready-to-run prompt for the dedicated
+    review agent.
+*   Runs only when a pull request actually becomes ready for review, not on
+    every draft update.
+
+**Inputs:**
+*   ``pull-request-number``: required only for manual dispatch.
+
+**Repository permissions:**
+*   ``contents: read``
+*   ``pull-requests: write``
+
+This workflow does not replace human review. It standardizes the review intake
+moment and keeps the same review capability manually invokable for an already
+open pull request.
 
 Maintenance Workflows
 ---------------------

--- a/resources/github-actions/review.yml
+++ b/resources/github-actions/review.yml
@@ -1,0 +1,20 @@
+name: Rigorous Pull Request Review
+
+on:
+  pull_request_target:
+    types: [ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pull-request-number:
+        description: Pull request number to review manually.
+        required: true
+        type: string
+
+jobs:
+  rigorous-review:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: php-fast-forward/dev-tools/.github/workflows/review.yml@main
+    with:
+      pull-request-number: ${{ github.event.pull_request.number || inputs.pull-request-number || '' }}


### PR DESCRIPTION
## Related Issue

Closes #147

## Motivation / Context

Fast Forward already ships issue, changelog, docs, README, and test-focused agents, but we were still missing a repository-standard rigorous review intake when a pull request becomes ready for review.

## Changes

- package a new `pull-request-review` skill with a findings-first review contract and review-surface guidance
- package a matching `review-guardian` project agent for repository and consumer use
- add a reusable `review.yml` workflow plus `resources/github-actions/review.yml` consumer wrapper
- isolate workflow rendering logic in `.github/actions/review/render-request`
- update README, AGENTS, changelog, and GitHub Actions documentation for the new review flow

## Verification

- `ruby -e 'require "yaml"; %w[.github/workflows/review.yml resources/github-actions/review.yml .github/actions/review/render-request/action.yml].each { |path| YAML.load_file(path) }'`
- `node <<'NODE' ... require('./.github/actions/review/render-request/run.cjs') ... NODE` smoke test for action outputs
- `composer dev-tools changelog:check`
- `git diff --check`

## Documentation / Generated Output

- updated `README.md`
- updated `AGENTS.md`
- updated `docs/advanced/consumer-automation.rst`
- updated `docs/usage/github-actions.rst`
- updated `docs/usage/common-workflows.rst`
- updated `CHANGELOG.md`

## Changelog

- Added `Package a rigorous pull-request review skill, review-guardian agent, and ready-for-review workflow brief for repositories and synchronized consumers (#147)` to `Unreleased`

## Reviewer Notes

- the workflow standardizes the ready-for-review intake and posts a deterministic brief for the dedicated review agent; it does not attempt to replace human review or execute an unavailable remote agent runtime automatically
- local `.github/wiki` changes were intentionally kept out of this PR
