### PR TITLE
[ci] Keep required tests reporting after wiki pointer commits (#230)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,13 +48,9 @@ jobs:
             php-version: ${{ steps.resolve.outputs.php-version }}
             php-version-source: ${{ steps.resolve.outputs.php-version-source }}
             test-matrix: ${{ steps.resolve.outputs.test-matrix }}
-            run-tests: ${{ steps.scope.outputs.run-tests }}
-            test-scope-reason: ${{ steps.scope.outputs.reason }}
 
         steps:
             - uses: actions/checkout@v6
-              with:
-                fetch-depth: 0
             - name: Checkout dev-tools workflow action source
               uses: actions/checkout@v6
               with:
@@ -68,47 +64,6 @@ jobs:
               id: resolve
               uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
-            - name: Resolve test workflow scope
-              id: scope
-              shell: bash
-              env:
-                BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-              run: |
-                set -euo pipefail
-
-                if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
-                  {
-                    echo "run-tests=true"
-                    echo "reason=non-pull-request-event"
-                  } >> "$GITHUB_OUTPUT"
-
-                  exit 0
-                fi
-
-                git fetch --no-tags --depth=1 origin "${BASE_SHA}"
-                git diff --name-only "${BASE_SHA}...HEAD" > changed-files.txt
-
-                run_tests=false
-                while IFS= read -r changed_file; do
-                  case "${changed_file}" in
-                    src/*|tests/*|composer.json|composer.lock|.github/actions/*|.github/workflows/tests.yml|resources/github-actions/tests.yml)
-                      run_tests=true
-                      break
-                      ;;
-                  esac
-                done < changed-files.txt
-
-                if [ "${run_tests}" = "true" ]; then
-                  reason="test-sensitive-pr-diff"
-                else
-                  reason="no-test-sensitive-pr-diff"
-                fi
-
-                {
-                  echo "run-tests=${run_tests}"
-                  echo "reason=${reason}"
-                } >> "$GITHUB_OUTPUT"
-
     tests:
         needs: resolve_php
         name: Run Tests
@@ -119,9 +74,7 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
-              if: needs.resolve_php.outputs.run-tests == 'true'
             - name: Checkout dev-tools workflow action source
-              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: actions/checkout@v6
               with:
                 repository: php-fast-forward/dev-tools
@@ -131,7 +84,6 @@ jobs:
                   .github/actions
 
             - name: Setup PHP and install dependencies
-              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ matrix.php-version }}
@@ -141,28 +93,20 @@ jobs:
                 install-options: --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Composer Audit
-              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer audit
 
             - name: Resolve minimum coverage
-              if: needs.resolve_php.outputs.run-tests == 'true'
               id: minimum-coverage
               run: echo "value=${INPUT_MIN_COVERAGE:-80}" >> "$GITHUB_OUTPUT"
               env:
                   INPUT_MIN_COVERAGE: ${{ inputs.min-coverage }}
 
             - name: Run PHPUnit tests
-              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer dev-tools tests -- --coverage=.dev-tools/coverage --min-coverage=${{ steps.minimum-coverage.outputs.value }}
-
-            - name: Mark tests intentionally skipped
-              if: needs.resolve_php.outputs.run-tests != 'true'
-              run: |
-                echo "No test-sensitive PR diff detected; required test context completed without running PHPUnit."
 
     dependency-health:
         needs: resolve_php
@@ -172,9 +116,7 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
-              if: needs.resolve_php.outputs.run-tests == 'true'
             - name: Checkout dev-tools workflow action source
-              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: actions/checkout@v6
               with:
                 repository: php-fast-forward/dev-tools
@@ -184,7 +126,6 @@ jobs:
                   .github/actions
 
             - name: Setup PHP and install dependencies
-              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
@@ -192,15 +133,9 @@ jobs:
                 install-options: --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Run dependency health check
-              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer dev-tools dependencies -- --max-outdated=${{ inputs.max-outdated || -1 }}
-
-            - name: Mark dependency health intentionally skipped
-              if: needs.resolve_php.outputs.run-tests != 'true'
-              run: |
-                echo "No test-sensitive PR diff detected; dependency health completed without running dependency analysis."
 
     summarize:
         if: ${{ always() }}
@@ -229,8 +164,6 @@ jobs:
                   - Workflow PHP version: `${{ needs.resolve_php.outputs.php-version }}`
                   - PHP version source: `${{ needs.resolve_php.outputs.php-version-source }}`
                   - Test matrix: `${{ needs.resolve_php.outputs.test-matrix }}`
-                  - Test-sensitive diff: `${{ needs.resolve_php.outputs.run-tests }}`
-                  - Test scope reason: `${{ needs.resolve_php.outputs.test-scope-reason }}`
                   - Minimum coverage threshold: `${{ inputs.min-coverage || 80 }}`
                   - Dependency health `max-outdated`: `${{ inputs.max-outdated || -1 }}`
                   - Tests job result: `${{ needs.tests.result }}`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ permissions:
 
 concurrency:
     group: ${{ github.event_name == 'pull_request' && format('tests-pr-{0}', github.event.pull_request.number) || format('tests-{0}', github.ref) }}
-    cancel-in-progress: false
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
     FORCE_COLOR: '1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,7 @@ on:
                 type: number
                 default: -1
     pull_request:
-        paths:
-          - 'src/**'
-          - 'tests/**'
-          - 'composer.json'
-          - 'composer.lock'
-          - '.github/actions/**'
-          - '.github/workflows/tests.yml'
+        types: [opened, synchronize, reopened]
     push:
         branches: [ "main" ]
 
@@ -41,7 +35,7 @@ permissions:
 
 concurrency:
     group: ${{ github.event_name == 'pull_request' && format('tests-pr-{0}', github.event.pull_request.number) || format('tests-{0}', github.ref) }}
-    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    cancel-in-progress: false
 
 env:
     FORCE_COLOR: '1'
@@ -54,9 +48,13 @@ jobs:
             php-version: ${{ steps.resolve.outputs.php-version }}
             php-version-source: ${{ steps.resolve.outputs.php-version-source }}
             test-matrix: ${{ steps.resolve.outputs.test-matrix }}
+            run-tests: ${{ steps.scope.outputs.run-tests }}
+            test-scope-reason: ${{ steps.scope.outputs.reason }}
 
         steps:
             - uses: actions/checkout@v6
+              with:
+                fetch-depth: 0
             - name: Checkout dev-tools workflow action source
               uses: actions/checkout@v6
               with:
@@ -70,6 +68,47 @@ jobs:
               id: resolve
               uses: ./.dev-tools-actions/.github/actions/php/resolve-version
 
+            - name: Resolve test workflow scope
+              id: scope
+              shell: bash
+              env:
+                BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+              run: |
+                set -euo pipefail
+
+                if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+                  {
+                    echo "run-tests=true"
+                    echo "reason=non-pull-request-event"
+                  } >> "$GITHUB_OUTPUT"
+
+                  exit 0
+                fi
+
+                git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+                git diff --name-only "${BASE_SHA}...HEAD" > changed-files.txt
+
+                run_tests=false
+                while IFS= read -r changed_file; do
+                  case "${changed_file}" in
+                    src/*|tests/*|composer.json|composer.lock|.github/actions/*|.github/workflows/tests.yml|resources/github-actions/tests.yml)
+                      run_tests=true
+                      break
+                      ;;
+                  esac
+                done < changed-files.txt
+
+                if [ "${run_tests}" = "true" ]; then
+                  reason="test-sensitive-pr-diff"
+                else
+                  reason="no-test-sensitive-pr-diff"
+                fi
+
+                {
+                  echo "run-tests=${run_tests}"
+                  echo "reason=${reason}"
+                } >> "$GITHUB_OUTPUT"
+
     tests:
         needs: resolve_php
         name: Run Tests
@@ -80,7 +119,9 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
+              if: needs.resolve_php.outputs.run-tests == 'true'
             - name: Checkout dev-tools workflow action source
+              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: actions/checkout@v6
               with:
                 repository: php-fast-forward/dev-tools
@@ -90,6 +131,7 @@ jobs:
                   .github/actions
 
             - name: Setup PHP and install dependencies
+              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ matrix.php-version }}
@@ -99,20 +141,28 @@ jobs:
                 install-options: --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Composer Audit
+              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer audit
 
             - name: Resolve minimum coverage
+              if: needs.resolve_php.outputs.run-tests == 'true'
               id: minimum-coverage
               run: echo "value=${INPUT_MIN_COVERAGE:-80}" >> "$GITHUB_OUTPUT"
               env:
                   INPUT_MIN_COVERAGE: ${{ inputs.min-coverage }}
 
             - name: Run PHPUnit tests
+              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer dev-tools tests -- --coverage=.dev-tools/coverage --min-coverage=${{ steps.minimum-coverage.outputs.value }}
+
+            - name: Mark tests intentionally skipped
+              if: needs.resolve_php.outputs.run-tests != 'true'
+              run: |
+                echo "No test-sensitive PR diff detected; required test context completed without running PHPUnit."
 
     dependency-health:
         needs: resolve_php
@@ -122,7 +172,9 @@ jobs:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
         steps:
             - uses: actions/checkout@v6
+              if: needs.resolve_php.outputs.run-tests == 'true'
             - name: Checkout dev-tools workflow action source
+              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: actions/checkout@v6
               with:
                 repository: php-fast-forward/dev-tools
@@ -132,6 +184,7 @@ jobs:
                   .github/actions
 
             - name: Setup PHP and install dependencies
+              if: needs.resolve_php.outputs.run-tests == 'true'
               uses: ./.dev-tools-actions/.github/actions/php/setup-composer
               with:
                 php-version: ${{ needs.resolve_php.outputs.php-version }}
@@ -139,9 +192,15 @@ jobs:
                 install-options: --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
 
             - name: Run dependency health check
+              if: needs.resolve_php.outputs.run-tests == 'true'
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer dev-tools dependencies -- --max-outdated=${{ inputs.max-outdated || -1 }}
+
+            - name: Mark dependency health intentionally skipped
+              if: needs.resolve_php.outputs.run-tests != 'true'
+              run: |
+                echo "No test-sensitive PR diff detected; dependency health completed without running dependency analysis."
 
     summarize:
         if: ${{ always() }}
@@ -170,6 +229,8 @@ jobs:
                   - Workflow PHP version: `${{ needs.resolve_php.outputs.php-version }}`
                   - PHP version source: `${{ needs.resolve_php.outputs.php-version-source }}`
                   - Test matrix: `${{ needs.resolve_php.outputs.test-matrix }}`
+                  - Test-sensitive diff: `${{ needs.resolve_php.outputs.run-tests }}`
+                  - Test scope reason: `${{ needs.resolve_php.outputs.test-scope-reason }}`
                   - Minimum coverage threshold: `${{ inputs.min-coverage || 80 }}`
                   - Dependency health `max-outdated`: `${{ inputs.max-outdated || -1 }}`
                   - Tests job result: `${{ needs.tests.result }}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow and aligning the packaged consumer test wrapper (#230)
+- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by running the pull-request test workflow without top-level path filters and aligning the packaged consumer test wrapper (#230)
 
 ## [1.21.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow, queueing same-PR test runs, and aligning the packaged consumer test wrapper (#230)
+- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow and aligning the packaged consumer test wrapper (#230)
 
 ## [1.21.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep Composer autoload, Rector, and ECS from traversing nested fixture `vendor` directories when the composer-plugin consumer fixture has installed dependencies (#179)
 - Skip LICENSE generation cleanly when a consumer composer manifest omits or leaves the `license` field empty (#227)
 - Run nested DevTools subprocesses without forcing PTY, fixing aggregate commands in non-interactive environments (#171)
+- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow, queueing same-PR test runs, and aligning the packaged consumer test wrapper (#230)
 
 ## [1.20.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow, queueing same-PR test runs, and aligning the packaged consumer test wrapper (#230)
+
 ## [1.21.0] - 2026-04-24
 
 ### Changed
@@ -26,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep Composer autoload, Rector, and ECS from traversing nested fixture `vendor` directories when the composer-plugin consumer fixture has installed dependencies (#179)
 - Skip LICENSE generation cleanly when a consumer composer manifest omits or leaves the `license` field empty (#227)
 - Run nested DevTools subprocesses without forcing PTY, fixing aggregate commands in non-interactive environments (#171)
-- Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by moving PR test-skip decisions inside the tests workflow, queueing same-PR test runs, and aligning the packaged consumer test wrapper (#230)
 
 ## [1.20.0] - 2026-04-23
 

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -106,10 +106,11 @@ intentional skip message instead of leaving branch protection waiting for
 missing checks. If the pull request does include test-sensitive changes, the
 matrix runs even when the newest commit is only the generated wiki pointer.
 
-Test workflow concurrency queues runs for the same pull request instead of
-canceling in-progress jobs. This prevents the wiki-pointer run from canceling a
-source-change run and then completing with a lightweight skip before the real
-validation has reported.
+Test workflow concurrency cancels older in-progress runs for the same pull
+request. Because the skip decision uses the effective pull request diff instead
+of only the latest commit, a generated wiki-pointer commit still runs the matrix
+when the pull request contains source, test, Composer, test-workflow, packaged
+test-wrapper, or local-action changes.
 
 At a high level, the workflows need permission to read repository contents,
 write generated preview commits, update pull request comments, and publish Pages

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -97,20 +97,12 @@ to refresh generated pointers manually. The preferred path is to allow bot
 updates on PR branches while keeping ``main`` protected.
 
 Required test checks must still report for workflow-managed pointer commits.
-The tests workflow therefore triggers on every pull request update and resolves
-whether the effective pull request diff contains test-sensitive files inside the
-workflow itself. If the latest commit only refreshes ``.github/wiki`` and the
-pull request has no source, test, Composer, test-workflow, packaged test-wrapper,
-or local-action changes, the required ``Run Tests`` matrix jobs complete with an
-intentional skip message instead of leaving branch protection waiting for
-missing checks. If the pull request does include test-sensitive changes, the
-matrix runs even when the newest commit is only the generated wiki pointer.
-
-Test workflow concurrency cancels older in-progress runs for the same pull
-request. Because the skip decision uses the effective pull request diff instead
-of only the latest commit, a generated wiki-pointer commit still runs the matrix
-when the pull request contains source, test, Composer, test-workflow, packaged
-test-wrapper, or local-action changes.
+The tests workflow therefore triggers on every pull request update without
+top-level path filters. This ensures GitHub always creates the required
+``Run Tests`` matrix checks for the latest pull request head, including bot
+commits that only refresh ``.github/wiki``. Test workflow concurrency cancels
+older in-progress runs for the same pull request so the newest commit owns the
+required check contexts.
 
 At a high level, the workflows need permission to read repository contents,
 write generated preview commits, update pull request comments, and publish Pages

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -96,6 +96,21 @@ should either allow the workflow token to update PR branches or require authors
 to refresh generated pointers manually. The preferred path is to allow bot
 updates on PR branches while keeping ``main`` protected.
 
+Required test checks must still report for workflow-managed pointer commits.
+The tests workflow therefore triggers on every pull request update and resolves
+whether the effective pull request diff contains test-sensitive files inside the
+workflow itself. If the latest commit only refreshes ``.github/wiki`` and the
+pull request has no source, test, Composer, test-workflow, packaged test-wrapper,
+or local-action changes, the required ``Run Tests`` matrix jobs complete with an
+intentional skip message instead of leaving branch protection waiting for
+missing checks. If the pull request does include test-sensitive changes, the
+matrix runs even when the newest commit is only the generated wiki pointer.
+
+Test workflow concurrency queues runs for the same pull request instead of
+canceling in-progress jobs. This prevents the wiki-pointer run from canceling a
+source-change run and then completing with a lightweight skip before the real
+validation has reported.
+
 At a high level, the workflows need permission to read repository contents,
 write generated preview commits, update pull request comments, and publish Pages
 content. Keep those permissions scoped to the workflow jobs that actually need

--- a/resources/github-actions/tests.yml
+++ b/resources/github-actions/tests.yml
@@ -2,6 +2,11 @@ name: "Fast Forward Test Suite"
 
 on:
   push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
     inputs:
       max-outdated:


### PR DESCRIPTION
## Related Issue

Closes #230

## Motivation / Context

- Wiki preview automation commits `.github/wiki` pointer updates back to PR branches.
- The tests workflow previously used a top-level `pull_request.paths` filter, so a wiki-pointer-only head commit could skip the workflow entirely.
- Branch protection still expects `Run Tests (8.3)`, `Run Tests (8.4)`, and `Run Tests (8.5)`, leaving those contexts stuck as `Expected`.

## Changes

- Removed the top-level `pull_request.paths` filter from `.github/workflows/tests.yml` so required test contexts are always reported for PR updates.
- Kept same-PR test workflow runs cancelable, so the newest PR SHA owns the required contexts without making maintainers wait for superseded runs.
- Restored `pull_request` triggering in the packaged consumer test wrapper.
- Documented the branch-protection/wiki-pointer contract and added a changelog entry.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s):
  - `ruby -e 'require "yaml"; %w[.github/workflows/tests.yml resources/github-actions/tests.yml].each { |f| YAML.load_file(f); puts "#{f} OK" }'`
  - `composer dev-tools code-style -- --fix --json`
  - `composer dev-tools changelog:check`
  - `git diff --check`
- [x] Manual verification: after this PR ran in GitHub Actions, the required `Run Tests (8.3)`, `Run Tests (8.4)`, and `Run Tests (8.5)` contexts were created and completed successfully instead of staying `Expected`.

`composer dev-tools` was not run locally because this branch changes GitHub Actions/docs only and the local full gate still runs the heavy reports/metrics path; the workflow syntax was validated directly.

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

No generated docs/wiki output was committed.

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The key behavior is that GitHub branch protection cannot wait on missing contexts anymore: the workflow triggers and the required matrix jobs always exist for pull request updates.
- This intentionally favors reliability of required checks over path-filter optimization.
