### PR TITLE
Fix release project-board promotion

### DIFF
--- a/.github/actions/project-board/transition-status/action.yml
+++ b/.github/actions/project-board/transition-status/action.yml
@@ -8,7 +8,12 @@ inputs:
     default: ''
   from-status:
     description: Source project status name.
-    required: true
+    required: false
+    default: ''
+  from-statuses:
+    description: Comma-separated source project status names.
+    required: false
+    default: ''
   to-status:
     description: Destination project status name.
     required: true
@@ -17,13 +22,26 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  moved-count:
+    description: Number of project items moved to the destination status.
+    value: ${{ steps.transition.outputs.moved-count }}
+  skipped-count:
+    description: Number of project items inspected but not moved.
+    value: ${{ steps.transition.outputs.skipped-count }}
+  source-statuses:
+    description: Comma-separated source statuses used for the transition.
+    value: ${{ steps.transition.outputs.source-statuses }}
+
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v8
+    - id: transition
+      uses: actions/github-script@v8
       env:
         INPUT_PROJECT: ${{ inputs.project }}
         INPUT_FROM_STATUS: ${{ inputs.from-status }}
+        INPUT_FROM_STATUSES: ${{ inputs.from-statuses }}
         INPUT_TO_STATUS: ${{ inputs.to-status }}
         INPUT_INCLUDE_CURRENT_PULL_REQUEST: ${{ inputs.include-current-pull-request }}
       with:

--- a/.github/actions/project-board/transition-status/run.cjs
+++ b/.github/actions/project-board/transition-status/run.cjs
@@ -7,8 +7,23 @@ const board = require('../shared/project-board-client.cjs');
  */
 module.exports = async function transitionStatus({ github, context, core }) {
     const includeCurrentPullRequest = 'true' === (process.env.INPUT_INCLUDE_CURRENT_PULL_REQUEST ?? '').toLowerCase();
-    const fromStatus = process.env.INPUT_FROM_STATUS;
+    const sourceStatuses = [
+        ...(process.env.INPUT_FROM_STATUSES ?? '').split(','),
+        process.env.INPUT_FROM_STATUS ?? '',
+    ]
+        .map((status) => status.trim())
+        .filter((status, index, statuses) => '' !== status && statuses.indexOf(status) === index);
     const toStatus = process.env.INPUT_TO_STATUS;
+
+    core.setOutput('source-statuses', sourceStatuses.join(','));
+
+    if (0 === sourceStatuses.length) {
+        core.info('No source project statuses were provided. Skipping status transition.');
+        core.setOutput('moved-count', '0');
+        core.setOutput('skipped-count', '0');
+
+        return;
+    }
 
     const project = await board.loadConfiguredProject(
         github,
@@ -18,6 +33,8 @@ module.exports = async function transitionStatus({ github, context, core }) {
 
     if (!project) {
         core.info('No configured GitHub Project V2 was resolved. Skipping status transition.');
+        core.setOutput('moved-count', '0');
+        core.setOutput('skipped-count', '0');
 
         return;
     }
@@ -27,107 +44,93 @@ module.exports = async function transitionStatus({ github, context, core }) {
 
     if (!statusField || !targetOption) {
         core.info(`Project "${project.title}" does not expose the expected target status "${toStatus}".`);
+        core.setOutput('moved-count', '0');
+        core.setOutput('skipped-count', '0');
 
         return;
     }
 
-    const result = await github.graphql(
-        `query($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
-          repository(owner: $owner, name: $repo) {
-            issues(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: CLOSED) {
-              nodes {
-                number
-                projectItems(first: 20) {
-                  nodes {
-                    id
-                    project {
-                      ... on ProjectV2 {
-                        id
-                      }
-                    }
-                    fieldValues(first: 20) {
-                      nodes {
-                        __typename
-                        ... on ProjectV2ItemFieldSingleSelectValue {
-                          field {
-                            ... on ProjectV2SingleSelectField {
-                              name
-                            }
-                          }
-                          name
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, states: [MERGED, CLOSED]) {
-              nodes {
-                number
-                projectItems(first: 20) {
-                  nodes {
-                    id
-                    project {
-                      ... on ProjectV2 {
-                        id
-                      }
-                    }
-                    fieldValues(first: 20) {
-                      nodes {
-                        __typename
-                        ... on ProjectV2ItemFieldSingleSelectValue {
-                          field {
-                            ... on ProjectV2SingleSelectField {
-                              name
-                            }
-                          }
-                          name
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            pullRequest(number: $pullRequestNumber) {
-              number
-              projectItems(first: 20) {
-                nodes {
-                  id
-                  project {
+    const loadProjectItems = async () => {
+        const items = [];
+        let cursor = null;
+
+        do {
+            const result = await github.graphql(
+                `query($project: ID!, $cursor: String) {
+                  node(id: $project) {
                     ... on ProjectV2 {
-                      id
-                    }
-                  }
-                  fieldValues(first: 20) {
-                    nodes {
-                      __typename
-                      ... on ProjectV2ItemFieldSingleSelectValue {
-                        field {
-                          ... on ProjectV2SingleSelectField {
-                            name
+                      items(first: 100, after: $cursor) {
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
+                        nodes {
+                          id
+                          content {
+                            __typename
+                            ... on Issue {
+                              number
+                              title
+                              url
+                            }
+                            ... on PullRequest {
+                              number
+                              title
+                              url
+                            }
+                          }
+                          fieldValues(first: 20) {
+                            nodes {
+                              __typename
+                              ... on ProjectV2ItemFieldSingleSelectValue {
+                                field {
+                                  ... on ProjectV2SingleSelectField {
+                                    name
+                                  }
+                                }
+                                name
+                              }
+                            }
                           }
                         }
-                        name
                       }
                     }
                   }
-                }
-              }
-            }
-          }
-        }`,
-        {
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pullRequestNumber: context.payload.pull_request?.number ?? 0,
-        },
-    );
+                }`,
+                {
+                    project: project.id,
+                    cursor,
+                },
+            );
+
+            const page = result.node?.items;
+
+            items.push(...(page?.nodes ?? []));
+            cursor = page?.pageInfo?.hasNextPage ? page.pageInfo.endCursor : null;
+        } while (null !== cursor);
+
+        return items;
+    };
+
+    const formatLabel = (item) => {
+        const content = item.content;
+
+        if ('Issue' === content?.__typename) {
+            return `Issue #${content.number}`;
+        }
+
+        if ('PullRequest' === content?.__typename) {
+            return `PR #${content.number}`;
+        }
+
+        return `Project item ${item.id}`;
+    };
 
     const moveToStatus = async (item, label) => {
-        if (!item || board.getExistingFieldValue(item, 'Status') !== fromStatus) {
-            return;
+        const currentStatus = board.getExistingFieldValue(item, 'Status');
+
+        if (!sourceStatuses.includes(currentStatus)) {
+            return false;
         }
 
         await board.updateSingleSelectField(
@@ -138,27 +141,29 @@ module.exports = async function transitionStatus({ github, context, core }) {
             targetOption.id,
         );
 
-        core.info(`${label} moved to ${toStatus}.`);
+        core.info(`${label} moved from ${currentStatus} to ${toStatus}.`);
+
+        return true;
     };
 
     if (includeCurrentPullRequest) {
-        await moveToStatus(
-            board.findProjectItem(result.repository.pullRequest?.projectItems?.nodes ?? [], project.id),
-            `Pull request #${context.payload.pull_request.number}`,
-        );
+        core.info('The include-current-pull-request input is kept for compatibility; project item pagination already includes the current pull request when it is on the board.');
     }
 
-    for (const pullRequest of result.repository.pullRequests.nodes) {
-        await moveToStatus(
-            board.findProjectItem(pullRequest.projectItems.nodes, project.id),
-            `PR #${pullRequest.number}`,
-        );
+    let movedCount = 0;
+    let skippedCount = 0;
+
+    for (const item of await loadProjectItems()) {
+        if (await moveToStatus(item, formatLabel(item))) {
+            movedCount++;
+
+            continue;
+        }
+
+        skippedCount++;
     }
 
-    for (const issue of result.repository.issues.nodes) {
-        await moveToStatus(
-            board.findProjectItem(issue.projectItems.nodes, project.id),
-            `Issue #${issue.number}`,
-        );
-    }
+    core.info(`${movedCount} project item(s) moved to ${toStatus}; ${skippedCount} inspected item(s) skipped.`);
+    core.setOutput('moved-count', String(movedCount));
+    core.setOutput('skipped-count', String(skippedCount));
 };

--- a/.github/actions/project-board/transition-status/run.cjs
+++ b/.github/actions/project-board/transition-status/run.cjs
@@ -70,11 +70,17 @@ module.exports = async function transitionStatus({ github, context, core }) {
                             __typename
                             ... on Issue {
                               number
+                              repository {
+                                nameWithOwner
+                              }
                               title
                               url
                             }
                             ... on PullRequest {
                               number
+                              repository {
+                                nameWithOwner
+                              }
                               title
                               url
                             }
@@ -126,6 +132,12 @@ module.exports = async function transitionStatus({ github, context, core }) {
         return `Project item ${item.id}`;
     };
 
+    const belongsToCurrentRepository = (item) => {
+        const repository = item.content?.repository?.nameWithOwner;
+
+        return `${context.repo.owner}/${context.repo.repo}` === repository;
+    };
+
     const moveToStatus = async (item, label) => {
         const currentStatus = board.getExistingFieldValue(item, 'Status');
 
@@ -154,6 +166,12 @@ module.exports = async function transitionStatus({ github, context, core }) {
     let skippedCount = 0;
 
     for (const item of await loadProjectItems()) {
+        if (!belongsToCurrentRepository(item)) {
+            skippedCount++;
+
+            continue;
+        }
+
         if (await moveToStatus(item, formatLabel(item))) {
             movedCount++;
 

--- a/.github/actions/project-board/transition-status/run.test.cjs
+++ b/.github/actions/project-board/transition-status/run.test.cjs
@@ -28,12 +28,22 @@ const project = {
 /**
  * @param {string} id
  * @param {string} status
+ * @param {'Issue'|'PullRequest'} type
+ * @param {number} number
+ * @param {string} repository
  *
  * @returns {object}
  */
-function projectItem(id, status) {
+function projectItem(id, status, type = 'Issue', number = 1, repository = 'php-fast-forward/dev-tools') {
     return {
         id,
+        content: {
+            __typename: type,
+            number,
+            repository: {
+                nameWithOwner: repository,
+            },
+        },
         project: {
             id: project.id,
         },
@@ -157,27 +167,10 @@ async function withEnvironment(env, callback) {
 
 test('moves items from multiple source statuses to the release status', async () => {
     const projectItems = [
-        {
-            ...projectItem('current-pr', 'Release Prepared'),
-            content: {
-                __typename: 'PullRequest',
-                number: 10,
-            },
-        },
-        {
-            ...projectItem('merged-pr', 'Merged'),
-            content: {
-                __typename: 'PullRequest',
-                number: 9,
-            },
-        },
-        {
-            ...projectItem('backlog-issue', 'Backlog'),
-            content: {
-                __typename: 'Issue',
-                number: 8,
-            },
-        },
+        projectItem('current-pr', 'Release Prepared', 'PullRequest', 10),
+        projectItem('merged-pr', 'Merged', 'PullRequest', 9),
+        projectItem('foreign-merged-pr', 'Merged', 'PullRequest', 7, 'php-fast-forward/enum'),
+        projectItem('backlog-issue', 'Backlog', 'Issue', 8),
     ];
     const {github, mutations} = createGithub(projectItems);
     const {core, outputs} = createCore();
@@ -209,18 +202,12 @@ test('moves items from multiple source statuses to the release status', async ()
     assert.deepEqual(mutations.map((mutation) => mutation.itemId), ['current-pr', 'merged-pr']);
     assert.equal(outputs['source-statuses'], 'Release Prepared,Merged');
     assert.equal(outputs['moved-count'], '2');
-    assert.equal(outputs['skipped-count'], '1');
+    assert.equal(outputs['skipped-count'], '2');
 });
 
 test('keeps the legacy from-status input supported', async () => {
     const projectItems = [
-        {
-            ...projectItem('merged-issue', 'Merged'),
-            content: {
-                __typename: 'Issue',
-                number: 8,
-            },
-        },
+        projectItem('merged-issue', 'Merged', 'Issue', 8),
     ];
     const {github, mutations} = createGithub(projectItems);
     const {core, outputs} = createCore();

--- a/.github/actions/project-board/transition-status/run.test.cjs
+++ b/.github/actions/project-board/transition-status/run.test.cjs
@@ -1,0 +1,252 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const transitionStatus = require('./run.cjs');
+
+const project = {
+    id: 'project-1',
+    title: 'PHP Fast Forward Project',
+    fields: {
+        nodes: [
+            {
+                __typename: 'ProjectV2SingleSelectField',
+                id: 'status-field',
+                name: 'Status',
+                options: [
+                    {
+                        id: 'released-option',
+                        name: 'Released',
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+/**
+ * @param {string} id
+ * @param {string} status
+ *
+ * @returns {object}
+ */
+function projectItem(id, status) {
+    return {
+        id,
+        project: {
+            id: project.id,
+        },
+        fieldValues: {
+            nodes: [
+                {
+                    __typename: 'ProjectV2ItemFieldSingleSelectValue',
+                    field: {
+                        name: 'Status',
+                    },
+                    name: status,
+                },
+            ],
+        },
+    };
+}
+
+/**
+ * @param {Array<object>} projectItems
+ *
+ * @returns {{github: {graphql: Function}, mutations: Array<object>}}
+ */
+function createGithub(projectItems) {
+    const mutations = [];
+    const github = {
+        graphql: async (query, variables) => {
+            if (query.includes('updateProjectV2ItemFieldValue')) {
+                mutations.push(variables);
+
+                return {
+                    updateProjectV2ItemFieldValue: {
+                        projectV2Item: {
+                            id: variables.itemId,
+                        },
+                    },
+                };
+            }
+
+            if (query.includes('node(id: $project)')) {
+                return {
+                    node: {
+                        items: {
+                            pageInfo: {
+                                hasNextPage: false,
+                                endCursor: null,
+                            },
+                            nodes: projectItems,
+                        },
+                    },
+                };
+            }
+
+            if (query.includes('projectV2(number: $number)')) {
+                return {
+                    organization: {
+                        projectV2: project,
+                    },
+                    user: {
+                        projectV2: null,
+                    },
+                };
+            }
+
+            throw new Error(`Unexpected GraphQL operation: ${query}`);
+        },
+    };
+
+    return {
+        github,
+        mutations,
+    };
+}
+
+/**
+ * @returns {{info: Array<string>, outputs: Record<string, string>, core: object}}
+ */
+function createCore() {
+    const info = [];
+    const outputs = {};
+
+    return {
+        info,
+        outputs,
+        core: {
+            info: (message) => info.push(message),
+            setOutput: (name, value) => {
+                outputs[name] = value;
+            },
+        },
+    };
+}
+
+/**
+ * @param {Record<string, string>} env
+ * @param {Function} callback
+ *
+ * @returns {Promise<void>}
+ */
+async function withEnvironment(env, callback) {
+    const previous = {};
+
+    for (const key of Object.keys(env)) {
+        previous[key] = process.env[key];
+        process.env[key] = env[key];
+    }
+
+    try {
+        await callback();
+    } finally {
+        for (const [key, value] of Object.entries(previous)) {
+            if (undefined === value) {
+                delete process.env[key];
+
+                continue;
+            }
+
+            process.env[key] = value;
+        }
+    }
+}
+
+test('moves items from multiple source statuses to the release status', async () => {
+    const projectItems = [
+        {
+            ...projectItem('current-pr', 'Release Prepared'),
+            content: {
+                __typename: 'PullRequest',
+                number: 10,
+            },
+        },
+        {
+            ...projectItem('merged-pr', 'Merged'),
+            content: {
+                __typename: 'PullRequest',
+                number: 9,
+            },
+        },
+        {
+            ...projectItem('backlog-issue', 'Backlog'),
+            content: {
+                __typename: 'Issue',
+                number: 8,
+            },
+        },
+    ];
+    const {github, mutations} = createGithub(projectItems);
+    const {core, outputs} = createCore();
+
+    await withEnvironment({
+        INPUT_INCLUDE_CURRENT_PULL_REQUEST: 'true',
+        INPUT_FROM_STATUS: '',
+        INPUT_FROM_STATUSES: 'Release Prepared,Merged',
+        INPUT_TO_STATUS: 'Released',
+        INPUT_PROJECT: '1',
+    }, async () => {
+        await transitionStatus({
+            github,
+            context: {
+                repo: {
+                    owner: 'php-fast-forward',
+                    repo: 'dev-tools',
+                },
+                payload: {
+                    pull_request: {
+                        number: 10,
+                    },
+                },
+            },
+            core,
+        });
+    });
+
+    assert.deepEqual(mutations.map((mutation) => mutation.itemId), ['current-pr', 'merged-pr']);
+    assert.equal(outputs['source-statuses'], 'Release Prepared,Merged');
+    assert.equal(outputs['moved-count'], '2');
+    assert.equal(outputs['skipped-count'], '1');
+});
+
+test('keeps the legacy from-status input supported', async () => {
+    const projectItems = [
+        {
+            ...projectItem('merged-issue', 'Merged'),
+            content: {
+                __typename: 'Issue',
+                number: 8,
+            },
+        },
+    ];
+    const {github, mutations} = createGithub(projectItems);
+    const {core, outputs} = createCore();
+
+    await withEnvironment({
+        INPUT_INCLUDE_CURRENT_PULL_REQUEST: 'false',
+        INPUT_FROM_STATUS: 'Merged',
+        INPUT_FROM_STATUSES: '',
+        INPUT_TO_STATUS: 'Released',
+        INPUT_PROJECT: '1',
+    }, async () => {
+        await transitionStatus({
+            github,
+            context: {
+                repo: {
+                    owner: 'php-fast-forward',
+                    repo: 'dev-tools',
+                },
+                payload: {},
+            },
+            core,
+        });
+    });
+
+    assert.deepEqual(mutations.map((mutation) => mutation.itemId), ['merged-issue']);
+    assert.equal(outputs['source-statuses'], 'Merged');
+    assert.equal(outputs['moved-count'], '1');
+    assert.equal(outputs['skipped-count'], '0');
+});

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -309,10 +309,11 @@ jobs:
                   sparse-checkout: |
                       .github/actions
 
-            - uses: ./.dev-tools-actions/.github/actions/project-board/transition-status
+            - id: release_project_status
+              uses: ./.dev-tools-actions/.github/actions/project-board/transition-status
               with:
                   project: ${{ inputs.project || vars.PROJECT || '' }}
-                  from-status: Release Prepared
+                  from-statuses: Release Prepared,Merged
                   to-status: Released
                   include-current-pull-request: 'true'
 
@@ -325,3 +326,6 @@ jobs:
                       - Published tag: `v${{ steps.version.outputs.value }}`
                       - Release operation: `${{ steps.publish_release.outputs.operation }}`
                       - Release URL: ${{ steps.publish_release.outputs.url }}
+                      - Project items released: `${{ steps.release_project_status.outputs.moved-count }}`
+                      - Project items skipped: `${{ steps.release_project_status.outputs.skipped-count }}`
+                      - Project source statuses: `${{ steps.release_project_status.outputs.source-statuses }}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Promote any remaining project-board `Merged` work to `Released` during release publication so bypassed or skipped preparation transitions do not leave completed items stale (#253)
 - Grant project-board write permission in the packaged changelog workflow wrapper so consumer release workflows can call the reusable changelog automation without GitHub rejecting the requested permissions (#251)
 
 ## [1.22.0] - 2026-04-24

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -279,7 +279,11 @@ Maintenance Workflows
     *   Promotes approved pull requests into ``Ready to Merge``.
     *   Moves merged pull requests and linked issues into ``Merged``.
     *   Moves all currently ``Merged`` work into ``Release Prepared`` when ``changelog.yml`` opens or updates a release-preparation pull request.
-    *   Promotes all ``Release Prepared`` work into ``Released`` when the release-preparation pull request is merged and the GitHub release is published.
+    *   Promotes ``Release Prepared`` work into ``Released`` when the
+        release-preparation pull request is merged and the GitHub release is
+        published, and also promotes any remaining ``Merged`` items as a
+        release-publication safety net when the preparation transition did not
+        run.
     *   Uses the built-in workflow token for project updates.
 *   **Label Sync**: Synchronizes repository labels with ecosystem standards.
 


### PR DESCRIPTION
## Related Issue

Closes #253

## Motivation / Context

- Release project-board automation could leave completed work in `Merged` when the release-preparation transition was skipped or bypassed.
- The release publication path should be self-healing and promote release-included work to `Released` even if some items never reached `Release Prepared`.

## Changes

- Teach the `project-board/transition-status` action to accept comma-separated `from-statuses` while keeping the legacy `from-status` input.
- Switch the transition action to paginate Project V2 items directly instead of sampling recent closed repository issues/PRs.
- Publish release summary counts for moved/skipped project items and source statuses.
- Promote both `Release Prepared` and remaining `Merged` items to `Released` during changelog release publication.
- Add a focused Node test for multi-source release promotion and legacy input compatibility.
- Update docs and changelog for the release safety net.

## Verification

- [ ] `composer dev-tools`
- [x] Focused command(s): `node --test .github/actions/project-board/transition-status/run.test.cjs`
- [x] Focused command(s): `actionlint .github/workflows/changelog.yml resources/github-actions/changelog.yml`
- [x] Focused command(s): `ruby -ryaml -e 'ARGV.each { |file| YAML.load_file(file); puts "YAML OK: #{file}" }' .github/actions/project-board/transition-status/action.yml .github/workflows/changelog.yml resources/github-actions/changelog.yml`
- [x] Focused command(s): `composer dev-tools changelog:check`
- [x] Focused command(s): `git diff --check`
- [x] Manual verification: moved all current Project V2 items that were still in `Merged` to `Released` before implementing the automation fix.

## Documentation / Generated Output

- [ ] README updated
- [x] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The release publication workflow now treats `Merged` as a safe fallback source only in the release-publication transition to `Released`; normal PR merge automation still moves individual PRs/issues into `Merged`.
