### PR TITLE
Fix release PR required checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -51,6 +51,7 @@ on:
         types: [closed]
 
 permissions:
+    actions: write
     contents: write
     pull-requests: write
     repository-projects: write
@@ -220,6 +221,13 @@ jobs:
 
                       - source: `${{ steps.version.outputs.source }}`
 
+            - name: Dispatch required tests for release pull request
+              if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_BRANCH: ${{ env.RELEASE_BRANCH_PREFIX }}${{ steps.version.outputs.value }}
+              run: gh workflow run tests.yml --ref "${RELEASE_BRANCH}" -f max-outdated=-1 -f publish-required-statuses=true
+
             - uses: actions/checkout@v6
             - name: Checkout dev-tools workflow action source
               uses: actions/checkout@v6
@@ -246,6 +254,7 @@ jobs:
                       - Version source: `${{ steps.version.outputs.source }}`
                       - Pull request operation: `${{ steps.create_pr.outputs.pull-request-operation || 'none' }}`
                       - Pull request URL: ${{ steps.create_pr.outputs.pull-request-url || 'not created' }}
+                      - Required test dispatch: `${{ steps.create_pr.outputs.pull-request-number != '' && 'requested' || 'not needed' }}`
 
     publish_merged_release:
         name: Publish Merged Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Dispatch required test status mirroring after changelog release-preparation workflows create or update release pull requests so release branches no longer require branch-protection bypass for workflow-authored commits (#250)
+
 ## [1.22.1] - 2026-04-24
 
 ### Fixed

--- a/docs/advanced/branch-protection-and-bot-commits.rst
+++ b/docs/advanced/branch-protection-and-bot-commits.rst
@@ -125,6 +125,15 @@ also pushed with the built-in workflow token, the workflow dispatches
 ``tests.yml`` for the refreshed branch after a successful push so required test
 statuses can be reported for the new commit.
 
+Release-preparation pull requests follow the same rule. The changelog workflow
+creates or updates ``release/v...`` branches with the built-in workflow token,
+so GitHub does not start ordinary ``pull_request`` test runs for the new release
+commit. After the release pull request exists, the changelog workflow
+dispatches ``tests.yml`` for the release branch with required-status mirroring
+enabled. The dispatched run publishes the same required ``Run Tests`` contexts
+for the release PR head, which lets branch protection evaluate the final
+workflow-managed release commit without a maintainer bypass.
+
 At a high level, the workflows need permission to read repository contents,
 write generated preview commits, update pull request comments, and publish Pages
 content. Keep those permissions scoped to the workflow jobs that actually need
@@ -187,6 +196,9 @@ workflow MAY fall back to the first organization Project V2 when no explicit
 project number is provided. The reusable project-board helpers now live under
 ``.github/actions/project-board/*``, which keeps project-state transitions
 shared across issue, pull-request, review, changelog, and release workflows.
+Consumer changelog wrappers MUST also grant ``actions: write`` so the reusable
+release-preparation workflow can dispatch ``tests.yml`` after creating or
+updating a release pull request.
 
 Resolving ``.github/wiki`` Pointer Conflicts
 --------------------------------------------

--- a/docs/usage/github-actions.rst
+++ b/docs/usage/github-actions.rst
@@ -176,8 +176,13 @@ wrapper in ``resources/github-actions/changelog.yml``.
     *   Writes a release-notes preview file to ``.dev-tools/release-notes.md`` with
         ``composer dev-tools changelog:show -- <version>``.
     *   Opens or updates a release-preparation pull request instead of committing directly to ``main``.
+    *   Dispatches ``tests.yml`` for the release branch with required-status
+        mirroring enabled, because release branches are written by the workflow
+        token and do not receive ordinary ``pull_request`` test runs
+        automatically.
     *   Appends a run summary with the resolved version, version source, and pull-request URL.
-    *   Requires repository Actions permissions that allow the workflow token to create pull requests.
+    *   Requires repository Actions permissions that allow the workflow token
+        to create pull requests and dispatch workflows.
 *   **Merged Release Pull Requests**:
     *   Detects merged branches that match the configured release branch prefix.
     *   Renders the released changelog section with ``composer dev-tools changelog:show -- <version>``.

--- a/resources/github-actions/changelog.yml
+++ b/resources/github-actions/changelog.yml
@@ -29,6 +29,7 @@ on:
         default: release/v
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   repository-projects: write


### PR DESCRIPTION
## Summary
- grant changelog automation `actions: write` so it can dispatch the test workflow after preparing a release PR
- dispatch `tests.yml` with required-status mirroring for the release branch created or updated by the workflow token
- document the release-branch status-reporting contract for maintainers and consumer wrappers

## Verification
- `actionlint .github/workflows/changelog.yml resources/github-actions/changelog.yml .github/workflows/tests.yml resources/github-actions/tests.yml`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/changelog.yml resources/github-actions/changelog.yml`
- `composer dev-tools changelog:check`
- `git diff --check`
- GrumPHP pre-commit hook

Closes #250