### PR TITLE
[changelog] Fix Dependabot fallback branch validation (#191)

### DIFF
--- a/.github/actions/changelog/create-dependabot-entry/action.yml
+++ b/.github/actions/changelog/create-dependabot-entry/action.yml
@@ -22,6 +22,9 @@ outputs:
   created:
     description: Whether a changelog entry was created and pushed.
     value: ${{ steps.create.outputs.created }}
+  status:
+    description: Whether the branch already had an entry, auto-created one, or still remains missing.
+    value: ${{ steps.create.outputs.status }}
   message:
     description: Generated changelog entry message, or empty when no entry was needed.
     value: ${{ steps.create.outputs.message }}

--- a/.github/actions/changelog/create-dependabot-entry/run.sh
+++ b/.github/actions/changelog/create-dependabot-entry/run.sh
@@ -1,24 +1,62 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if composer dev-tools changelog:check -- --file="${INPUT_CHANGELOG_FILE}" --against="origin/${INPUT_BASE_REF}" >/dev/null 2>&1; then
-    echo "created=false" >> "$GITHUB_OUTPUT"
-    exit 0
-fi
+entry_message="$(php -r 'require "vendor/autoload.php"; $resolver = new \FastForward\DevTools\Changelog\DependabotChangelogEntryMessageResolver(); echo $resolver->resolve(getenv("INPUT_PULL_REQUEST_TITLE") ?: "", (int) (getenv("INPUT_PULL_REQUEST_NUMBER") ?: 0));')"
 
+git fetch --no-tags --depth=1 origin "+refs/heads/${INPUT_BASE_REF}:refs/remotes/origin/${INPUT_BASE_REF}"
 git fetch --no-tags --depth=1 origin "+refs/heads/${INPUT_HEAD_REF}:refs/remotes/origin/${INPUT_HEAD_REF}"
 git switch -C "${INPUT_HEAD_REF}" "refs/remotes/origin/${INPUT_HEAD_REF}"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-entry_message="$(php -r 'require "vendor/autoload.php"; $resolver = new \FastForward\DevTools\Changelog\DependabotChangelogEntryMessageResolver(); echo $resolver->resolve(getenv("INPUT_PULL_REQUEST_TITLE") ?: "", (int) (getenv("INPUT_PULL_REQUEST_NUMBER") ?: 0));')"
+if composer dev-tools changelog:check -- --file="${INPUT_CHANGELOG_FILE}" --against="origin/${INPUT_BASE_REF}" >/dev/null 2>&1; then
+    {
+        echo "created=false"
+        echo "status=already-present"
+        printf 'message=%s\n' "${entry_message}"
+    } >> "$GITHUB_OUTPUT"
+
+    exit 0
+fi
 
 composer dev-tools changelog:entry -- --type=changed --file="${INPUT_CHANGELOG_FILE}" "${entry_message}"
 git add "${INPUT_CHANGELOG_FILE}"
+
+if git diff --cached --quiet -- "${INPUT_CHANGELOG_FILE}"; then
+    {
+        echo "created=false"
+        echo "status=missing"
+        printf 'message=%s\n' "${entry_message}"
+    } >> "$GITHUB_OUTPUT"
+
+    exit 1
+fi
+
 git commit -m "Add changelog entry for Dependabot PR #${INPUT_PULL_REQUEST_NUMBER}"
 git push origin "HEAD:${INPUT_HEAD_REF}"
 
+if ! composer dev-tools changelog:check -- --file="${INPUT_CHANGELOG_FILE}" --against="origin/${INPUT_BASE_REF}" >/dev/null 2>&1; then
+    {
+        echo "created=false"
+        echo "status=missing"
+        printf 'message=%s\n' "${entry_message}"
+    } >> "$GITHUB_OUTPUT"
+
+    exit 1
+fi
+
+if ! grep -F --quiet -- "- ${entry_message}" "${INPUT_CHANGELOG_FILE}"; then
+    {
+        echo "created=false"
+        echo "status=missing"
+        printf 'message=%s\n' "${entry_message}"
+    } >> "$GITHUB_OUTPUT"
+
+    exit 1
+fi
+
 {
     echo "created=true"
+    echo "status=auto-created"
     printf 'message=%s\n' "${entry_message}"
 } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -141,8 +141,9 @@ jobs:
 
                       - Changelog file: `${{ env.CHANGELOG_FILE }}`
                       - Compared base ref: `origin/${{ env.BASE_REF }}`
+                      - Dependabot fallback status: `${{ steps.dependabot_entry.outputs.status || 'not needed' }}`
                       - Dependabot fallback entry created: `${{ steps.dependabot_entry.outputs.created || 'false' }}`
-                      - Dependabot fallback entry message: `${{ steps.dependabot_entry.outputs.message || 'not needed' }}`
+                      - Dependabot fallback generated message: `${{ steps.dependabot_entry.outputs.message || 'not needed' }}`
                       - Validation result: success
 
     prepare_release_pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions(deps): Bump marocchino/sticky-pull-request-comment from 2 to 3 (#182)
 - GitHub Actions(deps): Bump actions/github-script from 8 to 9 (#183)
 - Auto-create and push minimal changelog entries for same-repository Dependabot pull requests before changelog validation reruns (#186)
+- Resolve Dependabot changelog fallback state from the actual PR head branch and report `already-present`, `auto-created`, or `missing` in the workflow summary so rebased PRs cannot pass on inherited `Unreleased` entries alone (#191)
 
 ## [1.20.0] - 2026-04-23
 

--- a/tests/Changelog/Checker/UnreleasedEntryCheckerTest.php
+++ b/tests/Changelog/Checker/UnreleasedEntryCheckerTest.php
@@ -179,6 +179,59 @@ final class UnreleasedEntryCheckerTest extends TestCase
      * @return void
      */
     #[Test]
+    public function hasPendingChangesWillIgnoreEntriesOnlyInheritedFromTheBaseBranch(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument([
+                'Auto-create and push minimal changelog entries for same-repository Dependabot pull requests before changelog validation reruns (#186)',
+            ]))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->willReturn('baseline changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('baseline changelog')
+            ->willReturn($this->createDocument([
+                'Auto-create and push minimal changelog entries for same-repository Dependabot pull requests before changelog validation reruns (#186)',
+            ]))
+            ->shouldBeCalledOnce();
+
+        self::assertFalse($this->checker->hasPendingChanges(self::FILE, 'origin/main'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function hasPendingChangesWillStillDetectBranchSpecificEntriesAlongsideInheritedOnes(): void
+    {
+        $this->filesystem->readFile(self::FILE)
+            ->willReturn('current changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('current changelog')
+            ->willReturn($this->createDocument([
+                'Auto-create and push minimal changelog entries for same-repository Dependabot pull requests before changelog validation reruns (#186)',
+                'GitHub Actions(deps): Bump actions/github-script from 8 to 9 (#183)',
+            ]))
+            ->shouldBeCalledOnce();
+        $this->gitClient->show('origin/main', self::FILE, self::WORKING_DIRECTORY)
+            ->willReturn('baseline changelog')
+            ->shouldBeCalledOnce();
+        $this->parser->parse('baseline changelog')
+            ->willReturn($this->createDocument([
+                'Auto-create and push minimal changelog entries for same-repository Dependabot pull requests before changelog validation reruns (#186)',
+            ]))
+            ->shouldBeCalledOnce();
+
+        self::assertTrue($this->checker->hasPendingChanges(self::FILE, 'origin/main'));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function hasPendingChangesWillReturnTrueWhenTheBaselineCannotBeLoaded(): void
     {
         $this->filesystem->readFile(self::FILE)


### PR DESCRIPTION
## Related Issue

Closes #191

## Motivation / Context

- Dependabot PRs could pass changelog validation after a rebase without actually having their own branch-specific changelog entry.
- The fallback action was deciding from the checked out PR merge ref instead of the real head branch, which let inherited `Unreleased` state look good enough.

## Changes

- switch the Dependabot fallback action to fetch and evaluate the actual PR head branch before deciding whether an entry is already present
- make the action self-contained by fetching the base ref itself and emitting an explicit `already-present`, `auto-created`, or `missing` status
- fail the fallback action if it still cannot prove that the generated entry exists after creation
- add regression coverage for rebased branches that inherit unrelated `Unreleased` entries from `main`

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s):
  - `./vendor/bin/phpunit tests/Changelog/Checker/UnreleasedEntryCheckerTest.php tests/Changelog/DependabotChangelogEntryMessageResolverTest.php tests/Console/Command/ChangelogCheckCommandTest.php tests/Console/Command/ChangelogEntryCommandTest.php`
  - `bash -n .github/actions/changelog/create-dependabot-entry/run.sh`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/actions/changelog/create-dependabot-entry/action.yml"); YAML.load_file(".github/workflows/changelog.yml"); puts "yaml ok"'`
  - `composer dev-tools changelog:check`
  - `git diff --check`
- [ ] Manual verification:

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The fix intentionally keeps the generic changelog checker as the source of truth for "meaningful branch-specific entry", but now runs that check from the real head branch instead of the PR merge checkout.
