### PR TITLE
Fix changelog workflow permissions for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Grant project-board write permission in the packaged changelog workflow wrapper so consumer release workflows can call the reusable changelog automation without GitHub rejecting the requested permissions (#251)
+
 ## [1.22.0] - 2026-04-24
 
 ### Added

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -177,7 +177,10 @@ To enable reusable project automation in consumer repositories, pass
 ``project`` through the thin ``workflow_call`` wrapper or configure the
 repository variable ``PROJECT`` so the workflow can resolve the target GitHub
 Project without hardcoding repository-specific board identifiers into the
-packaged workflow itself. The workflow derives the owner from
+packaged workflow itself. Consumer wrappers that call reusable workflows with
+project-board release transitions MUST also grant ``repository-projects: write``
+at the caller level; otherwise GitHub rejects the workflow before the release
+automation starts. The workflow derives the owner from
 ``github.repository_owner`` and uses the built-in workflow token for the actual
 project mutations. Inside ``php-fast-forward`` repositories, the reusable
 workflow MAY fall back to the first organization Project V2 when no explicit

--- a/resources/github-actions/changelog.yml
+++ b/resources/github-actions/changelog.yml
@@ -31,6 +31,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  repository-projects: write
 
 jobs:
   changelog:


### PR DESCRIPTION
## Related Issue

Closes #251

## Motivation / Context

- Consumer repositories can fail release workflow validation when the packaged changelog wrapper calls the reusable DevTools changelog workflow without granting `repository-projects: write`.
- This blocked the `php-fast-forward/enum` release flow before the changelog automation could start.

## Changes

- Grant `repository-projects: write` in `resources/github-actions/changelog.yml` so synced consumer wrappers can call the reusable changelog workflow successfully.
- Document the caller-level permission requirement for project-board release transitions.
- Add a changelog entry for the consumer workflow permission fix.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s): `actionlint resources/github-actions/changelog.yml .github/workflows/changelog.yml`
- [x] Focused command(s): `composer dev-tools changelog:check`
- [x] Focused command(s): `git diff --check`
- [x] Manual verification: confirmed the packaged wrapper now grants the permission requested by `.github/workflows/changelog.yml`.

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- This is intentionally the smallest fix for the immediate consumer failure: the reusable workflow already requests `repository-projects: write`; the synced wrapper now grants the same permission at the caller level.
