### PR TITLE
[license] Handle missing license metadata (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrite drifted Git hooks by removing the previous target first, restore the intended `0o755` executable mode, and report unwritable hook replacements cleanly when `.git/hooks` stays locked (#190)
 - Keep Composer plugin command discovery compatible with consumer environments by moving unsupported Symfony Console named parameters out of command metadata/configuration and by decoupling the custom filesystem wrapper from Composer's bundled Symfony Filesystem signatures (#185)
 - Keep Composer autoload, Rector, and ECS from traversing nested fixture `vendor` directories when the composer-plugin consumer fixture has installed dependencies (#179)
+- Skip LICENSE generation cleanly when a consumer composer manifest omits or leaves the `license` field empty (#227)
 
 ## [1.20.0] - 2026-04-23
 

--- a/src/License/Resolver.php
+++ b/src/License/Resolver.php
@@ -47,13 +47,17 @@ final class Resolver implements ResolverInterface
     /**
      * Resolves a license identifier to its template filename.
      *
-     * @param string $license The license identifier to resolve
+     * @param string|null $license The license identifier to resolve
      *
      * @return string|null The template filename if supported, or null if not
      */
-    public function resolve(string $license): ?string
+    public function resolve(?string $license): ?string
     {
         $normalized = $this->normalize($license);
+
+        if (null === $normalized) {
+            return null;
+        }
 
         if (! isset(self::SUPPORTED_LICENSES[$normalized])) {
             return null;
@@ -65,12 +69,18 @@ final class Resolver implements ResolverInterface
     /**
      * Normalizes the license identifier for comparison.
      *
-     * @param string $license The license identifier to normalize
+     * @param string|null $license The license identifier to normalize
      *
-     * @return string The normalized license string
+     * @return string|null The normalized license string, or null when unavailable
      */
-    private function normalize(string $license): string
+    private function normalize(?string $license): ?string
     {
-        return trim($license);
+        if (null === $license) {
+            return null;
+        }
+
+        $license = trim($license);
+
+        return '' === $license ? null : $license;
     }
 }

--- a/src/License/ResolverInterface.php
+++ b/src/License/ResolverInterface.php
@@ -30,9 +30,9 @@ interface ResolverInterface
     /**
      * Resolves a license identifier to its template filename.
      *
-     * @param string $license The license identifier to resolve
+     * @param string|null $license The license identifier to resolve
      *
      * @return string|null The template filename if supported, or null if not
      */
-    public function resolve(string $license): ?string;
+    public function resolve(?string $license): ?string;
 }

--- a/tests/License/GeneratorTest.php
+++ b/tests/License/GeneratorTest.php
@@ -113,6 +113,24 @@ final class GeneratorTest extends TestCase
      * @return void
      */
     #[Test]
+    public function generateWithMissingLicenseWillReturnNull(): void
+    {
+        $this->composer->getLicense()
+            ->willReturn(null);
+        $this->resolver->resolve(null)
+            ->willReturn(null);
+        $this->filesystem->dumpFile(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $result = $this->generator->generate('/tmp/LICENSE');
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function generateWithValidLicenseWillCreateFile(): void
     {
         $targetPath = '/tmp/LICENSE';

--- a/tests/License/ResolverTest.php
+++ b/tests/License/ResolverTest.php
@@ -65,4 +65,22 @@ final class ResolverTest extends TestCase
     {
         self::assertNull($this->resolver->resolve('Unknown-License'));
     }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveWithMissingLicenseWillReturnNull(): void
+    {
+        self::assertNull($this->resolver->resolve(null));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveWithEmptyLicenseWillReturnNull(): void
+    {
+        self::assertNull($this->resolver->resolve('  '));
+    }
 }


### PR DESCRIPTION
## Related Issue

Closes #227

## Motivation / Context

- Consumers may omit the `license` field or leave it empty in `composer.json`.
- The license generator previously passed that missing metadata into `License\Resolver::resolve()`, causing a `TypeError` before the command could skip generation cleanly.

## Changes

- Allows the license resolver contract to receive missing or empty license metadata and return `null`.
- Keeps unsupported or absent license metadata on the existing skip path instead of failing.
- Adds regression coverage for missing, null, and empty license metadata without committing another consumer project fixture.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s):
  - `./vendor/bin/phpunit tests/License/ResolverTest.php tests/License/GeneratorTest.php tests/Console/Command/LicenseCommandTest.php`
  - `composer dev-tools tests -- --filter='License' --no-cache`
  - `composer dev-tools code-style -- --json`
  - `composer dev-tools refactor -- --json`
  - `composer dev-tools phpdoc -- --json`
  - `composer dev-tools changelog:check`
  - `git diff --check`
- [x] Manual verification: created a temporary consumer fixture without `license`, ran `composer install`, then ran `composer dev-tools license -- --dry-run --json`; it skipped LICENSE generation cleanly without the previous `TypeError`. The temporary fixture was removed after the check.

`composer dev-tools` was also attempted, but this local shell still hits the existing nested process TTY failure (`proc_open(/dev/tty): Failed to open stream: Device not configured`) before the full gate can complete.

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

No public docs or generated output changed; this is a defensive bug fix for missing metadata.

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The consumer-without-license case is covered permanently by unit tests; the full fixture project was intentionally not committed because this regression does not need another fixture tree.
