### PR TITLE
[ci] Fix actionlint finding in reports workflow

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -95,7 +95,7 @@ jobs:
 
             - name: Fix permissions
               run: |
-                chmod -c -R +rX "${REPORTS_TARGET}/" | while read line; do
+                chmod -c -R +rX "${REPORTS_TARGET}/" | while IFS= read -r line; do
                     echo "::warning title=Invalid file permissions automatically fixed::$line"
                 done
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,7 @@ jobs:
         name: Run Tests
         runs-on: ubuntu-latest
         strategy:
+            fail-fast: false
             matrix: ${{ fromJson(needs.resolve_php.outputs.test-matrix) }}
         env:
             TESTS_ROOT_VERSION: ${{ github.event_name == 'pull_request' && format('dev-{0}', github.event.pull_request.head.ref) || 'dev-main' }}
@@ -118,6 +119,31 @@ jobs:
               env:
                 COMPOSER_ROOT_VERSION: ${{ env.TESTS_ROOT_VERSION }}
               run: composer dev-tools tests -- --coverage=.dev-tools/coverage --min-coverage=${{ steps.minimum-coverage.outputs.value }}
+
+            - name: Publish required test status
+              if: ${{ always() && inputs.publish-required-statuses }}
+              env:
+                GH_TOKEN: ${{ github.token }}
+                TARGET_SHA: ${{ github.sha }}
+                TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                TEST_CONTEXT: Run Tests (${{ matrix.php-version }})
+                TEST_RESULT: ${{ job.status }}
+              run: |
+                if [ "${TEST_RESULT}" = "success" ]; then
+                  state="success"
+                  description="Workflow-dispatched PHPUnit job passed."
+                else
+                  state="failure"
+                  description="Workflow-dispatched PHPUnit job result: ${TEST_RESULT}."
+                fi
+
+                gh api \
+                  --method POST \
+                  "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+                  -f state="${state}" \
+                  -f context="${TEST_CONTEXT}" \
+                  -f description="${description}" \
+                  -f target_url="${TARGET_URL}"
 
     dependency-health:
         needs: resolve_php
@@ -184,30 +210,22 @@ jobs:
         if: ${{ always() && inputs.publish-required-statuses }}
         name: Publish Required Test Statuses
         needs:
-            - tests
+            - resolve_php
         runs-on: ubuntu-latest
         steps:
-            - name: Mirror required test matrix contexts
+            - name: Publish pending required test statuses
               env:
                 GH_TOKEN: ${{ github.token }}
                 TARGET_SHA: ${{ github.sha }}
                 TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                TESTS_RESULT: ${{ needs.tests.result }}
+                TEST_MATRIX: ${{ needs.resolve_php.outputs.test-matrix }}
               run: |
-                if [ "${TESTS_RESULT}" = "success" ]; then
-                  state="success"
-                  description="Workflow-dispatched PHPUnit matrix passed."
-                else
-                  state="failure"
-                  description="Workflow-dispatched PHPUnit matrix result: ${TESTS_RESULT}."
-                fi
-
-                for context in "Run Tests (8.3)" "Run Tests (8.4)" "Run Tests (8.5)"; do
+                php -r "foreach (json_decode(getenv('TEST_MATRIX'), true, 512, JSON_THROW_ON_ERROR)['php-version'] as \$version) { echo \$version, PHP_EOL; }" | while IFS= read -r php_version; do
                   gh api \
                     --method POST \
                     "repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
-                    -f state="${state}" \
-                    -f context="${context}" \
-                    -f description="${description}" \
+                    -f state="pending" \
+                    -f context="Run Tests (${php_version})" \
+                    -f description="Workflow-dispatched PHPUnit job is pending." \
                     -f target_url="${TARGET_URL}"
                 done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep the reports workflow permission warning loop shell-safe for paths containing backslashes (#244)
 - Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by running the pull-request test workflow without top-level path filters and aligning the packaged consumer test wrapper (#230)
+- Publish pending and per-version required PHPUnit statuses for workflow-dispatched test runs so wiki pointer commits do not wait for an all-matrix aggregate status (#230)
 - Ignore intentional Composer Dependency Analyser shadow dependency findings by default while adding `dependencies --show-shadow-dependencies` for audits (#233)
 - Dispatch the required test workflow after wiki preview automation updates a pull-request `.github/wiki` pointer, avoiding permanently pending required checks on bot-authored pointer commits (#230)
 - Mirror workflow-dispatched wiki pointer test results into required `Run Tests` commit statuses so branch protection recognizes bot-authored pointer commits (#230)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep the reports workflow permission warning loop shell-safe for paths containing backslashes (#244)
 - Keep required PHPUnit matrix checks reporting after workflow-managed `.github/wiki` pointer commits by running the pull-request test workflow without top-level path filters and aligning the packaged consumer test wrapper (#230)
 - Ignore intentional Composer Dependency Analyser shadow dependency findings by default while adding `dependencies --show-shadow-dependencies` for audits (#233)
 - Dispatch the required test workflow after wiki preview automation updates a pull-request `.github/wiki` pointer, avoiding permanently pending required checks on bot-authored pointer commits (#230)

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -108,10 +108,12 @@ a parent-repository pointer update, it explicitly dispatches ``tests.yml`` for
 the pull request head branch so the newest bot-authored commit receives the
 required ``Run Tests`` matrix checks. Because manually dispatched workflow check
 runs are not always treated as pull-request required checks, that dispatched
-test run also mirrors the matrix result into commit statuses named
-``Run Tests (8.3)``, ``Run Tests (8.4)``, and ``Run Tests (8.5)``. Test workflow
-concurrency cancels older in-progress runs for the same pull request so the
-newest commit owns the required check contexts.
+test run first publishes pending commit statuses for the resolved PHP matrix and
+then lets each matrix job publish its own final status. The status contexts use
+the same required-check names, such as ``Run Tests (8.3)``, ``Run Tests (8.4)``,
+and ``Run Tests (8.5)``. Test workflow concurrency cancels older in-progress
+runs for the same pull request so the newest commit owns the required check
+contexts.
 
 The predictable-conflict workflow MAY also refresh pull request branches when
 the only conflicts are ``.github/wiki`` pointer drift and/or ``CHANGELOG.md``


### PR DESCRIPTION
## Related Issue

Closes #244

## Motivation / Context

- `actionlint` reported ShellCheck `SC2162` in the reports workflow because the permission warning loop used `read` without `-r`.
- The warning loop should preserve emitted paths exactly while keeping the existing GitHub annotation behavior.

## Changes

- Updates the reports workflow permission-fix loop to use `while IFS= read -r line`.
- Publishes pending required PHPUnit statuses as soon as workflow-dispatched wiki pointer tests start.
- Publishes each required PHPUnit status from its own matrix job instead of waiting for the aggregate matrix result.
- Disables matrix fail-fast so one failing version does not leave another required status without a final state.
- Adds changelog entries for the workflow lint and required-status fixes.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s): `actionlint .github/workflows/*.yml resources/github-actions/*.yml`
- [x] Focused command(s): `composer dev-tools changelog:check`
- [x] Focused command(s): `git diff --check`
- [x] Focused command(s): validated the test-matrix PHP extraction snippet locally
- [x] Manual verification: Confirmed there is no equivalent permission loop in `resources/github-actions/*.yml` to align.

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- Full `composer dev-tools` was not run because this PR changes workflow shell/status behavior only; the relevant workflow lint, changelog check, and matrix extraction smoke test passed locally.

