### PR TITLE
[process] Stop forcing PTY for queued processes (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep Composer plugin command discovery compatible with consumer environments by moving unsupported Symfony Console named parameters out of command metadata/configuration and by decoupling the custom filesystem wrapper from Composer's bundled Symfony Filesystem signatures (#185)
 - Keep Composer autoload, Rector, and ECS from traversing nested fixture `vendor` directories when the composer-plugin consumer fixture has installed dependencies (#179)
 - Skip LICENSE generation cleanly when a consumer composer manifest omits or leaves the `license` field empty (#227)
+- Run nested DevTools subprocesses without forcing PTY, fixing aggregate commands in non-interactive environments (#171)
 
 ## [1.20.0] - 2026-04-23
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -142,6 +142,11 @@ Likely causes:
 - a tool is prompting for confirmation;
 - CI is missing required environment variables.
 
+DevTools streams child-process output through Symfony Process callbacks rather
+than forcing pseudo-terminal execution. Aggregated commands such as
+``reports``, ``standards``, and ``dev-tools:fix`` MUST keep nested commands
+non-PTY in CI or other non-interactive process runners.
+
 Recovery:
 
 .. code-block:: bash

--- a/src/Process/ProcessQueue.php
+++ b/src/Process/ProcessQueue.php
@@ -87,10 +87,6 @@ final class ProcessQueue implements ProcessQueueInterface
         bool $detached = false,
         ?string $label = null
     ): void {
-        if (Process::isPtySupported()) {
-            $process->setPty(true);
-        }
-
         $this->entries[] = [
             'process' => $process,
             'ignoreFailure' => $ignoreFailure,

--- a/tests/Process/ProcessQueueTest.php
+++ b/tests/Process/ProcessQueueTest.php
@@ -76,19 +76,24 @@ final class ProcessQueueTest extends TestCase
     }
 
     /**
-     * @param ObjectProphecy<Process> $process
-     *
      * @return void
      */
-    private function expectPtyConfiguration(ObjectProphecy $process): void
+    #[Test]
+    public function addWillNotEnablePtyForQueuedProcesses(): void
     {
-        if (! Process::isPtySupported()) {
-            return;
-        }
+        $process = $this->prophesize(Process::class);
+        $process->setPty(Argument::any())
+            ->shouldNotBeCalled();
+        $process->run(Argument::any())
+            ->willReturn(ProcessQueueInterface::SUCCESS);
+        $process->getExitCode()
+            ->willReturn(ProcessQueueInterface::SUCCESS);
+        $process->isRunning()
+            ->willReturn(false);
 
-        $process->setPty(true)
-            ->willReturn($process->reveal())
-            ->shouldBeCalled();
+        $this->queue->add($process->reveal());
+
+        self::assertSame(ProcessQueueInterface::SUCCESS, $this->queue->run($this->output->reveal()));
     }
 
     /**
@@ -102,7 +107,6 @@ final class ProcessQueueTest extends TestCase
         bool $isRunning = false,
     ): ObjectProphecy {
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->run(Argument::any())
             ->willReturn($exitCode ?? ProcessQueueInterface::FAILURE);
         $process->getCommandLine()
@@ -127,7 +131,6 @@ final class ProcessQueueTest extends TestCase
     private function createDetachedProcessMock(bool ...$runningSequence): ObjectProphecy
     {
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->getCommandLine()
             ->willReturn('test-command');
         $process->getWorkingDirectory()
@@ -212,7 +215,6 @@ final class ProcessQueueTest extends TestCase
     public function runBlockingProcessExceptionReturnsFailure(): void
     {
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->getCommandLine()
             ->willReturn('test-command');
         $process->getWorkingDirectory()
@@ -249,7 +251,6 @@ final class ProcessQueueTest extends TestCase
     public function runDetachedProcessStartFailureReturnsFailure(): void
     {
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->getCommandLine()
             ->willReturn('test-command');
         $process->getWorkingDirectory()
@@ -271,7 +272,6 @@ final class ProcessQueueTest extends TestCase
     public function runDetachedProcessStartFailureWithIgnoreFailureReturnsSuccess(): void
     {
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->getCommandLine()
             ->willReturn('test-command');
         $process->getWorkingDirectory()
@@ -295,7 +295,6 @@ final class ProcessQueueTest extends TestCase
         $capturedCallback = null;
 
         $process = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($process);
         $process->run(Argument::that(function ($callback) use (&$capturedCallback): bool {
             $capturedCallback = $callback;
 
@@ -335,7 +334,6 @@ final class ProcessQueueTest extends TestCase
         $capturedSecondCallback = null;
 
         $firstProcess = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($firstProcess);
         $firstProcess->getCommandLine()
             ->willReturn('first-command');
         $firstProcess->getWorkingDirectory()
@@ -355,7 +353,6 @@ final class ProcessQueueTest extends TestCase
             })->shouldBeCalled();
 
         $secondProcess = $this->prophesize(Process::class);
-        $this->expectPtyConfiguration($secondProcess);
         $secondProcess->getCommandLine()
             ->willReturn('second-command');
         $secondProcess->getWorkingDirectory()


### PR DESCRIPTION
## Related Issue

Closes #171

## Motivation / Context

- Aggregate commands such as `reports`, `standards`, and `dev-tools:fix` enqueue nested DevTools subprocesses.
- `ProcessQueue` was enabling PTY on every queued process whenever Symfony reported PTY support, which still fails in non-interactive runners without `/dev/tty`.
- The queue already streams child stdout/stderr through Symfony Process callbacks, including detached processes, so forcing PTY is unnecessary for output forwarding.

## Changes

- Removed unconditional `setPty(true)` from `ProcessQueue::add()`.
- Added regression coverage asserting queued processes are not switched to PTY.
- Documented that nested command output is streamed via process callbacks and aggregate commands should stay non-PTY in CI/non-interactive contexts.
- Added an unreleased changelog entry for the non-interactive aggregate-command fix.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s):
  - `./vendor/bin/phpunit tests/Process/ProcessQueueTest.php`
  - `composer dev-tools tests -- --filter='ProcessQueue' --no-cache`
  - `composer dev-tools tests -- --filter='Process' --no-cache`
  - `composer dev-tools code-style -- --fix --json`
  - `composer dev-tools phpdoc -- --json --no-cache`
  - `composer dev-tools refactor -- --json`
  - `composer dev-tools changelog:check`
  - `git diff --check`
- [x] Manual verification: reproduced the original `reports` failure before the fix (`proc_open(/dev/tty): Failed to open stream: Device not configured`). After removing forced PTY, `reports` and `standards` advanced into their nested child commands without the `/dev/tty` failure; the local run was interrupted once it reached the long `phpmetrics` stage.

`composer dev-tools` was not completed end-to-end locally because the full gate enters the long `reports -> metrics` path in this shell; the original immediate `/dev/tty` failure is no longer reproduced.

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

No generated docs/wiki output was committed.

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- This intentionally removes PTY use instead of adding terminal detection. Symfony Process callbacks already preserve streamed stdout/stderr for blocking and detached processes, which keeps the queue behavior simpler and safer in non-interactive environments.
