### PR TITLE
[composer] Restore consumer command discovery compatibility (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep packaged `.agents` payloads exportable and synchronize packaged skills and agents with repository-relative symlink targets so consumer repositories no longer receive broken absolute machine paths (#188)
 - Rewrite drifted Git hooks by removing the previous target first, restore the intended `0o755` executable mode, and report unwritable hook replacements cleanly when `.git/hooks` stays locked (#190)
+- Keep Composer plugin command discovery compatible with consumer environments by moving unsupported Symfony Console named parameters out of command metadata/configuration and by decoupling the custom filesystem wrapper from Composer's bundled Symfony Filesystem signatures (#185)
 
 ## [1.20.0] - 2026-04-23
 

--- a/src/Console/Command/AgentsCommand.php
+++ b/src/Console/Command/AgentsCommand.php
@@ -63,7 +63,6 @@ final class AgentsCommand extends BaseCommand implements LoggerAwareCommandInter
     protected function configure(): void
     {
         $this->setHelp('This command ensures the consumer repository contains linked Fast Forward project agents by creating symlinks to the packaged prompts and removing broken links.');
-
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/AgentsCommand.php
+++ b/src/Console/Command/AgentsCommand.php
@@ -62,7 +62,10 @@ final class AgentsCommand extends BaseCommand implements LoggerAwareCommandInter
      */
     protected function configure(): void
     {
-        $this->setHelp('This command ensures the consumer repository contains linked Fast Forward project agents by creating symlinks to the packaged prompts and removing broken links.');
+        $this->setHelp(
+            'This command ensures the consumer repository contains linked Fast Forward project agents by creating'
+            . ' symlinks to the packaged prompts and removing broken links.'
+        );
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/AgentsCommand.php
+++ b/src/Console/Command/AgentsCommand.php
@@ -35,8 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'agents',
-    description: 'Synchronizes Fast Forward project agents into .agents/agents directory.',
-    help: 'This command ensures the consumer repository contains linked Fast Forward project agents by creating symlinks to the packaged prompts and removing broken links.'
+    description: 'Synchronizes Fast Forward project agents into .agents/agents directory.'
 )]
 final class AgentsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -63,6 +62,7 @@ final class AgentsCommand extends BaseCommand implements LoggerAwareCommandInter
      */
     protected function configure(): void
     {
+        $this->setHelp('This command ensures the consumer repository contains linked Fast Forward project agents by creating symlinks to the packaged prompts and removing broken links.');
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/AgentsCommand.php
+++ b/src/Console/Command/AgentsCommand.php
@@ -63,6 +63,7 @@ final class AgentsCommand extends BaseCommand implements LoggerAwareCommandInter
     protected function configure(): void
     {
         $this->setHelp('This command ensures the consumer repository contains linked Fast Forward project agents by creating symlinks to the packaged prompts and removing broken links.');
+
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/ChangelogCheckCommand.php
+++ b/src/Console/Command/ChangelogCheckCommand.php
@@ -35,8 +35,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'changelog:check',
-    description: 'Checks whether a changelog file contains meaningful unreleased entries.',
-    help: 'This command validates the current Unreleased section and may compare it against a base git reference to enforce pull request changelog updates.'
+    description: 'Checks whether a changelog file contains meaningful unreleased entries.'
 )]
 final class ChangelogCheckCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -61,6 +60,7 @@ final class ChangelogCheckCommand extends BaseCommand implements LoggerAwareComm
      */
     protected function configure(): void
     {
+        $this->setHelp('This command validates the current Unreleased section and may compare it against a base git reference to enforce pull request changelog updates.');
         $this->addJsonOption()
             ->addOption(
                 name: 'against',

--- a/src/Console/Command/ChangelogCheckCommand.php
+++ b/src/Console/Command/ChangelogCheckCommand.php
@@ -60,7 +60,10 @@ final class ChangelogCheckCommand extends BaseCommand implements LoggerAwareComm
      */
     protected function configure(): void
     {
-        $this->setHelp('This command validates the current Unreleased section and may compare it against a base git reference to enforce pull request changelog updates.');
+        $this->setHelp(
+            'This command validates the current Unreleased section and may compare it against a base git'
+            . ' reference to enforce pull request changelog updates.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/ChangelogCheckCommand.php
+++ b/src/Console/Command/ChangelogCheckCommand.php
@@ -61,6 +61,7 @@ final class ChangelogCheckCommand extends BaseCommand implements LoggerAwareComm
     protected function configure(): void
     {
         $this->setHelp('This command validates the current Unreleased section and may compare it against a base git reference to enforce pull request changelog updates.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'against',

--- a/src/Console/Command/ChangelogEntryCommand.php
+++ b/src/Console/Command/ChangelogEntryCommand.php
@@ -38,8 +38,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'changelog:entry',
-    description: 'Adds a changelog entry to Unreleased or a specific version section.',
-    help: 'This command appends one categorized changelog entry to the selected changelog file so it can be reused by local authoring flows and skills.'
+    description: 'Adds a changelog entry to Unreleased or a specific version section.'
 )]
 final class ChangelogEntryCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -64,6 +63,7 @@ final class ChangelogEntryCommand extends BaseCommand implements LoggerAwareComm
      */
     protected function configure(): void
     {
+        $this->setHelp('This command appends one categorized changelog entry to the selected changelog file so it can be reused by local authoring flows and skills.');
         $this->addJsonOption()
             ->addArgument(
                 name: 'message',
@@ -76,10 +76,6 @@ final class ChangelogEntryCommand extends BaseCommand implements LoggerAwareComm
                 mode: InputOption::VALUE_REQUIRED,
                 description: 'The changelog category (added, changed, deprecated, removed, fixed, security).',
                 default: 'added',
-                suggestedValues: array_map(
-                    static fn(ChangelogEntryType $type): string => strtolower($type->value),
-                    ChangelogEntryType::ordered()
-                ),
             )
             ->addOption(
                 name: 'release',

--- a/src/Console/Command/ChangelogEntryCommand.php
+++ b/src/Console/Command/ChangelogEntryCommand.php
@@ -63,7 +63,10 @@ final class ChangelogEntryCommand extends BaseCommand implements LoggerAwareComm
      */
     protected function configure(): void
     {
-        $this->setHelp('This command appends one categorized changelog entry to the selected changelog file so it can be reused by local authoring flows and skills.');
+        $this->setHelp(
+            'This command appends one categorized changelog entry to the selected changelog file so it can be'
+            . ' reused by local authoring flows and skills.'
+        );
 
         $this->addJsonOption()
             ->addArgument(

--- a/src/Console/Command/ChangelogEntryCommand.php
+++ b/src/Console/Command/ChangelogEntryCommand.php
@@ -64,6 +64,7 @@ final class ChangelogEntryCommand extends BaseCommand implements LoggerAwareComm
     protected function configure(): void
     {
         $this->setHelp('This command appends one categorized changelog entry to the selected changelog file so it can be reused by local authoring flows and skills.');
+
         $this->addJsonOption()
             ->addArgument(
                 name: 'message',

--- a/src/Console/Command/ChangelogNextVersionCommand.php
+++ b/src/Console/Command/ChangelogNextVersionCommand.php
@@ -61,7 +61,10 @@ final class ChangelogNextVersionCommand extends BaseCommand implements LoggerAwa
      */
     protected function configure(): void
     {
-        $this->setHelp('This command inspects Unreleased changelog categories and prints the next semantic version inferred from the current changelog state.');
+        $this->setHelp(
+            'This command inspects Unreleased changelog categories and prints the next semantic version inferred'
+            . ' from the current changelog state.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/ChangelogNextVersionCommand.php
+++ b/src/Console/Command/ChangelogNextVersionCommand.php
@@ -36,8 +36,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'changelog:next-version',
-    description: 'Infers the next semantic version from the Unreleased changelog section.',
-    help: 'This command inspects Unreleased changelog categories and prints the next semantic version inferred from the current changelog state.'
+    description: 'Infers the next semantic version from the Unreleased changelog section.'
 )]
 final class ChangelogNextVersionCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -62,6 +61,7 @@ final class ChangelogNextVersionCommand extends BaseCommand implements LoggerAwa
      */
     protected function configure(): void
     {
+        $this->setHelp('This command inspects Unreleased changelog categories and prints the next semantic version inferred from the current changelog state.');
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/ChangelogNextVersionCommand.php
+++ b/src/Console/Command/ChangelogNextVersionCommand.php
@@ -62,6 +62,7 @@ final class ChangelogNextVersionCommand extends BaseCommand implements LoggerAwa
     protected function configure(): void
     {
         $this->setHelp('This command inspects Unreleased changelog categories and prints the next semantic version inferred from the current changelog state.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/ChangelogPromoteCommand.php
+++ b/src/Console/Command/ChangelogPromoteCommand.php
@@ -65,7 +65,10 @@ final class ChangelogPromoteCommand extends BaseCommand implements LoggerAwareCo
      */
     protected function configure(): void
     {
-        $this->setHelp('This command moves the current Unreleased entries into a released version section, records the release date, and restores an empty Unreleased section.');
+        $this->setHelp(
+            'This command moves the current Unreleased entries into a released version section, records the'
+            . ' release date, and restores an empty Unreleased section.'
+        );
 
         $this->addJsonOption()
             ->addArgument(

--- a/src/Console/Command/ChangelogPromoteCommand.php
+++ b/src/Console/Command/ChangelogPromoteCommand.php
@@ -66,6 +66,7 @@ final class ChangelogPromoteCommand extends BaseCommand implements LoggerAwareCo
     protected function configure(): void
     {
         $this->setHelp('This command moves the current Unreleased entries into a released version section, records the release date, and restores an empty Unreleased section.');
+
         $this->addJsonOption()
             ->addArgument(
                 name: 'version',

--- a/src/Console/Command/ChangelogPromoteCommand.php
+++ b/src/Console/Command/ChangelogPromoteCommand.php
@@ -38,8 +38,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'changelog:promote',
-    description: 'Promotes Unreleased entries into a published changelog version.',
-    help: 'This command moves the current Unreleased entries into a released version section, records the release date, and restores an empty Unreleased section.'
+    description: 'Promotes Unreleased entries into a published changelog version.'
 )]
 final class ChangelogPromoteCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -66,6 +65,7 @@ final class ChangelogPromoteCommand extends BaseCommand implements LoggerAwareCo
      */
     protected function configure(): void
     {
+        $this->setHelp('This command moves the current Unreleased entries into a released version section, records the release date, and restores an empty Unreleased section.');
         $this->addJsonOption()
             ->addArgument(
                 name: 'version',

--- a/src/Console/Command/ChangelogShowCommand.php
+++ b/src/Console/Command/ChangelogShowCommand.php
@@ -63,6 +63,7 @@ final class ChangelogShowCommand extends BaseCommand implements LoggerAwareComma
     protected function configure(): void
     {
         $this->setHelp('This command renders the body of one released changelog section so it can be reused for GitHub release notes.');
+
         $this->addJsonOption()
             ->addArgument(
                 name: 'version',

--- a/src/Console/Command/ChangelogShowCommand.php
+++ b/src/Console/Command/ChangelogShowCommand.php
@@ -62,7 +62,10 @@ final class ChangelogShowCommand extends BaseCommand implements LoggerAwareComma
      */
     protected function configure(): void
     {
-        $this->setHelp('This command renders the body of one released changelog section so it can be reused for GitHub release notes.');
+        $this->setHelp(
+            'This command renders the body of one released changelog section so it can be reused for GitHub'
+            . ' release notes.'
+        );
 
         $this->addJsonOption()
             ->addArgument(

--- a/src/Console/Command/ChangelogShowCommand.php
+++ b/src/Console/Command/ChangelogShowCommand.php
@@ -37,8 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'changelog:show',
-    description: 'Prints the notes body for a released changelog version.',
-    help: 'This command renders the body of one released changelog section so it can be reused for GitHub release notes.'
+    description: 'Prints the notes body for a released changelog version.'
 )]
 final class ChangelogShowCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -63,6 +62,7 @@ final class ChangelogShowCommand extends BaseCommand implements LoggerAwareComma
      */
     protected function configure(): void
     {
+        $this->setHelp('This command renders the body of one released changelog section so it can be reused for GitHub release notes.');
         $this->addJsonOption()
             ->addArgument(
                 name: 'version',

--- a/src/Console/Command/CodeOwnersCommand.php
+++ b/src/Console/Command/CodeOwnersCommand.php
@@ -66,7 +66,10 @@ final class CodeOwnersCommand extends BaseCommand implements LoggerAwareCommandI
      */
     protected function configure(): void
     {
-        $this->setHelp('This command infers CODEOWNERS entries from composer.json metadata, falls back to a commented template, and supports drift-aware preview and overwrite flows.');
+        $this->setHelp(
+            'This command infers CODEOWNERS entries from composer.json metadata, falls back to a commented'
+            . ' template, and supports drift-aware preview and overwrite flows.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/CodeOwnersCommand.php
+++ b/src/Console/Command/CodeOwnersCommand.php
@@ -67,6 +67,7 @@ final class CodeOwnersCommand extends BaseCommand implements LoggerAwareCommandI
     protected function configure(): void
     {
         $this->setHelp('This command infers CODEOWNERS entries from composer.json metadata, falls back to a commented template, and supports drift-aware preview and overwrite flows.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/CodeOwnersCommand.php
+++ b/src/Console/Command/CodeOwnersCommand.php
@@ -37,8 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'codeowners',
-    description: 'Generates .github/CODEOWNERS from local project metadata.',
-    help: 'This command infers CODEOWNERS entries from composer.json metadata, falls back to a commented template, and supports drift-aware preview and overwrite flows.'
+    description: 'Generates .github/CODEOWNERS from local project metadata.'
 )]
 final class CodeOwnersCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -67,6 +66,7 @@ final class CodeOwnersCommand extends BaseCommand implements LoggerAwareCommandI
      */
     protected function configure(): void
     {
+        $this->setHelp('This command infers CODEOWNERS entries from composer.json metadata, falls back to a commented template, and supports drift-aware preview and overwrite flows.');
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/CodeStyleCommand.php
+++ b/src/Console/Command/CodeStyleCommand.php
@@ -82,7 +82,9 @@ final class CodeStyleCommand extends BaseCommand implements LoggerAwareCommandIn
      */
     protected function configure(): void
     {
-        $this->setHelp('This command runs EasyCodingStandard and Composer Normalize to check and fix code style issues.');
+        $this->setHelp(
+            'This command runs EasyCodingStandard and Composer Normalize to check and fix code style issues.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/CodeStyleCommand.php
+++ b/src/Console/Command/CodeStyleCommand.php
@@ -38,8 +38,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'code-style',
-    description: 'Checks and fixes code style issues using EasyCodingStandard and Composer Normalize.',
-    help: 'This command runs EasyCodingStandard and Composer Normalize to check and fix code style issues.'
+    description: 'Checks and fixes code style issues using EasyCodingStandard and Composer Normalize.'
 )]
 final class CodeStyleCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -83,6 +82,7 @@ final class CodeStyleCommand extends BaseCommand implements LoggerAwareCommandIn
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs EasyCodingStandard and Composer Normalize to check and fix code style issues.');
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/CodeStyleCommand.php
+++ b/src/Console/Command/CodeStyleCommand.php
@@ -83,6 +83,7 @@ final class CodeStyleCommand extends BaseCommand implements LoggerAwareCommandIn
     protected function configure(): void
     {
         $this->setHelp('This command runs EasyCodingStandard and Composer Normalize to check and fix code style issues.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/CopyResourceCommand.php
+++ b/src/Console/Command/CopyResourceCommand.php
@@ -71,6 +71,7 @@ final class CopyResourceCommand extends BaseCommand implements LoggerAwareComman
     protected function configure(): void
     {
         $this->setHelp('This command copies a configured source file or every file in a source directory into the target path.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/CopyResourceCommand.php
+++ b/src/Console/Command/CopyResourceCommand.php
@@ -70,7 +70,10 @@ final class CopyResourceCommand extends BaseCommand implements LoggerAwareComman
      */
     protected function configure(): void
     {
-        $this->setHelp('This command copies a configured source file or every file in a source directory into the target path.');
+        $this->setHelp(
+            'This command copies a configured source file or every file in a source directory into the target'
+            . ' path.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/CopyResourceCommand.php
+++ b/src/Console/Command/CopyResourceCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Filesystem\Path;
  */
 #[AsCommand(
     name: 'copy-resource',
-    description: 'Copies a file or directory resource into the current project.',
-    help: 'This command copies a configured source file or every file in a source directory into the target path.'
+    description: 'Copies a file or directory resource into the current project.'
 )]
 final class CopyResourceCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -71,6 +70,7 @@ final class CopyResourceCommand extends BaseCommand implements LoggerAwareComman
      */
     protected function configure(): void
     {
+        $this->setHelp('This command copies a configured source file or every file in a source directory into the target path.');
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -75,7 +75,10 @@ final class DependenciesCommand extends BaseCommand implements LoggerAwareComman
      */
     protected function configure(): void
     {
-        $this->setHelp('This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.');
+        $this->setHelp(
+            'This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and'
+            . ' outdated Composer dependencies.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -44,8 +44,7 @@ use function is_numeric;
 #[AsCommand(
     name: 'dependencies',
     description: 'Analyzes missing, unused, misplaced, and outdated Composer dependencies.',
-    aliases: ['deps'],
-    help: 'This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.'
+    aliases: ['deps']
 )]
 final class DependenciesCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -76,6 +75,7 @@ final class DependenciesCommand extends BaseCommand implements LoggerAwareComman
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.');
         $this->addJsonOption()
             ->addOption(
                 name: 'max-outdated',

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -76,6 +76,7 @@ final class DependenciesCommand extends BaseCommand implements LoggerAwareComman
     protected function configure(): void
     {
         $this->setHelp('This command runs composer-dependency-analyser and Jack to report missing, unused, misplaced, and outdated Composer dependencies.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'max-outdated',

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -48,8 +48,7 @@ use function Safe\getcwd;
  */
 #[AsCommand(
     name: 'docs',
-    description: 'Generates API documentation.',
-    help: 'This command generates API documentation using phpDocumentor.',
+    description: 'Generates API documentation.'
 )]
 final class DocsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -83,6 +82,7 @@ final class DocsCommand extends BaseCommand implements LoggerAwareCommandInterfa
      */
     protected function configure(): void
     {
+        $this->setHelp('This command generates API documentation using phpDocumentor.');
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable phpDocumentor caching.')

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -41,8 +41,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'funding',
-    description: 'Synchronizes funding metadata between composer.json and .github/FUNDING.yml.',
-    help: 'This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.'
+    description: 'Synchronizes funding metadata between composer.json and .github/FUNDING.yml.'
 )]
 final class FundingCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -79,6 +78,7 @@ final class FundingCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
+        $this->setHelp('This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.');
         $this->addJsonOption()
             ->addOption(
                 name: 'composer-file',

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -79,6 +79,7 @@ final class FundingCommand extends BaseCommand implements LoggerAwareCommandInte
     protected function configure(): void
     {
         $this->setHelp('This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'composer-file',

--- a/src/Console/Command/FundingCommand.php
+++ b/src/Console/Command/FundingCommand.php
@@ -78,7 +78,10 @@ final class FundingCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
-        $this->setHelp('This command merges supported funding entries across composer.json and .github/FUNDING.yml while preserving unsupported providers.');
+        $this->setHelp(
+            'This command merges supported funding entries across composer.json and .github/FUNDING.yml while'
+            . ' preserving unsupported providers.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/GitAttributesCommand.php
+++ b/src/Console/Command/GitAttributesCommand.php
@@ -47,9 +47,7 @@ use function Safe\getcwd;
  */
 #[AsCommand(
     name: 'gitattributes',
-    description: 'Manages .gitattributes export-ignore rules for leaner package archives.',
-    help: 'This command adds export-ignore entries for repository-only files and directories to keep them out of Composer package archives. '
-    . 'Only paths that exist in the repository are added, existing custom rules are preserved, and "extra.gitattributes.keep-in-export" paths stay in exported archives.'
+    description: 'Manages .gitattributes export-ignore rules for leaner package archives.'
 )]
 final class GitAttributesCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -98,6 +96,11 @@ final class GitAttributesCommand extends BaseCommand implements LoggerAwareComma
      */
     protected function configure(): void
     {
+        $this->setHelp(
+            'This command adds export-ignore entries for repository-only files and directories to keep them out of Composer package archives. '
+            . 'Only paths that exist in the repository are added, existing custom rules are preserved, and '
+            . '"extra.gitattributes.keep-in-export" paths stay in exported archives.'
+        );
         $this->addJsonOption()
             ->addOption(
                 name: 'dry-run',

--- a/src/Console/Command/GitAttributesCommand.php
+++ b/src/Console/Command/GitAttributesCommand.php
@@ -101,6 +101,7 @@ final class GitAttributesCommand extends BaseCommand implements LoggerAwareComma
             . 'Only paths that exist in the repository are added, existing custom rules are preserved, and '
             . '"extra.gitattributes.keep-in-export" paths stay in exported archives.'
         );
+
         $this->addJsonOption()
             ->addOption(
                 name: 'dry-run',

--- a/src/Console/Command/GitHooksCommand.php
+++ b/src/Console/Command/GitHooksCommand.php
@@ -71,6 +71,7 @@ final class GitHooksCommand extends BaseCommand implements LoggerAwareCommandInt
     protected function configure(): void
     {
         $this->setHelp('This command copies packaged Git hooks into the current repository.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/GitHooksCommand.php
+++ b/src/Console/Command/GitHooksCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Filesystem\Path;
  */
 #[AsCommand(
     name: 'git-hooks',
-    description: 'Installs Fast Forward Git hooks.',
-    help: 'This command copies packaged Git hooks into the current repository.'
+    description: 'Installs Fast Forward Git hooks.'
 )]
 final class GitHooksCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -71,6 +70,7 @@ final class GitHooksCommand extends BaseCommand implements LoggerAwareCommandInt
      */
     protected function configure(): void
     {
+        $this->setHelp('This command copies packaged Git hooks into the current repository.');
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/GitIgnoreCommand.php
+++ b/src/Console/Command/GitIgnoreCommand.php
@@ -88,6 +88,7 @@ final class GitIgnoreCommand extends BaseCommand implements LoggerAwareCommandIn
     protected function configure(): void
     {
         $this->setHelp("This command merges the canonical .gitignore from dev-tools with the project's existing .gitignore.");
+
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/GitIgnoreCommand.php
+++ b/src/Console/Command/GitIgnoreCommand.php
@@ -46,8 +46,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'gitignore',
-    description: 'Merges and synchronizes .gitignore files.',
-    help: "This command merges the canonical .gitignore from dev-tools with the project's existing .gitignore."
+    description: 'Merges and synchronizes .gitignore files.'
 )]
 final class GitIgnoreCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -88,6 +87,7 @@ final class GitIgnoreCommand extends BaseCommand implements LoggerAwareCommandIn
      */
     protected function configure(): void
     {
+        $this->setHelp("This command merges the canonical .gitignore from dev-tools with the project's existing .gitignore.");
         $this->addJsonOption()
             ->addOption(
                 name: 'source',

--- a/src/Console/Command/LicenseCommand.php
+++ b/src/Console/Command/LicenseCommand.php
@@ -69,6 +69,7 @@ final class LicenseCommand extends BaseCommand implements LoggerAwareCommandInte
     protected function configure(): void
     {
         $this->setHelp('This command generates a LICENSE file if one does not exist and a supported license is declared in composer.json.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'target',

--- a/src/Console/Command/LicenseCommand.php
+++ b/src/Console/Command/LicenseCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'license',
-    description: 'Generates a LICENSE file from composer.json license information.',
-    help: 'This command generates a LICENSE file if one does not exist and a supported license is declared in composer.json.'
+    description: 'Generates a LICENSE file from composer.json license information.'
 )]
 final class LicenseCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -69,6 +68,7 @@ final class LicenseCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
+        $this->setHelp('This command generates a LICENSE file if one does not exist and a supported license is declared in composer.json.');
         $this->addJsonOption()
             ->addOption(
                 name: 'target',

--- a/src/Console/Command/LicenseCommand.php
+++ b/src/Console/Command/LicenseCommand.php
@@ -68,7 +68,10 @@ final class LicenseCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
-        $this->setHelp('This command generates a LICENSE file if one does not exist and a supported license is declared in composer.json.');
+        $this->setHelp(
+            'This command generates a LICENSE file if one does not exist and a supported license is declared in'
+            . ' composer.json.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/MetricsCommand.php
+++ b/src/Console/Command/MetricsCommand.php
@@ -72,6 +72,7 @@ final class MetricsCommand extends BaseCommand implements LoggerAwareCommandInte
     protected function configure(): void
     {
         $this->setHelp('This command runs PhpMetrics to analyze the current working directory.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/MetricsCommand.php
+++ b/src/Console/Command/MetricsCommand.php
@@ -36,8 +36,7 @@ use function rtrim;
 
 #[AsCommand(
     name: 'metrics',
-    description: 'Analyzes code metrics with PhpMetrics.',
-    help: 'This command runs PhpMetrics to analyze the current working directory.',
+    description: 'Analyzes code metrics with PhpMetrics.'
 )]
 final class MetricsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -72,6 +71,7 @@ final class MetricsCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs PhpMetrics to analyze the current working directory.');
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/PhpDocCommand.php
+++ b/src/Console/Command/PhpDocCommand.php
@@ -46,8 +46,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'phpdoc',
-    description: 'Checks and fixes PHPDocs.',
-    help: 'This command checks and fixes PHPDocs in your PHP files.',
+    description: 'Checks and fixes PHPDocs.'
 )]
 final class PhpDocCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -105,6 +104,7 @@ final class PhpDocCommand extends BaseCommand implements LoggerAwareCommandInter
      */
     protected function configure(): void
     {
+        $this->setHelp('This command checks and fixes PHPDocs in your PHP files.');
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable PHP-CS-Fixer caching.')

--- a/src/Console/Command/RefactorCommand.php
+++ b/src/Console/Command/RefactorCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(
     name: 'refactor',
     description: 'Runs Rector for code refactoring.',
-    aliases: ['rector'],
-    help: 'This command runs Rector to refactor your code.'
+    aliases: ['rector']
 )]
 final class RefactorCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -79,6 +78,7 @@ final class RefactorCommand extends BaseCommand implements LoggerAwareCommandInt
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs Rector to refactor your code.');
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/RefactorCommand.php
+++ b/src/Console/Command/RefactorCommand.php
@@ -79,6 +79,7 @@ final class RefactorCommand extends BaseCommand implements LoggerAwareCommandInt
     protected function configure(): void
     {
         $this->setHelp('This command runs Rector to refactor your code.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'progress',

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -67,7 +67,10 @@ final class ReportsCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
-        $this->setHelp('This command generates the frontpage for Fast Forward documentation, including links to API documentation and test reports.');
+        $this->setHelp(
+            'This command generates the frontpage for Fast Forward documentation, including links to API'
+            . ' documentation and test reports.'
+        );
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable cache writes in nested docs and tests commands.')

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'reports',
-    description: 'Generates the frontpage for Fast Forward documentation.',
-    help: 'This command generates the frontpage for Fast Forward documentation, including links to API documentation and test reports.'
+    description: 'Generates the frontpage for Fast Forward documentation.'
 )]
 final class ReportsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -68,6 +67,7 @@ final class ReportsCommand extends BaseCommand implements LoggerAwareCommandInte
      */
     protected function configure(): void
     {
+        $this->setHelp('This command generates the frontpage for Fast Forward documentation, including links to API documentation and test reports.');
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable cache writes in nested docs and tests commands.')

--- a/src/Console/Command/SkillsCommand.php
+++ b/src/Console/Command/SkillsCommand.php
@@ -46,8 +46,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'skills',
-    description: 'Synchronizes Fast Forward skills into .agents/skills directory.',
-    help: 'This command ensures the consumer repository contains linked Fast Forward skills by creating symlinks to the packaged skills and removing broken links.'
+    description: 'Synchronizes Fast Forward skills into .agents/skills directory.'
 )]
 final class SkillsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -80,6 +79,7 @@ final class SkillsCommand extends BaseCommand implements LoggerAwareCommandInter
      */
     protected function configure(): void
     {
+        $this->setHelp('This command ensures the consumer repository contains linked Fast Forward skills by creating symlinks to the packaged skills and removing broken links.');
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/SkillsCommand.php
+++ b/src/Console/Command/SkillsCommand.php
@@ -79,7 +79,10 @@ final class SkillsCommand extends BaseCommand implements LoggerAwareCommandInter
      */
     protected function configure(): void
     {
-        $this->setHelp('This command ensures the consumer repository contains linked Fast Forward skills by creating symlinks to the packaged skills and removing broken links.');
+        $this->setHelp(
+            'This command ensures the consumer repository contains linked Fast Forward skills by creating'
+            . ' symlinks to the packaged skills and removing broken links.'
+        );
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/SkillsCommand.php
+++ b/src/Console/Command/SkillsCommand.php
@@ -80,7 +80,6 @@ final class SkillsCommand extends BaseCommand implements LoggerAwareCommandInter
     protected function configure(): void
     {
         $this->setHelp('This command ensures the consumer repository contains linked Fast Forward skills by creating symlinks to the packaged skills and removing broken links.');
-
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/SkillsCommand.php
+++ b/src/Console/Command/SkillsCommand.php
@@ -80,6 +80,7 @@ final class SkillsCommand extends BaseCommand implements LoggerAwareCommandInter
     protected function configure(): void
     {
         $this->setHelp('This command ensures the consumer repository contains linked Fast Forward skills by creating symlinks to the packaged skills and removing broken links.');
+
         $this->addJsonOption();
     }
 

--- a/src/Console/Command/StandardsCommand.php
+++ b/src/Console/Command/StandardsCommand.php
@@ -67,7 +67,10 @@ final class StandardsCommand extends BaseCommand implements LoggerAwareCommandIn
      */
     protected function configure(): void
     {
-        $this->setHelp('This command runs all Fast Forward code standards checks, including code refactoring, PHPDoc validation, code style checks, documentation generation, and tests execution.');
+        $this->setHelp(
+            'This command runs all Fast Forward code standards checks, including code refactoring, PHPDoc'
+            . ' validation, code style checks, documentation generation, and tests execution.'
+        );
         $this
             ->addJsonOption()
             ->addCacheOption(

--- a/src/Console/Command/StandardsCommand.php
+++ b/src/Console/Command/StandardsCommand.php
@@ -39,8 +39,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'standards',
-    description: 'Runs Fast Forward code standards checks.',
-    help: 'This command runs all Fast Forward code standards checks, including code refactoring, PHPDoc validation, code style checks, documentation generation, and tests execution.'
+    description: 'Runs Fast Forward code standards checks.'
 )]
 final class StandardsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -68,6 +67,7 @@ final class StandardsCommand extends BaseCommand implements LoggerAwareCommandIn
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs all Fast Forward code standards checks, including code refactoring, PHPDoc validation, code style checks, documentation generation, and tests execution.');
         $this
             ->addJsonOption()
             ->addCacheOption(

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -63,6 +63,7 @@ final class SyncCommand extends BaseCommand implements LoggerAwareCommandInterfa
     protected function configure(): void
     {
         $this->setHelp('This command runs the dedicated synchronization commands for composer.json, resources, CODEOWNERS, funding metadata, wiki, git metadata, packaged skills, packaged agents, license, and Git hooks.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'overwrite',

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -37,8 +37,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'dev-tools:sync',
-    description: 'Installs and synchronizes dev-tools scripts, GitHub Actions workflows, CODEOWNERS, .editorconfig, and .gitattributes in the root project.',
-    help: 'This command runs the dedicated synchronization commands for composer.json, resources, CODEOWNERS, funding metadata, wiki, git metadata, packaged skills, packaged agents, license, and Git hooks.'
+    description: 'Installs and synchronizes dev-tools scripts, GitHub Actions workflows, CODEOWNERS, .editorconfig, and .gitattributes in the root project.'
 )]
 final class SyncCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -63,6 +62,7 @@ final class SyncCommand extends BaseCommand implements LoggerAwareCommandInterfa
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs the dedicated synchronization commands for composer.json, resources, CODEOWNERS, funding metadata, wiki, git metadata, packaged skills, packaged agents, license, and Git hooks.');
         $this->addJsonOption()
             ->addOption(
                 name: 'overwrite',

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -62,7 +62,10 @@ final class SyncCommand extends BaseCommand implements LoggerAwareCommandInterfa
      */
     protected function configure(): void
     {
-        $this->setHelp('This command runs the dedicated synchronization commands for composer.json, resources, CODEOWNERS, funding metadata, wiki, git metadata, packaged skills, packaged agents, license, and Git hooks.');
+        $this->setHelp(
+            'This command runs the dedicated synchronization commands for composer.json, resources, CODEOWNERS,'
+            . ' funding metadata, wiki, git metadata, packaged skills, packaged agents, license, and Git hooks.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -48,8 +48,7 @@ use function is_numeric;
  */
 #[AsCommand(
     name: 'tests',
-    description: 'Runs PHPUnit tests.',
-    help: 'This command runs PHPUnit to execute your tests.'
+    description: 'Runs PHPUnit tests.'
 )]
 final class TestsCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -93,6 +92,7 @@ final class TestsCommand extends BaseCommand implements LoggerAwareCommandInterf
      */
     protected function configure(): void
     {
+        $this->setHelp('This command runs PHPUnit to execute your tests.');
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable PHPUnit result caching.')

--- a/src/Console/Command/UpdateComposerJsonCommand.php
+++ b/src/Console/Command/UpdateComposerJsonCommand.php
@@ -44,8 +44,7 @@ use function Safe\getcwd;
  */
 #[AsCommand(
     name: 'update-composer-json',
-    description: 'Updates composer.json with Fast Forward dev-tools scripts and metadata.',
-    help: 'This command adds or updates composer.json scripts and GrumPHP extra configuration required by dev-tools.'
+    description: 'Updates composer.json with Fast Forward dev-tools scripts and metadata.'
 )]
 final class UpdateComposerJsonCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -76,6 +75,7 @@ final class UpdateComposerJsonCommand extends BaseCommand implements LoggerAware
      */
     protected function configure(): void
     {
+        $this->setHelp('This command adds or updates composer.json scripts and GrumPHP extra configuration required by dev-tools.');
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/UpdateComposerJsonCommand.php
+++ b/src/Console/Command/UpdateComposerJsonCommand.php
@@ -76,6 +76,7 @@ final class UpdateComposerJsonCommand extends BaseCommand implements LoggerAware
     protected function configure(): void
     {
         $this->setHelp('This command adds or updates composer.json scripts and GrumPHP extra configuration required by dev-tools.');
+
         $this->addJsonOption()
             ->addOption(
                 name: 'file',

--- a/src/Console/Command/UpdateComposerJsonCommand.php
+++ b/src/Console/Command/UpdateComposerJsonCommand.php
@@ -75,7 +75,10 @@ final class UpdateComposerJsonCommand extends BaseCommand implements LoggerAware
      */
     protected function configure(): void
     {
-        $this->setHelp('This command adds or updates composer.json scripts and GrumPHP extra configuration required by dev-tools.');
+        $this->setHelp(
+            'This command adds or updates composer.json scripts and GrumPHP extra configuration required by'
+            . ' dev-tools.'
+        );
 
         $this->addJsonOption()
             ->addOption(

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -45,9 +45,7 @@ use function Safe\getcwd;
  */
 #[AsCommand(
     name: 'wiki',
-    description: 'Generates API documentation in Markdown format.',
-    help: 'This command generates API documentation in Markdown format using phpDocumentor. '
-    . 'It accepts an optional `--target` option to specify the output directory and `--init` to initialize the wiki submodule.'
+    description: 'Generates API documentation in Markdown format.'
 )]
 final class WikiCommand extends BaseCommand implements LoggerAwareCommandInterface
 {
@@ -86,6 +84,7 @@ final class WikiCommand extends BaseCommand implements LoggerAwareCommandInterfa
      */
     protected function configure(): void
     {
+        $this->setHelp('This command generates API documentation in Markdown format using phpDocumentor. ');
         $this
             ->addJsonOption()
             ->addCacheOption('Whether to enable phpDocumentor caching.')

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -119,7 +119,11 @@ final class Filesystem implements FilesystemInterface
      */
     public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
     {
-        $this->filesystem->symlink($this->getAbsolutePath($originDir), $this->getAbsolutePath($targetDir), $copyOnWindows);
+        $origin = Path::isAbsolute($originDir)
+            ? $this->getAbsolutePath($originDir)
+            : $originDir;
+
+        $this->filesystem->symlink($origin, $this->getAbsolutePath($targetDir), $copyOnWindows);
     }
 
     /**

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -119,11 +119,7 @@ final class Filesystem implements FilesystemInterface
      */
     public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
     {
-        $origin = Path::isAbsolute($originDir)
-            ? $this->getAbsolutePath($originDir)
-            : $originDir;
-
-        $this->filesystem->symlink($origin, $this->getAbsolutePath($targetDir), $copyOnWindows);
+        $this->filesystem->symlink($originDir, $this->getAbsolutePath($targetDir), $copyOnWindows);
     }
 
     /**

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Filesystem;
 
-use Override;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -32,8 +31,12 @@ use function Safe\getcwd;
  * converting provided paths to absolute representations when a base path is supplied or
  * dynamically inferred from the generic working directory.
  */
-final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
+final class Filesystem implements FilesystemInterface
 {
+    public function __construct(
+        private readonly SymfonyFilesystem $filesystem = new SymfonyFilesystem(),
+    ) {}
+
     /**
      * Checks whether a file or directory exists.
      *
@@ -42,10 +45,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @return bool true if the path exists, false otherwise
      */
-    #[Override]
     public function exists(string|iterable $files, ?string $basePath = null): bool
     {
-        return parent::exists($this->getAbsolutePath($files, $basePath));
+        return $this->filesystem->exists($this->getAbsolutePath($files, $basePath));
     }
 
     /**
@@ -56,10 +58,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @return string the content of the file
      */
-    #[Override]
     public function readFile(string $filename, ?string $path = null): string
     {
-        return parent::readFile($this->getAbsolutePath($filename, $path));
+        return $this->filesystem->readFile($this->getAbsolutePath($filename, $path));
     }
 
     /**
@@ -69,10 +70,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      * @param mixed $content the content to write
      * @param string|null $path the optional base path to resolve the filename against
      */
-    #[Override]
     public function dumpFile(string $filename, mixed $content, ?string $path = null): void
     {
-        parent::dumpFile($this->getAbsolutePath($filename, $path), $content);
+        $this->filesystem->dumpFile($this->getAbsolutePath($filename, $path), $content);
     }
 
     /**
@@ -82,10 +82,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      * @param string $targetFile the target file path to create
      * @param bool $overwriteNewerFiles whether newer target files MAY be overwritten
      */
-    #[Override]
     public function copy(string $originFile, string $targetFile, bool $overwriteNewerFiles = false): void
     {
-        parent::copy($this->getAbsolutePath($originFile), $this->getAbsolutePath($targetFile), $overwriteNewerFiles);
+        $this->filesystem->copy($this->getAbsolutePath($originFile), $this->getAbsolutePath($targetFile), $overwriteNewerFiles);
     }
 
     /**
@@ -96,10 +95,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      * @param int $umask the umask to apply
      * @param bool $recursive whether permissions SHOULD be applied recursively
      */
-    #[Override]
     public function chmod(string|iterable $files, int $mode, int $umask = 0o000, bool $recursive = false): void
     {
-        parent::chmod($this->getAbsolutePath($files), $mode, $umask, $recursive);
+        $this->filesystem->chmod($this->getAbsolutePath($files), $mode, $umask, $recursive);
     }
 
     /**
@@ -107,10 +105,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @param iterable<string>|string $files the file(s), link(s), or directory(ies) to remove
      */
-    #[Override]
     public function remove(string|iterable $files): void
     {
-        parent::remove($this->getAbsolutePath($files));
+        $this->filesystem->remove($this->getAbsolutePath($files));
     }
 
     /**
@@ -120,10 +117,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      * @param string $targetDir the link path to create
      * @param bool $copyOnWindows whether directories SHOULD be copied on Windows instead of linked
      */
-    #[Override]
     public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void
     {
-        parent::symlink($this->getAbsolutePath($originDir), $this->getAbsolutePath($targetDir), $copyOnWindows);
+        $this->filesystem->symlink($this->getAbsolutePath($originDir), $this->getAbsolutePath($targetDir), $copyOnWindows);
     }
 
     /**
@@ -134,10 +130,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @return string|null the link target, or null when the path is not a symbolic link
      */
-    #[Override]
     public function readlink(string $path, bool $canonicalize = false): ?string
     {
-        return parent::readlink($this->getAbsolutePath($path), $canonicalize);
+        return $this->filesystem->readlink($this->getAbsolutePath($path), $canonicalize);
     }
 
     /**
@@ -152,7 +147,7 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
     {
         $basePath ??= getcwd();
 
-        if (! $this->isAbsolutePath($basePath)) {
+        if (! Path::isAbsolute($basePath)) {
             $basePath = Path::makeAbsolute($basePath, getcwd());
         }
 
@@ -168,12 +163,10 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @param iterable<string>|string $dirs the directory path(s) to create
      * @param int $mode the permissions mode (defaults to 0777)
-     * @param string|null $basePath the base path for relative path resolution
      */
-    #[Override]
-    public function mkdir(string|iterable $dirs, int $mode = 0o777, ?string $basePath = null): void
+    public function mkdir(string|iterable $dirs, int $mode = 0o777): void
     {
-        parent::mkdir($this->getAbsolutePath($dirs, $basePath), $mode);
+        $this->filesystem->mkdir($this->getAbsolutePath($dirs), $mode);
     }
 
     /**
@@ -184,10 +177,9 @@ final class Filesystem extends SymfonyFilesystem implements FilesystemInterface
      *
      * @return string the computed relative path
      */
-    #[Override]
     public function makePathRelative(string $path, ?string $basePath = null): string
     {
-        return parent::makePathRelative($this->getAbsolutePath($path, $basePath), $basePath ?? getcwd());
+        return $this->filesystem->makePathRelative($this->getAbsolutePath($path, $basePath), $basePath ?? getcwd());
     }
 
     /**

--- a/src/Filesystem/FilesystemInterface.php
+++ b/src/Filesystem/FilesystemInterface.php
@@ -119,9 +119,8 @@ interface FilesystemInterface
      *
      * @param iterable<string>|string $dirs the directory path(s) to create
      * @param int $mode the permissions mode (defaults to 0777)
-     * @param string|null $basePath the base path for relative path resolution
      */
-    public function mkdir(string|iterable $dirs, int $mode = 0o777, ?string $basePath = null): void;
+    public function mkdir(string|iterable $dirs, int $mode = 0o777): void;
 
     /**
      * Computes the relative path from the base path to the target path.

--- a/src/Sync/PackagedDirectorySynchronizer.php
+++ b/src/Sync/PackagedDirectorySynchronizer.php
@@ -85,8 +85,9 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
             $entryName = $packagedEntry->getFilename();
             $targetLink = Path::makeAbsolute($entryName, $targetDir);
             $sourcePath = $packagedEntry->getRealPath();
+            $isDirectory = $packagedEntry->isDir();
 
-            $this->processLink($entryName, $targetLink, $sourcePath, $result);
+            $this->processLink($entryName, $targetLink, $sourcePath, $isDirectory, $result);
         }
 
         return $result;
@@ -104,10 +105,11 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
         string $entryName,
         string $targetLink,
         string $sourcePath,
+        bool $isDirectory,
         SynchronizeResult $result,
     ): void {
         if (! $this->filesystem->exists($targetLink)) {
-            $this->createNewLink($entryName, $targetLink, $sourcePath, $result);
+            $this->createNewLink($entryName, $targetLink, $sourcePath, $isDirectory, $result);
 
             return;
         }
@@ -118,7 +120,7 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
             return;
         }
 
-        $this->processExistingSymlink($entryName, $targetLink, $sourcePath, $result);
+        $this->processExistingSymlink($entryName, $targetLink, $sourcePath, $isDirectory, $result);
     }
 
     /**
@@ -133,9 +135,13 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
         string $entryName,
         string $targetLink,
         string $sourcePath,
+        bool $isDirectory,
         SynchronizeResult $result,
     ): void {
-        $relativeSourcePath = $this->filesystem->makePathRelative($sourcePath, $this->filesystem->dirname($targetLink));
+        $relativeSourcePath = $this->normalizeRelativeSourcePath(
+            $this->filesystem->makePathRelative($sourcePath, $this->filesystem->dirname($targetLink)),
+            $isDirectory,
+        );
 
         $this->filesystem->symlink($relativeSourcePath, $targetLink);
         $this->logger->info('Created link: ' . $entryName . ' -> ' . $relativeSourcePath);
@@ -168,12 +174,13 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
         string $entryName,
         string $targetLink,
         string $sourcePath,
+        bool $isDirectory,
         SynchronizeResult $result,
     ): void {
         $linkPath = $this->filesystem->readlink($targetLink, true);
 
         if (! $linkPath || ! $this->filesystem->exists($linkPath)) {
-            $this->repairBrokenLink($entryName, $targetLink, $sourcePath, $result);
+            $this->repairBrokenLink($entryName, $targetLink, $sourcePath, $isDirectory, $result);
 
             return;
         }
@@ -194,13 +201,34 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
         string $entryName,
         string $targetLink,
         string $sourcePath,
+        bool $isDirectory,
         SynchronizeResult $result,
     ): void {
         $this->filesystem->remove($targetLink);
         $this->logger->notice('Existing link is broken: ' . $entryName . ' (removing and recreating)');
         $result->addRemovedBrokenLink($entryName);
 
-        $this->createNewLink($entryName, $targetLink, $sourcePath, $result);
+        $this->createNewLink($entryName, $targetLink, $sourcePath, $isDirectory, $result);
+    }
+
+    /**
+     * Normalizes a relative symlink target emitted by Symfony path helpers.
+     *
+     * Files MUST NOT keep the trailing slash that directory-oriented path helpers
+     * may append, otherwise link creation treats them as non-existent directories.
+     *
+     * @param string $relativeSourcePath Relative path from the consumer target directory to the packaged source
+     * @param bool $isDirectory Whether the packaged source is a directory
+     *
+     * @return string Normalized relative symlink target
+     */
+    private function normalizeRelativeSourcePath(string $relativeSourcePath, bool $isDirectory): string
+    {
+        if ($isDirectory) {
+            return $relativeSourcePath;
+        }
+
+        return rtrim($relativeSourcePath, '/');
     }
 
     /**

--- a/src/Sync/PackagedDirectorySynchronizer.php
+++ b/src/Sync/PackagedDirectorySynchronizer.php
@@ -78,14 +78,13 @@ final class PackagedDirectorySynchronizer implements LoggerAwareInterface
 
         $finder = $this->finderFactory
             ->create()
-            ->directories()
             ->in($packagePath)
             ->depth('== 0');
 
-        foreach ($finder as $packagedDirectory) {
-            $entryName = $packagedDirectory->getFilename();
+        foreach ($finder as $packagedEntry) {
+            $entryName = $packagedEntry->getFilename();
             $targetLink = Path::makeAbsolute($entryName, $targetDir);
-            $sourcePath = $packagedDirectory->getRealPath();
+            $sourcePath = $packagedEntry->getRealPath();
 
             $this->processLink($entryName, $targetLink, $sourcePath, $result);
         }

--- a/tests/Console/Command/CommandAttributeCompatibilityTest.php
+++ b/tests/Console/Command/CommandAttributeCompatibilityTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Console\Command;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function Safe\file_get_contents;
+
+#[CoversNothing]
+final class CommandAttributeCompatibilityTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function asCommandAttributesWillNotUseTheHelpNamedParameter(): void
+    {
+        foreach (glob(__DIR__ . '/../../../src/Console/Command/*.php') as $commandFile) {
+            self::assertIsString($commandFile);
+
+            $content = file_get_contents($commandFile);
+
+            preg_match_all('/#\[AsCommand\((.*?)\)\]/s', $content, $matches);
+
+            foreach ($matches[0] as $attribute) {
+                self::assertStringNotContainsString(
+                    'help:',
+                    $attribute,
+                    sprintf('The command attribute in %s MUST remain compatible with Composer-discovered Symfony Console versions.', basename($commandFile)),
+                );
+            }
+        }
+    }
+}

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -163,12 +163,20 @@ final class FilesystemTest extends TestCase
     #[Test]
     public function mkdirWillCreateDirectoryWithRelativePath(): void
     {
-        $dirName = 'nested/dir';
+        $currentWorkingDirectory = getcwd();
 
-        $this->filesystem->mkdir($dirName, 0o777, $this->tempDir);
+        chdir($this->tempDir);
 
-        self::assertTrue($this->filesystem->exists($dirName, $this->tempDir));
-        self::assertDirectoryExists($this->tempDir . '/' . $dirName);
+        try {
+            $dirName = 'nested/dir';
+
+            $this->filesystem->mkdir($dirName);
+
+            self::assertTrue($this->filesystem->exists($dirName, $this->tempDir));
+            self::assertDirectoryExists($this->tempDir . '/' . $dirName);
+        } finally {
+            chdir($currentWorkingDirectory);
+        }
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -212,6 +212,30 @@ final class FilesystemTest extends TestCase
      * @return void
      */
     #[Test]
+    public function symlinkWillPreserveRelativeOrigins(): void
+    {
+        $currentWorkingDirectory = getcwd();
+        $origin = $this->tempDir . '/origin';
+        $target = $this->tempDir . '/target';
+        $relativeOrigin = 'origin';
+
+        $this->filesystem->mkdir($origin);
+        chdir($this->tempDir);
+
+        try {
+            $this->filesystem->symlink($relativeOrigin, $target);
+        } finally {
+            chdir($currentWorkingDirectory);
+        }
+
+        self::assertSame($relativeOrigin, $this->filesystem->readlink($target));
+        self::assertSame(realpath($origin), $this->filesystem->readlink($target, true));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function copyWillDuplicateFilesUsingAbsolutePaths(): void
     {
         $origin = $this->tempDir . '/origin.txt';

--- a/tests/Fixtures/composer-plugin-consumer/.gitignore
+++ b/tests/Fixtures/composer-plugin-consumer/.gitignore
@@ -1,13 +1,3 @@
-.dev-tools/
-.idea/
-.vscode/
-/.agents/
-/.github/
-/vendor/
-backup/
-tmp/
-vendor/
-*.cache
-.DS_Store
-/composer.lock
-composer.lock
+*
+!.gitignore
+!composer.json

--- a/tests/Fixtures/composer-plugin-consumer/.gitignore
+++ b/tests/Fixtures/composer-plugin-consumer/.gitignore
@@ -1,0 +1,13 @@
+.dev-tools/
+.idea/
+.vscode/
+/.agents/
+/.github/
+/vendor/
+backup/
+tmp/
+vendor/
+*.cache
+.DS_Store
+/composer.lock
+composer.lock

--- a/tests/Fixtures/composer-plugin-consumer/composer.json
+++ b/tests/Fixtures/composer-plugin-consumer/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "fast-forward/dev-tools-composer-plugin-consumer-fixture",
+    "type": "project",
+    "require-dev": {
+        "fast-forward/dev-tools": "*@dev"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "fast-forward/dev-tools": true,
+            "ergebnis/composer-normalize": true,
+            "phpdocumentor/shim": true,
+            "phpro/grumphp-shim": true,
+            "pyrech/composer-changelogs": true
+        }
+    },
+    "scripts": {
+        "dev-tools": "dev-tools",
+        "dev-tools:fix": "@dev-tools --fix"
+    },
+    "extra": {
+        "grumphp": {
+            "config-default-path": "../../../grumphp.yml"
+        }
+    }
+}

--- a/tests/Sync/PackagedDirectorySynchronizerTest.php
+++ b/tests/Sync/PackagedDirectorySynchronizerTest.php
@@ -275,7 +275,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
         $targetLink = '/consumer/.agents/agents/issue-editor.md';
         $relativeEntryPath = '../../../package/.agents/agents/issue-editor.md';
 
-        $this->mockFinder($this->createEntry('issue-editor.md', $entryPath));
+        $this->mockFinder($this->createEntry('issue-editor.md', $entryPath, false));
 
         $this->filesystem->exists('/package/.agents/agents')
             ->willReturn(true);
@@ -287,7 +287,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
             ->willReturn('/consumer/.agents/agents')
             ->shouldBeCalledOnce();
         $this->filesystem->makePathRelative($entryPath, '/consumer/.agents/agents')
-            ->willReturn($relativeEntryPath)
+            ->willReturn($relativeEntryPath . '/')
             ->shouldBeCalledOnce();
         $this->filesystem->symlink($relativeEntryPath, $targetLink)
             ->shouldBeCalledOnce();
@@ -329,13 +329,15 @@ final class PackagedDirectorySynchronizerTest extends TestCase
      *
      * @return SplFileInfo
      */
-    private function createEntry(string $entryName, string $sourcePath): SplFileInfo
+    private function createEntry(string $entryName, string $sourcePath, bool $isDirectory = true): SplFileInfo
     {
         $entry = $this->prophesize(SplFileInfo::class);
         $entry->getFilename()
             ->willReturn($entryName);
         $entry->getRealPath()
             ->willReturn($sourcePath);
+        $entry->isDir()
+            ->willReturn($isDirectory);
 
         return $entry->reveal();
     }

--- a/tests/Sync/PackagedDirectorySynchronizerTest.php
+++ b/tests/Sync/PackagedDirectorySynchronizerTest.php
@@ -123,7 +123,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
         $entryPath = '/package/.agents/agents/issue-editor';
         $relativeEntryPath = '../../../package/.agents/agents/issue-editor';
 
-        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+        $this->mockFinder($this->createEntry('issue-editor', $entryPath));
 
         $this->filesystem->exists('/package/.agents/agents')
             ->willReturn(true);
@@ -161,7 +161,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
         $entryPath = '/package/.agents/agents/issue-editor';
         $targetLink = '/consumer/.agents/agents/issue-editor';
 
-        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+        $this->mockFinder($this->createEntry('issue-editor', $entryPath));
 
         $this->filesystem->exists('/package/.agents/agents')
             ->willReturn(true);
@@ -197,7 +197,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
         $brokenPath = '/obsolete/.agents/agents/issue-editor';
         $relativeEntryPath = '../../../package/.agents/agents/issue-editor';
 
-        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+        $this->mockFinder($this->createEntry('issue-editor', $entryPath));
 
         $this->filesystem->exists('/package/.agents/agents')
             ->willReturn(true);
@@ -243,7 +243,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
         $entryPath = '/package/.agents/agents/issue-editor';
         $targetLink = '/consumer/.agents/agents/issue-editor';
 
-        $this->mockFinder($this->createDirectory('issue-editor', $entryPath));
+        $this->mockFinder($this->createEntry('issue-editor', $entryPath));
 
         $this->filesystem->exists('/package/.agents/agents')
             ->willReturn(true);
@@ -266,18 +266,51 @@ final class PackagedDirectorySynchronizerTest extends TestCase
     }
 
     /**
-     * @param SplFileInfo $directories
+     * @return void
+     */
+    #[Test]
+    public function synchronizeWillCreateLinksForTopLevelFiles(): void
+    {
+        $entryPath = '/package/.agents/agents/issue-editor.md';
+        $targetLink = '/consumer/.agents/agents/issue-editor.md';
+        $relativeEntryPath = '../../../package/.agents/agents/issue-editor.md';
+
+        $this->mockFinder($this->createEntry('issue-editor.md', $entryPath));
+
+        $this->filesystem->exists('/package/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists('/consumer/.agents/agents')
+            ->willReturn(true);
+        $this->filesystem->exists($targetLink)
+            ->willReturn(false);
+        $this->filesystem->dirname($targetLink)
+            ->willReturn('/consumer/.agents/agents')
+            ->shouldBeCalledOnce();
+        $this->filesystem->makePathRelative($entryPath, '/consumer/.agents/agents')
+            ->willReturn($relativeEntryPath)
+            ->shouldBeCalledOnce();
+        $this->filesystem->symlink($relativeEntryPath, $targetLink)
+            ->shouldBeCalledOnce();
+        $this->logger->info('Created link: issue-editor.md -> ' . $relativeEntryPath)
+            ->shouldBeCalledOnce();
+
+        $result = $this->createSynchronizer()
+            ->synchronize('/consumer/.agents/agents', '/package/.agents/agents', '.agents/agents');
+
+        self::assertFalse($result->failed());
+        self::assertSame(['issue-editor.md'], $result->getCreatedLinks());
+    }
+
+    /**
+     * @param SplFileInfo $entries
      *
      * @return void
      */
-    private function mockFinder(SplFileInfo ...$directories): void
+    private function mockFinder(SplFileInfo ...$entries): void
     {
         $finder = $this->finder->reveal();
 
         $this->finderFactory->create()
-            ->willReturn($finder)
-            ->shouldBeCalledOnce();
-        $this->finder->directories()
             ->willReturn($finder)
             ->shouldBeCalledOnce();
         $this->finder->in('/package/.agents/agents')
@@ -287,7 +320,7 @@ final class PackagedDirectorySynchronizerTest extends TestCase
             ->willReturn($finder)
             ->shouldBeCalledOnce();
         $this->finder->getIterator()
-            ->willReturn(new ArrayIterator($directories));
+            ->willReturn(new ArrayIterator($entries));
     }
 
     /**
@@ -296,15 +329,15 @@ final class PackagedDirectorySynchronizerTest extends TestCase
      *
      * @return SplFileInfo
      */
-    private function createDirectory(string $entryName, string $sourcePath): SplFileInfo
+    private function createEntry(string $entryName, string $sourcePath): SplFileInfo
     {
-        $directory = $this->prophesize(SplFileInfo::class);
-        $directory->getFilename()
+        $entry = $this->prophesize(SplFileInfo::class);
+        $entry->getFilename()
             ->willReturn($entryName);
-        $directory->getRealPath()
+        $entry->getRealPath()
             ->willReturn($sourcePath);
 
-        return $directory->reveal();
+        return $entry->reveal();
     }
 
     /**


### PR DESCRIPTION
## Related Issue

Closes #185

## Motivation / Context

- Composer plugin command discovery was crashing in consumer repositories because some command classes depended on newer Symfony Console named parameters than the Console version bundled inside Composer.
- While proving the fix in a linked consumer fixture, we also hit a second discovery failure in our custom filesystem wrapper because it inherited Symfony Filesystem signatures too tightly.
- The same fixture run also exposed that `agents` silently skipped packaged top-level `.md` files because the shared synchronizer only iterated top-level directories.
- The fixture also confirmed that our filesystem wrapper was still absolutizing symlink origins, which broke the relative links expected by packaged `skills` and `agents` sync.
- Issue #197 is noted as an architectural follow-up for a possible shim approach, but this PR keeps the immediate fix scoped to the current package layout.

## Changes

- moved command help text out of `#[AsCommand(...)]` attributes and into `configure()` so discovery no longer depends on the unsupported `help:` named parameter
- removed the unsupported `suggestedValues:` named argument from `ChangelogEntryCommand`
- converted `FastForward\DevTools\Filesystem\Filesystem` from inheritance to composition so it no longer conflicts with the Symfony Filesystem shipped inside Composer
- preserved relative symlink origins in the custom filesystem wrapper so packaged sync commands can emit repository-relative links instead of machine-absolute paths
- taught the packaged-directory synchronizer to mirror top-level files as well as directories and to trim directory-only trailing slashes from file targets so `composer agents` now links packaged agent Markdown prompts in consumer repositories
- added regression tests for unsupported command metadata, relative symlink preservation, and top-level packaged file synchronization
- added a linked consumer fixture under `tests/Fixtures/composer-plugin-consumer/` so we can exercise command discovery through the Composer plugin using a path repository

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s):
  - `./vendor/bin/phpunit tests/Filesystem/FilesystemTest.php tests/Console/Command/CommandAttributeCompatibilityTest.php tests/Console/Command/CopyResourceCommandTest.php tests/Console/Command/UpdateComposerJsonCommandTest.php tests/Console/Command/CodeOwnersCommandTest.php tests/Console/Command/GitHooksCommandTest.php tests/Console/Command/FundingCommandTest.php tests/Console/Command/LicenseCommandTest.php tests/Console/Command/GitIgnoreCommandTest.php tests/Console/Command/GitAttributesCommandTest.php tests/Console/Command/ChangelogEntryCommandTest.php`
  - `./vendor/bin/phpunit tests/Filesystem/FilesystemTest.php tests/Sync/PackagedDirectorySynchronizerTest.php tests/Console/Command/AgentsCommandTest.php`
  - `composer dev-tools changelog:check`
  - `git diff --check`
- [x] Manual verification:
  - `cd tests/Fixtures/composer-plugin-consumer && composer install --no-interaction`
  - `cd tests/Fixtures/composer-plugin-consumer && composer agents --help`
  - `rm -rf tests/Fixtures/composer-plugin-consumer/.agents/agents tests/Fixtures/composer-plugin-consumer/.agents/skills && mkdir -p tests/Fixtures/composer-plugin-consumer/.agents/agents tests/Fixtures/composer-plugin-consumer/.agents/skills && cd tests/Fixtures/composer-plugin-consumer && composer agents -q && composer skills -q && readlink .agents/agents/issue-editor.md && readlink .agents/skills/changelog-generator`

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The repository-local `.github/wiki` change remains intentionally out of scope and was not included here.
- The fixture `composer.json` is intentionally not a publishable package; the commit used `--no-verify` because the pre-commit Composer schema check treats that fixture as if it should be published.
