### PR TITLE
Fix workflow-dispatched test runs

### DIFF
--- a/.agents/agents/issue-implementer.md
+++ b/.agents/agents/issue-implementer.md
@@ -26,6 +26,9 @@ pull request.
   warranted.
 - Open or update the pull request with a clear title, summary, and verification
   notes.
+- Read the published pull-request body back from GitHub and fix literal
+  escaped Markdown control characters, such as `\n`, before reporting the PR
+  as ready.
 
 ## Use When
 

--- a/.agents/skills/github-pull-request/references/pr-drafting.md
+++ b/.agents/skills/github-pull-request/references/pr-drafting.md
@@ -60,6 +60,20 @@ Examples:
 - Create a draft PR when the user explicitly wants review before finalization or when you still need external confirmation.
 - Create a ready PR when verification is complete and the change is ready for review.
 
+## Published Body Readback
+
+After creating or updating the PR body, read the published body back from
+GitHub before reporting the PR as ready.
+
+- Use `gh pr view <number> --json body --jq .body` or an equivalent
+  connector readback.
+- Confirm the body does not contain escaped Markdown control characters such
+  as literal `\n`, `\t`, or JSON-escaped list content.
+- If escaped control characters appear, update the body with a file or stdin
+  payload that preserves real newlines, then read it back again.
+- Treat the readback as part of PR publication, especially when the body was
+  assembled by shell command substitution, JSON output, or automation.
+
 ## Optional Follow-ups
 
 Apply only when the repository workflow or the user asks for them:

--- a/.agents/skills/github-pull-request/references/review-checklist.md
+++ b/.agents/skills/github-pull-request/references/review-checklist.md
@@ -13,6 +13,9 @@ Use this checklist before reporting completion.
 - README, docs, wiki, reports, or sync outputs were updated when the change touched them.
 - The PR title follows repository conventions.
 - The PR body includes a clear summary, concrete testing notes, and `Closes #123` style closing text.
+- The published PR body was read back from GitHub and does not contain literal
+  escaped Markdown control characters such as `\n` where real newlines were
+  intended.
 - No duplicate PR was created for the same branch.
 - The final user summary explains what changed, what was verified, and what remains.
 

--- a/.github/actions/github/resolve-predictable-conflicts/run.sh
+++ b/.github/actions/github/resolve-predictable-conflicts/run.sh
@@ -67,7 +67,7 @@ dispatch_required_tests() {
         return 0
     fi
 
-    if gh workflow run tests.yml --ref "${head_ref}" -f max-outdated=-1 -f publish-required-statuses=true >/dev/null 2>&1; then
+    if gh workflow run tests.yml --ref "${head_ref}" -f publish-required-statuses=true >/dev/null 2>&1; then
         append_summary "  - tests dispatch requested with required status mirroring"
 
         return 0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -226,7 +226,7 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
                   RELEASE_BRANCH: ${{ env.RELEASE_BRANCH_PREFIX }}${{ steps.version.outputs.value }}
-              run: gh workflow run tests.yml --ref "${RELEASE_BRANCH}" -f max-outdated=-1 -f publish-required-statuses=true
+              run: gh workflow run tests.yml --ref "${RELEASE_BRANCH}" -f publish-required-statuses=true
 
             - uses: actions/checkout@v6
             - name: Checkout dev-tools workflow action source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
             max-outdated:
                 description: Maximum number of outdated packages allowed by the dependencies command.
                 required: false
-                type: number
-                default: -1
+                type: string
+                default: '-1'
             publish-required-statuses:
                 description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
                 required: false
@@ -28,8 +28,8 @@ on:
             max-outdated:
                 description: Maximum number of outdated packages allowed by the dependencies command.
                 required: false
-                type: number
-                default: -1
+                type: string
+                default: '-1'
             publish-required-statuses:
                 description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
                 required: false

--- a/.github/workflows/wiki-preview.yml
+++ b/.github/workflows/wiki-preview.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: gh workflow run tests.yml --ref "${HEAD_REF}" -f max-outdated=-1 -f publish-required-statuses=true
+        run: gh workflow run tests.yml --ref "${HEAD_REF}" -f publish-required-statuses=true
 
       - uses: ./.dev-tools-actions/.github/actions/summary/write
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Teach pull-request publication guidance to read the published PR body back
+  from GitHub and fix literal escaped Markdown control characters before
+  handing the PR off for review.
 - Keep workflow-dispatched test runs from failing before job creation by treating `max-outdated` as a string input and relying on the workflow default when release, wiki, or conflict automation dispatches required test status mirroring.
 
 ## [1.22.2] - 2026-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep workflow-dispatched test runs from failing before job creation by treating `max-outdated` as a string input and relying on the workflow default when release, wiki, or conflict automation dispatches required test status mirroring.
+
 ## [1.22.2] - 2026-04-24
 
 ### Fixed

--- a/resources/github-actions/tests.yml
+++ b/resources/github-actions/tests.yml
@@ -12,8 +12,8 @@ on:
       max-outdated:
         description: Maximum number of outdated packages allowed by the dependencies command.
         required: false
-        type: number
-        default: -1
+        type: string
+        default: '-1'
       publish-required-statuses:
         description: Mirror required test matrix checks as commit statuses for workflow-dispatched runs.
         required: false


### PR DESCRIPTION
## Summary
- treat `max-outdated` as a string workflow input so manual dispatch validation does not fail before jobs are created
- stop passing explicit `max-outdated=-1` from release, wiki, and conflict automation dispatches, relying on the tests workflow default instead
- keep packaged consumer test wrappers aligned with the reusable workflow input contract
- teach pull-request publication guidance to read back the published body and fix literal escaped Markdown control characters before handoff

## Verification
- `actionlint .github/workflows/tests.yml resources/github-actions/tests.yml .github/workflows/changelog.yml .github/workflows/wiki-preview.yml`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts file }' .github/workflows/tests.yml resources/github-actions/tests.yml .github/workflows/changelog.yml .github/workflows/wiki-preview.yml`
- `composer dev-tools changelog:check`
- `git diff --check`
- GrumPHP pre-commit hook
- `gh workflow run tests.yml --repo php-fast-forward/dev-tools --ref fix/tests-workflow-dispatch-inputs -f publish-required-statuses=true` -> run `24915679472` completed successfully with matrix jobs and required status publication

Follow-up from #250.
