### PR TITLE
[ci] Mirror dispatched wiki tests as required statuses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,11 @@ on:
                 required: false
                 type: number
                 default: -1
+            publish-required-statuses:
+                description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
+                required: false
+                type: boolean
+                default: false
     workflow_dispatch:
         inputs:
             min-coverage:
@@ -25,6 +30,11 @@ on:
                 required: false
                 type: number
                 default: -1
+            publish-required-statuses:
+                description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
+                required: false
+                type: boolean
+                default: false
     pull_request:
         types: [opened, synchronize, reopened]
     push:
@@ -32,6 +42,7 @@ on:
 
 permissions:
     contents: read
+    statuses: write
 
 concurrency:
     group: ${{ github.event_name == 'pull_request' && format('tests-pr-{0}', github.event.pull_request.number) || format('tests-{0}', github.ref) }}
@@ -168,3 +179,35 @@ jobs:
                   - Dependency health `max-outdated`: `${{ inputs.max-outdated || -1 }}`
                   - Tests job result: `${{ needs.tests.result }}`
                   - Dependency health result: `${{ needs.dependency-health.result }}`
+
+    publish_required_statuses:
+        if: ${{ always() && inputs.publish-required-statuses }}
+        name: Publish Required Test Statuses
+        needs:
+            - tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Mirror required test matrix contexts
+              env:
+                GH_TOKEN: ${{ github.token }}
+                TARGET_SHA: ${{ github.sha }}
+                TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                TESTS_RESULT: ${{ needs.tests.result }}
+              run: |
+                if [ "${TESTS_RESULT}" = "success" ]; then
+                  state="success"
+                  description="Workflow-dispatched PHPUnit matrix passed."
+                else
+                  state="failure"
+                  description="Workflow-dispatched PHPUnit matrix result: ${TESTS_RESULT}."
+                fi
+
+                for context in "Run Tests (8.3)" "Run Tests (8.4)" "Run Tests (8.5)"; do
+                  gh api \
+                    --method POST \
+                    "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+                    -f state="${state}" \
+                    -f context="${context}" \
+                    -f description="${description}" \
+                    -f target_url="${TARGET_URL}"
+                done

--- a/.github/workflows/wiki-preview.yml
+++ b/.github/workflows/wiki-preview.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: gh workflow run tests.yml --ref "${HEAD_REF}" -f max-outdated=-1
+        run: gh workflow run tests.yml --ref "${HEAD_REF}" -f max-outdated=-1 -f publish-required-statuses=true
 
       - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by running the pull-request test workflow without top-level path filters and aligning the packaged consumer test wrapper (#230)
 - Ignore intentional Composer Dependency Analyser shadow dependency findings by default while adding `dependencies --show-shadow-dependencies` for audits (#233)
 - Dispatch the required test workflow after wiki preview automation updates a pull-request `.github/wiki` pointer, avoiding permanently pending required checks on bot-authored pointer commits (#230)
+- Mirror workflow-dispatched wiki pointer test results into required `Run Tests` commit statuses so branch protection recognizes bot-authored pointer commits (#230)
 
 ## [1.21.0] - 2026-04-24
 

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -106,9 +106,12 @@ does not start another ``pull_request`` or ``push`` workflow run for commits
 pushed with the built-in workflow token. After the wiki preview workflow commits
 a parent-repository pointer update, it explicitly dispatches ``tests.yml`` for
 the pull request head branch so the newest bot-authored commit receives the
-required ``Run Tests`` matrix checks. Test workflow concurrency cancels older
-in-progress runs for the same pull request so the newest commit owns the
-required check contexts.
+required ``Run Tests`` matrix checks. Because manually dispatched workflow check
+runs are not always treated as pull-request required checks, that dispatched
+test run also mirrors the matrix result into commit statuses named
+``Run Tests (8.3)``, ``Run Tests (8.4)``, and ``Run Tests (8.5)``. Test workflow
+concurrency cancels older in-progress runs for the same pull request so the
+newest commit owns the required check contexts.
 
 At a high level, the workflows need permission to read repository contents,
 write generated preview commits, update pull request comments, and publish Pages
@@ -122,8 +125,10 @@ The reusable workflows default to read-only repository access and grant write
 permissions at the job level when generated content must be pushed or pull
 requests must be updated.
 
-``tests.yml`` only needs ``contents: read`` because it checks out code, installs
-dependencies, and runs PHPUnit.
+``tests.yml`` needs ``contents: read`` because it checks out code, installs
+dependencies, and runs PHPUnit. It also declares ``statuses: write`` so
+workflow-dispatched test runs can mirror required matrix contexts onto
+bot-authored wiki pointer commits.
 
 ``reports.yml`` keeps ``contents: write`` on jobs that publish or clean
 ``gh-pages`` content. The pull request preview comment runs as a separate job

--- a/resources/github-actions/tests.yml
+++ b/resources/github-actions/tests.yml
@@ -14,13 +14,20 @@ on:
         required: false
         type: number
         default: -1
+      publish-required-statuses:
+        description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   tests:
     uses: php-fast-forward/dev-tools/.github/workflows/tests.yml@main
     with:
       max-outdated: ${{ inputs.max-outdated || -1 }}
+      publish-required-statuses: ${{ inputs.publish-required-statuses || false }}
     secrets: inherit


### PR DESCRIPTION
## Related Issue

Refs #230

## Motivation / Context

- PR #234 fixed part of the wiki pointer problem by dispatching `tests.yml` after bot-authored `.github/wiki` pointer commits.
- PR #235 showed the remaining gap: the workflow-dispatched test run can execute and pass on the bot-authored SHA, but GitHub branch protection may still keep the required `Run Tests (8.3)`, `Run Tests (8.4)`, and `Run Tests (8.5)` contexts pending because the run was not created by the normal `pull_request` event.

## Changes

- Add a `publish-required-statuses` input to the reusable and packaged tests workflows.
- When enabled, mirror the matrix result into commit statuses named exactly like the required `Run Tests` contexts.
- Dispatch the wiki pointer follow-up test run with `publish-required-statuses=true`.
- Document why workflow-dispatched test runs need commit-status mirroring for bot-authored wiki pointer commits.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s): `composer dev-tools code-style -- --fix --json`
- [x] Focused command(s): `composer dev-tools changelog:check`
- [x] Manual verification: `ruby -e 'require "yaml"; %w[.github/workflows/tests.yml .github/workflows/wiki-preview.yml resources/github-actions/tests.yml].each { |f| YAML.load_file(f); puts "#{f}: ok" }'`
- [x] Manual verification: `git diff --check`

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- This is deliberately split out from the closed `proof-html` experiment in PR #235. The HTML validation work was abandoned, but this CI fix is still needed for the earlier wiki pointer required-check problem.
- I did not run the full `composer dev-tools` locally because this branch only changes workflows/docs/changelog and the repository pre-commit `composer_script` has recently timed out at 120 seconds while running that full suite. The focused fix/check commands above passed before commit.
