### PR TITLE
[github-actions] Resolve consumer action paths in reusable workflows (#180)

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -28,8 +28,14 @@ jobs:
       project_number: ${{ steps.resolve.outputs.project-number }}
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
       - id: resolve
-        uses: ./.github/actions/project-board/resolve
+        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve
         with:
           project: ${{ inputs.project || vars.PROJECT || '' }}
 
@@ -48,7 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/project-board/sync-status
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
+      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -61,7 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/project-board/sync-linked-pr-metadata
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
+      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-linked-pr-metadata
 
   sync-pull-request-status:
     needs: resolve-project
@@ -73,10 +91,16 @@ jobs:
       pull_request_status: ${{ steps.compute.outputs.pull-request-status }}
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
       - id: compute
-        uses: ./.github/actions/project-board/resolve-pr-status
+        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve-pr-status
 
-      - uses: ./.github/actions/project-board/sync-status
+      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -84,7 +108,7 @@ jobs:
           status-value: ${{ steps.compute.outputs.pull-request-status }}
 
       - if: steps.compute.outputs.linked-issue-node-id != '' && steps.compute.outputs.linked-issue-status != ''
-        uses: ./.github/actions/project-board/sync-status
+        uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -97,10 +121,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
       - id: compute
-        uses: ./.github/actions/project-board/resolve-review-status
+        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve-review-status
 
-      - uses: ./.github/actions/project-board/sync-status
+      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -33,9 +33,11 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
       - id: resolve
-        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve
+        uses: ./.dev-tools-actions/.github/actions/project-board/resolve
         with:
           project: ${{ inputs.project || vars.PROJECT || '' }}
 
@@ -59,8 +61,10 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
-      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
+      - uses: ./.dev-tools-actions/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -78,8 +82,10 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
-      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-linked-pr-metadata
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
+      - uses: ./.dev-tools-actions/.github/actions/project-board/sync-linked-pr-metadata
 
   sync-pull-request-status:
     needs: resolve-project
@@ -96,11 +102,13 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
       - id: compute
-        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve-pr-status
+        uses: ./.dev-tools-actions/.github/actions/project-board/resolve-pr-status
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
+      - uses: ./.dev-tools-actions/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -108,7 +116,7 @@ jobs:
           status-value: ${{ steps.compute.outputs.pull-request-status }}
 
       - if: steps.compute.outputs.linked-issue-node-id != '' && steps.compute.outputs.linked-issue-status != ''
-        uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
+        uses: ./.dev-tools-actions/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}
@@ -126,11 +134,13 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
       - id: compute
-        uses: ./.dev-tools-workflow-source/.github/actions/project-board/resolve-review-status
+        uses: ./.dev-tools-actions/.github/actions/project-board/resolve-review-status
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/project-board/sync-status
+      - uses: ./.dev-tools-actions/.github/actions/project-board/sync-status
         with:
           organization: ${{ github.repository_owner }}
           project: ${{ needs.resolve-project.outputs.project_number }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -76,11 +76,13 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
+              uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
     validate_pull_request:
         name: Validate PR Changelog
@@ -100,10 +102,12 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -119,7 +123,7 @@ jobs:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: composer dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+            - uses: ./.dev-tools-actions/.github/actions/summary/write
               with:
                   markdown: |
                       ## Changelog Validation Summary
@@ -149,10 +153,12 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -160,7 +166,7 @@ jobs:
 
             - name: Resolve release version
               id: version
-              uses: ./.dev-tools-workflow-source/.github/actions/changelog/resolve-version
+              uses: ./.dev-tools-actions/.github/actions/changelog/resolve-version
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ inputs.version || '' }}
@@ -173,7 +179,7 @@ jobs:
                   composer dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
 
             - name: Render release notes preview
-              uses: ./.dev-tools-workflow-source/.github/actions/changelog/render-release-notes
+              uses: ./.dev-tools-actions/.github/actions/changelog/render-release-notes
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ steps.version.outputs.value }}
@@ -206,15 +212,17 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/project-board/transition-status
+            - uses: ./.dev-tools-actions/.github/actions/project-board/transition-status
               with:
                   project: ${{ inputs.project || vars.PROJECT || '' }}
                   from-status: Merged
                   to-status: Release Prepared
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+            - uses: ./.dev-tools-actions/.github/actions/summary/write
               with:
                   markdown: |
                       ## Release Preparation Summary
@@ -246,10 +254,12 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -257,20 +267,20 @@ jobs:
 
             - name: Resolve merged release version
               id: version
-              uses: ./.dev-tools-workflow-source/.github/actions/changelog/resolve-merged-version
+              uses: ./.dev-tools-actions/.github/actions/changelog/resolve-merged-version
               with:
                   head-ref: ${{ github.event.pull_request.head.ref }}
                   release-branch-prefix: ${{ env.RELEASE_BRANCH_PREFIX }}
 
             - name: Render release notes
-              uses: ./.dev-tools-workflow-source/.github/actions/changelog/render-release-notes
+              uses: ./.dev-tools-actions/.github/actions/changelog/render-release-notes
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ steps.version.outputs.value }}
 
             - name: Publish GitHub release
               id: publish_release
-              uses: ./.dev-tools-workflow-source/.github/actions/changelog/publish-release
+              uses: ./.dev-tools-actions/.github/actions/changelog/publish-release
               with:
                   version: ${{ steps.version.outputs.value }}
                   target: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
@@ -281,16 +291,18 @@ jobs:
               with:
                   repository: php-fast-forward/dev-tools
                   ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                  path: .dev-tools-workflow-source
+                  path: .dev-tools-actions
+                  sparse-checkout: |
+                      .github/actions
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/project-board/transition-status
+            - uses: ./.dev-tools-actions/.github/actions/project-board/transition-status
               with:
                   project: ${{ inputs.project || vars.PROJECT || '' }}
                   from-status: Release Prepared
                   to-status: Released
                   include-current-pull-request: 'true'
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+            - uses: ./.dev-tools-actions/.github/actions/summary/write
               with:
                   markdown: |
                       ## Release Publication Summary

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -71,10 +71,16 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.github/actions/php/resolve-version
+              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
 
     validate_pull_request:
         name: Validate PR Changelog
@@ -89,9 +95,15 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -107,7 +119,7 @@ jobs:
                   BASE_REF: ${{ github.event.pull_request.base.ref }}
               run: composer dev-tools changelog:check -- --file="${CHANGELOG_FILE}" --against="origin/${BASE_REF}"
 
-            - uses: ./.github/actions/summary/write
+            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
               with:
                   markdown: |
                       ## Changelog Validation Summary
@@ -132,9 +144,15 @@ jobs:
                   token: ${{ github.token }}
                   ref: ${{ github.event.repository.default_branch }}
                   fetch-depth: 0
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -142,7 +160,7 @@ jobs:
 
             - name: Resolve release version
               id: version
-              uses: ./.github/actions/changelog/resolve-version
+              uses: ./.dev-tools-workflow-source/.github/actions/changelog/resolve-version
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ inputs.version || '' }}
@@ -155,7 +173,7 @@ jobs:
                   composer dev-tools changelog:promote -- "${RELEASE_VERSION}" --file="${CHANGELOG_FILE}" --date="${release_date}"
 
             - name: Render release notes preview
-              uses: ./.github/actions/changelog/render-release-notes
+              uses: ./.dev-tools-workflow-source/.github/actions/changelog/render-release-notes
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ steps.version.outputs.value }}
@@ -183,14 +201,20 @@ jobs:
                       - source: `${{ steps.version.outputs.source }}`
 
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
-            - uses: ./.github/actions/project-board/transition-status
+            - uses: ./.dev-tools-workflow-source/.github/actions/project-board/transition-status
               with:
                   project: ${{ inputs.project || vars.PROJECT || '' }}
                   from-status: Merged
                   to-status: Release Prepared
 
-            - uses: ./.github/actions/summary/write
+            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
               with:
                   markdown: |
                       ## Release Preparation Summary
@@ -217,9 +241,15 @@ jobs:
                   token: ${{ github.token }}
                   ref: ${{ github.event.pull_request.base.ref }}
                   fetch-depth: 0
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ env.CHANGELOG_ROOT_VERSION }}
@@ -227,34 +257,40 @@ jobs:
 
             - name: Resolve merged release version
               id: version
-              uses: ./.github/actions/changelog/resolve-merged-version
+              uses: ./.dev-tools-workflow-source/.github/actions/changelog/resolve-merged-version
               with:
                   head-ref: ${{ github.event.pull_request.head.ref }}
                   release-branch-prefix: ${{ env.RELEASE_BRANCH_PREFIX }}
 
             - name: Render release notes
-              uses: ./.github/actions/changelog/render-release-notes
+              uses: ./.dev-tools-workflow-source/.github/actions/changelog/render-release-notes
               with:
                   changelog-file: ${{ env.CHANGELOG_FILE }}
                   version: ${{ steps.version.outputs.value }}
 
             - name: Publish GitHub release
               id: publish_release
-              uses: ./.github/actions/changelog/publish-release
+              uses: ./.dev-tools-workflow-source/.github/actions/changelog/publish-release
               with:
                   version: ${{ steps.version.outputs.value }}
                   target: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
 
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                  repository: php-fast-forward/dev-tools
+                  ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                  path: .dev-tools-workflow-source
 
-            - uses: ./.github/actions/project-board/transition-status
+            - uses: ./.dev-tools-workflow-source/.github/actions/project-board/transition-status
               with:
                   project: ${{ inputs.project || vars.PROJECT || '' }}
                   from-status: Release Prepared
                   to-status: Released
                   include-current-pull-request: 'true'
 
-            - uses: ./.github/actions/summary/write
+            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
               with:
                   markdown: |
                       ## Release Publication Summary

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Copy labels from issue to PR
-        uses: ./.dev-tools-workflow-source/.github/actions/label-sync/copy-linked-issue-labels
+        uses: ./.dev-tools-actions/.github/actions/label-sync/copy-linked-issue-labels

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - name: Copy labels from issue to PR
-        uses: ./.github/actions/label-sync/copy-linked-issue-labels
+        uses: ./.dev-tools-workflow-source/.github/actions/label-sync/copy-linked-issue-labels

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -42,10 +42,16 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.github/actions/php/resolve-version
+              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
 
     reports:
         needs: resolve_php
@@ -63,9 +69,15 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 fetch-depth: 0
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
                 extensions: pcov, pcntl
@@ -99,7 +111,7 @@ jobs:
 
             - name: Copy existing previews into publish directory
               if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-              uses: ./.github/actions/github-pages/restore-previews
+              uses: ./.dev-tools-workflow-source/.github/actions/github-pages/restore-previews
               with:
                 source: gh-pages-current
                 target: ${{ env.REPORTS_TARGET }}
@@ -134,8 +146,14 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
-            - uses: ./.github/actions/github-pages/verify-deployment
+            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/verify-deployment
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
                 title: Reports health check failed
@@ -152,8 +170,14 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
-            - uses: ./.github/actions/github-pages/verify-deployment
+            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/verify-deployment
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}
                 title: Preview health check failed
@@ -195,6 +219,12 @@ jobs:
             - uses: actions/checkout@v6
               with:
                 ref: ${{ github.event.repository.default_branch }}
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Checkout gh-pages
               uses: actions/checkout@v6
@@ -202,7 +232,7 @@ jobs:
                 ref: gh-pages
                 path: gh-pages
 
-            - uses: ./.github/actions/github-pages/remove-preview
+            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/remove-preview
               with:
                 path: gh-pages
                 pull-request-number: ${{ github.event.pull_request.number }}
@@ -226,6 +256,12 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Checkout gh-pages
               uses: actions/checkout@v6
@@ -233,7 +269,7 @@ jobs:
                 ref: gh-pages
                 path: gh-pages
 
-            - uses: ./.github/actions/github-pages/cleanup-orphaned-previews
+            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/cleanup-orphaned-previews
               id: cleanup
               with:
                 path: gh-pages
@@ -256,6 +292,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - id: build_summary
               env:
@@ -300,6 +342,6 @@ jobs:
                   echo 'EOF'
                 } >> "$GITHUB_OUTPUT"
 
-            - uses: ./.github/actions/summary/write
+            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
               with:
                 markdown: ${{ steps.build_summary.outputs.markdown }}

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -47,11 +47,13 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
+              uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
     reports:
         needs: resolve_php
@@ -74,10 +76,12 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
                 extensions: pcov, pcntl
@@ -111,7 +115,7 @@ jobs:
 
             - name: Copy existing previews into publish directory
               if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-              uses: ./.dev-tools-workflow-source/.github/actions/github-pages/restore-previews
+              uses: ./.dev-tools-actions/.github/actions/github-pages/restore-previews
               with:
                 source: gh-pages-current
                 target: ${{ env.REPORTS_TARGET }}
@@ -151,9 +155,11 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/verify-deployment
+            - uses: ./.dev-tools-actions/.github/actions/github-pages/verify-deployment
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
                 title: Reports health check failed
@@ -175,9 +181,11 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/verify-deployment
+            - uses: ./.dev-tools-actions/.github/actions/github-pages/verify-deployment
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}
                 title: Preview health check failed
@@ -224,7 +232,9 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Checkout gh-pages
               uses: actions/checkout@v6
@@ -232,7 +242,7 @@ jobs:
                 ref: gh-pages
                 path: gh-pages
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/remove-preview
+            - uses: ./.dev-tools-actions/.github/actions/github-pages/remove-preview
               with:
                 path: gh-pages
                 pull-request-number: ${{ github.event.pull_request.number }}
@@ -261,7 +271,9 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Checkout gh-pages
               uses: actions/checkout@v6
@@ -269,7 +281,7 @@ jobs:
                 ref: gh-pages
                 path: gh-pages
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/github-pages/cleanup-orphaned-previews
+            - uses: ./.dev-tools-actions/.github/actions/github-pages/cleanup-orphaned-previews
               id: cleanup
               with:
                 path: gh-pages
@@ -297,7 +309,9 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - id: build_summary
               env:
@@ -342,6 +356,6 @@ jobs:
                   echo 'EOF'
                 } >> "$GITHUB_OUTPUT"
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+            - uses: ./.dev-tools-actions/.github/actions/summary/write
               with:
                 markdown: ${{ steps.build_summary.outputs.markdown }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -27,9 +27,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - id: render
-        uses: ./.github/actions/review/render-request
+        uses: ./.dev-tools-workflow-source/.github/actions/review/render-request
         with:
           pull-request-number: ${{ inputs.pull-request-number || github.event.inputs.pull-request-number || github.event.pull_request.number || '' }}
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -32,10 +32,12 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - id: render
-        uses: ./.dev-tools-workflow-source/.github/actions/review/render-request
+        uses: ./.dev-tools-actions/.github/actions/review/render-request
         with:
           pull-request-number: ${{ inputs.pull-request-number || github.event.inputs.pull-request-number || github.event.pull_request.number || '' }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,13 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
+              uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
     tests:
         needs: resolve_php
@@ -83,10 +85,12 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ matrix.php-version }}
                 extensions: pcov, pcntl
@@ -123,10 +127,12 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
             - name: Setup PHP and install dependencies
-              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+              uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
                 root-version: ${{ env.TESTS_ROOT_VERSION }}
@@ -152,9 +158,11 @@ jobs:
               with:
                 repository: php-fast-forward/dev-tools
                 ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-                path: .dev-tools-workflow-source
+                path: .dev-tools-actions
+                sparse-checkout: |
+                  .github/actions
 
-            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+            - uses: ./.dev-tools-actions/.github/actions/summary/write
               with:
                 markdown: |
                   ## Tests Workflow Summary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,10 +57,16 @@ jobs:
 
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Resolve workflow PHP version
               id: resolve
-              uses: ./.github/actions/php/resolve-version
+              uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
 
     tests:
         needs: resolve_php
@@ -72,9 +78,15 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                 php-version: ${{ matrix.php-version }}
                 extensions: pcov, pcntl
@@ -106,9 +118,15 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
             - name: Setup PHP and install dependencies
-              uses: ./.github/actions/php/setup-composer
+              uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
                 root-version: ${{ env.TESTS_ROOT_VERSION }}
@@ -129,8 +147,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
+            - name: Checkout dev-tools workflow action source
+              uses: actions/checkout@v6
+              with:
+                repository: php-fast-forward/dev-tools
+                ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+                path: .dev-tools-workflow-source
 
-            - uses: ./.github/actions/summary/write
+            - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
               with:
                 markdown: |
                   ## Tests Workflow Summary

--- a/.github/workflows/wiki-maintenance.yml
+++ b/.github/workflows/wiki-maintenance.yml
@@ -30,6 +30,12 @@ jobs:
           ref: main
           submodules: recursive
           fetch-depth: 0
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - name: Mark workspace as safe for git
         run: |
@@ -38,7 +44,7 @@ jobs:
 
       - name: Prepare wiki publish branch from preview branch
         id: prepare_publish
-        uses: ./.github/actions/wiki/prepare-publish-branch
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/prepare-publish-branch
         with:
           publish-branch: ${{ env.WIKI_PUBLISH_BRANCH }}
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
@@ -48,18 +54,18 @@ jobs:
         run: git push --force-with-lease origin HEAD:"${WIKI_PUBLISH_BRANCH}"
 
       - name: Validate wiki publish branch
-        uses: ./.github/actions/wiki/validate-publish-branch
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/validate-publish-branch
         with:
           publish-branch: ${{ env.WIKI_PUBLISH_BRANCH }}
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
           expected-preview-sha: ${{ steps.prepare_publish.outputs.expected-preview-sha }}
 
       - name: Delete wiki preview branch
-        uses: ./.github/actions/wiki/delete-preview-branch
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
-      - uses: ./.github/actions/summary/write
+      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Publish Summary
@@ -88,16 +94,22 @@ jobs:
           ref: main
           submodules: recursive
           fetch-depth: 0
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - name: Mark wiki workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki preview branch
-        uses: ./.github/actions/wiki/delete-preview-branch
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
-      - uses: ./.github/actions/summary/write
+      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Preview Cleanup Summary
@@ -121,15 +133,21 @@ jobs:
           ref: main
           submodules: recursive
           fetch-depth: 0
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - name: Mark wiki workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki branches for closed pull requests
         id: cleanup
-        uses: ./.github/actions/wiki/cleanup-orphaned-previews
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/cleanup-orphaned-previews
 
-      - uses: ./.github/actions/summary/write
+      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Orphan Cleanup Summary

--- a/.github/workflows/wiki-maintenance.yml
+++ b/.github/workflows/wiki-maintenance.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Mark workspace as safe for git
         run: |
@@ -44,7 +46,7 @@ jobs:
 
       - name: Prepare wiki publish branch from preview branch
         id: prepare_publish
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/prepare-publish-branch
+        uses: ./.dev-tools-actions/.github/actions/wiki/prepare-publish-branch
         with:
           publish-branch: ${{ env.WIKI_PUBLISH_BRANCH }}
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
@@ -54,18 +56,18 @@ jobs:
         run: git push --force-with-lease origin HEAD:"${WIKI_PUBLISH_BRANCH}"
 
       - name: Validate wiki publish branch
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/validate-publish-branch
+        uses: ./.dev-tools-actions/.github/actions/wiki/validate-publish-branch
         with:
           publish-branch: ${{ env.WIKI_PUBLISH_BRANCH }}
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
           expected-preview-sha: ${{ steps.prepare_publish.outputs.expected-preview-sha }}
 
       - name: Delete wiki preview branch
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/delete-preview-branch
+        uses: ./.dev-tools-actions/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+      - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Publish Summary
@@ -99,17 +101,19 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Mark wiki workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki preview branch
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/delete-preview-branch
+        uses: ./.dev-tools-actions/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+      - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Preview Cleanup Summary
@@ -138,16 +142,18 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Mark wiki workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki branches for closed pull requests
         id: cleanup
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/cleanup-orphaned-previews
+        uses: ./.dev-tools-actions/.github/actions/wiki/cleanup-orphaned-previews
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+      - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Orphan Cleanup Summary

--- a/.github/workflows/wiki-preview.yml
+++ b/.github/workflows/wiki-preview.yml
@@ -19,10 +19,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
 
       - name: Resolve workflow PHP version
         id: resolve
-        uses: ./.github/actions/php/resolve-version
+        uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
 
   preview:
     needs: resolve_php
@@ -45,8 +51,15 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Checkout dev-tools workflow action source
+        uses: actions/checkout@v6
+        with:
+          repository: php-fast-forward/dev-tools
+          ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
+          path: .dev-tools-workflow-source
+
       - name: Setup PHP and install dependencies
-        uses: ./.github/actions/php/setup-composer
+        uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
         with:
           php-version: ${{ needs.resolve_php.outputs.php-version }}
           root-version: dev-${{ github.event.pull_request.head.ref }}
@@ -54,7 +67,7 @@ jobs:
             ${{ github.workspace }}/.github/wiki
 
       - name: Prepare wiki preview branch
-        uses: ./.github/actions/wiki/prepare-preview-branch
+        uses: ./.dev-tools-workflow-source/.github/actions/wiki/prepare-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
@@ -93,7 +106,7 @@ jobs:
           pull: "--rebase --autostash"
           push: true
 
-      - uses: ./.github/actions/summary/write
+      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Preview Summary

--- a/.github/workflows/wiki-preview.yml
+++ b/.github/workflows/wiki-preview.yml
@@ -24,11 +24,13 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Resolve workflow PHP version
         id: resolve
-        uses: ./.dev-tools-workflow-source/.github/actions/php/resolve-version
+        uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
   preview:
     needs: resolve_php
@@ -56,10 +58,12 @@ jobs:
         with:
           repository: php-fast-forward/dev-tools
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
-          path: .dev-tools-workflow-source
+          path: .dev-tools-actions
+          sparse-checkout: |
+            .github/actions
 
       - name: Setup PHP and install dependencies
-        uses: ./.dev-tools-workflow-source/.github/actions/php/setup-composer
+        uses: ./.dev-tools-actions/.github/actions/php/setup-composer
         with:
           php-version: ${{ needs.resolve_php.outputs.php-version }}
           root-version: dev-${{ github.event.pull_request.head.ref }}
@@ -67,7 +71,7 @@ jobs:
             ${{ github.workspace }}/.github/wiki
 
       - name: Prepare wiki preview branch
-        uses: ./.dev-tools-workflow-source/.github/actions/wiki/prepare-preview-branch
+        uses: ./.dev-tools-actions/.github/actions/wiki/prepare-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
@@ -106,7 +110,7 @@ jobs:
           pull: "--rebase --autostash"
           push: true
 
-      - uses: ./.dev-tools-workflow-source/.github/actions/summary/write
+      - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:
           markdown: |
             ## Wiki Preview Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Force reusable workflows to check out the dev-tools repository before resolving local GitHub Actions so consumer wrappers stop failing on missing action paths (#180)
+
 ## [1.19.0] - 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Force reusable workflows to check out the dev-tools repository before resolving local GitHub Actions so consumer wrappers stop failing on missing action paths (#180)
+- Force reusable workflows to sparse-checkout `.github/actions` into a dedicated `.dev-tools-actions` workspace before resolving local GitHub Actions so consumer wrappers stop failing on missing action paths (#180)
 
 ## [1.19.0] - 2026-04-23
 

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -21,10 +21,11 @@ The automation model now has three layers:
     defaults local while delegating implementation to the reusable workflows in
     ``php-fast-forward/dev-tools``.
 *   **Workflow action source checkout** inside the reusable workflows when they
-    need local action implementations from ``.github/actions/``. This keeps
-    the consumer repository thin while still letting the reusable workflow
-    resolve action paths from the upstream ``php-fast-forward/dev-tools``
-    repository.
+    need local action implementations from ``.github/actions/``. The reusable
+    workflow performs a sparse checkout of that directory into a dedicated
+    ``.dev-tools-actions`` workspace path, which keeps the consumer
+    repository thin while still letting the reusable workflow resolve action
+    paths from the upstream ``php-fast-forward/dev-tools`` repository.
 
 Wrapper Workflows
 -----------------

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -20,6 +20,11 @@ The automation model now has three layers:
     ``dev-tools:sync``. These wrappers keep triggers and repository-specific
     defaults local while delegating implementation to the reusable workflows in
     ``php-fast-forward/dev-tools``.
+*   **Workflow action source checkout** inside the reusable workflows when they
+    need local action implementations from ``.github/actions/``. This keeps
+    the consumer repository thin while still letting the reusable workflow
+    resolve action paths from the upstream ``php-fast-forward/dev-tools``
+    repository.
 
 Wrapper Workflows
 -----------------

--- a/docs/usage/syncing-consumer-projects.rst
+++ b/docs/usage/syncing-consumer-projects.rst
@@ -76,8 +76,10 @@ The synchronized workflow files in consumer repositories are wrappers, not the
 full implementation. The actual reusable workflows live in the upstream
 ``php-fast-forward/dev-tools`` repository. When those reusable workflows need
 local action implementations, they explicitly check out the upstream
-``php-fast-forward/dev-tools`` repository into the run workspace first so the
-consumer repository does not need to mirror ``.github/actions`` locally.
+``php-fast-forward/dev-tools`` repository into a dedicated
+``.dev-tools-actions`` path in the run workspace first, using sparse checkout
+for ``.github/actions`` only, so the consumer repository does not need to
+mirror ``.github/actions`` locally.
 
 That matters most for these cases:
 

--- a/docs/usage/syncing-consumer-projects.rst
+++ b/docs/usage/syncing-consumer-projects.rst
@@ -74,8 +74,10 @@ Workflow Wrapper Notes
 
 The synchronized workflow files in consumer repositories are wrappers, not the
 full implementation. The actual reusable workflows live in the upstream
-``php-fast-forward/dev-tools`` repository and internally compose local actions
-from ``.github/actions/`` there.
+``php-fast-forward/dev-tools`` repository. When those reusable workflows need
+local action implementations, they explicitly check out the upstream
+``php-fast-forward/dev-tools`` repository into the run workspace first so the
+consumer repository does not need to mirror ``.github/actions`` locally.
 
 That matters most for these cases:
 


### PR DESCRIPTION
## Related Issue

- Closes #180

## Motivation / Context

Consumer repositories call the packaged reusable workflows from `php-fast-forward/dev-tools`, but those workflows were resolving local actions like `./.github/actions/...` relative to the caller repository. That made consumer runs fail as soon as a reusable workflow depended on a local action that only exists in this repository.

## Changes

- make reusable workflows check out `php-fast-forward/dev-tools` as a dedicated workflow-action source before using local actions
- resolve local actions from `./.dev-tools-workflow-source/.github/actions/...` instead of the caller repository
- keep the source ref stable for consumers while still using the current revision when workflows run inside this repository
- document that consumer repositories do not need mirrored `.github/actions` directories for these reusable workflows
- add the changelog entry for the workflow-action source checkout behavior

## Verification

- `ruby -e 'require "yaml"; %w[.github/workflows/auto-assign.yml .github/workflows/label-sync.yml .github/workflows/review.yml .github/workflows/tests.yml .github/workflows/reports.yml .github/workflows/changelog.yml .github/workflows/wiki-preview.yml .github/workflows/wiki-maintenance.yml].each { |path| YAML.load_file(path) }; puts "ok"'`
- `composer dev-tools changelog:check`
- `git diff --check`

## Documentation / Generated Output

- updated `docs/usage/github-actions.rst`
- updated `docs/usage/syncing-consumer-projects.rst`

## Changelog

- added an `Unreleased` entry for the reusable workflow action-source checkout fix

## Reviewer Notes

- `.github/wiki` remains local-only and is intentionally not part of this PR
