### PR TITLE
[command] Respect raw output when rendering DevTools banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Hide DevTools logo in nested subprocesses by adding a new `--no-logo` global option for the top-level application and automatically attaching it to internal DevTools child processes, avoiding banner repetition in orchestrated command queues (#277)
+
 ### Added
 
 - Add a configurable DevTools generated artifact workspace through `--workspace-dir` and `FAST_FORWARD_WORKSPACE_DIR`, keeping explicit output/cache command options authoritative (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option that is automatically forwarded to internal DevTools subprocesses to avoid banner repetition in orchestrated command queues (#277)
+- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option and automatically suppressing the banner for `--json` / `--pretty-json` invocations (including automatic forwarding of `--no-logo` to internal DevTools subprocesses) to avoid banner repetition in orchestrated command queues (#277)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Hide DevTools logo in nested subprocesses by adding a new `--no-logo` global option for the top-level application and automatically attaching it to internal DevTools child processes, avoiding banner repetition in orchestrated command queues (#277)
+- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option that is automatically forwarded to internal DevTools subprocesses to avoid banner repetition in orchestrated command queues (#277)
 
 ### Added
 

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -139,7 +139,9 @@ final class DevTools extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $noLogo = (bool) $input->getParameterOption('--no-logo', null, true);
+        $noLogo = (bool) $input->getParameterOption('--no-logo', null, true)
+            || (bool) $input->hasParameterOption('--json', true)
+            || (bool) $input->hasParameterOption('--pretty-json', true);
 
         if (! $noLogo) {
             $output->writeln(self::LOGO);

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -47,6 +47,8 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
+    private const string NO_LOGO_OPTION = 'no-logo';
+
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -88,14 +90,13 @@ final class DevTools extends Application
     }
 
     /**
-     * Gets the help message for the DevTools application, including the ASCII logo.
+     * Gets the help message for the DevTools application.
      *
-     * @return string
      */
     #[Override]
     public function getHelp(): string
     {
-        return self::LOGO . "\n\n" . parent::getHelp();
+        return parent::getHelp();
     }
 
     /**
@@ -128,6 +129,12 @@ final class DevTools extends Application
             description: 'Store generated DevTools artifacts in the given directory.',
         ));
 
+        $definition->addOption(new InputOption(
+            name: self::NO_LOGO_OPTION,
+            mode: InputOption::VALUE_NONE,
+            description: 'Hide the startup ASCII logo.',
+        ));
+
         return $definition;
     }
 
@@ -142,6 +149,10 @@ final class DevTools extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
+        if (! (bool) $input->getOption(self::NO_LOGO_OPTION)) {
+            $output->writeln(self::LOGO);
+        }
+
         try {
             $this->workingDirectorySwitcher->switchTo($this->getWorkingDirectoryOption($input));
             $this->configureWorkspaceDirectory($input);

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -53,9 +53,9 @@ final class DevTools extends Application
         | | | |/ _ \ \ / / | |/ _ \ / _ \| / __|
         | |_| |  __/\ V /  | | (_) | (_) | \__ \
         |____/ \___| \_/   |_|\___/ \___/|_|___/
-        LOGO;
+        ========================================
 
-    private const string NO_LOGO_OPTION = 'no-logo';
+        LOGO;
 
     /**
      * @var ContainerInterface holds the static container instance for global access within the DevTools context

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -47,6 +47,11 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
+    private const array RAW_OUTPUT_COMMANDS = [
+        'changelog:next-version',
+        'changelog:show',
+    ];
+
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -139,12 +144,9 @@ final class DevTools extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $noLogo = (bool) $input->getParameterOption('--no-logo', null, true)
-            || (bool) $input->hasParameterOption('--json', true)
-            || (bool) $input->hasParameterOption('--pretty-json', true);
-        $noLogo = $noLogo || $this->isRawOutputCommand($input);
+        $shouldRenderLogo = $this->shouldRenderLogo($input);
 
-        if (! $noLogo) {
+        if ($shouldRenderLogo) {
             $output->writeln(self::LOGO);
         }
 
@@ -157,7 +159,7 @@ final class DevTools extends Application
             return Command::FAILURE;
         }
 
-        if (! $noLogo && ! $this->isSelfUpdateCommand($input)) {
+        if ($shouldRenderLogo && ! $this->isSelfUpdateCommand($input)) {
             $this->runAutoUpdateWhenRequested($input, $output);
             $this->versionCheckNotifier->notify($output);
         }
@@ -255,16 +257,36 @@ final class DevTools extends Application
     }
 
     /**
+     * Whether to show the startup ASCII logo for this invocation.
+     *
+     * @param InputInterface $input
+     */
+    private function shouldRenderLogo(InputInterface $input): bool
+    {
+        return ! $this->isLogoSuppressedByOptions($input)
+            && ! $this->isRawOutputCommand($input);
+    }
+
+    /**
+     * Detects CLI flags that explicitly suppress logo output.
+     *
+     * @param InputInterface $input
+     */
+    private function isLogoSuppressedByOptions(InputInterface $input): bool
+    {
+        return (bool) $input->getParameterOption('--no-logo', null, true)
+            || (bool) $input->hasParameterOption('--json', true)
+            || (bool) $input->hasParameterOption('--pretty-json', true);
+    }
+
+    /**
      * Identifies commands that must keep CLI output unprefixed by logos.
      *
      * @param InputInterface $input
      */
     private function isRawOutputCommand(InputInterface $input): bool
     {
-        return \in_array((string) $input->getFirstArgument(), [
-            'changelog:next-version',
-            'changelog:show',
-        ], true);
+        return \in_array((string) $input->getFirstArgument(), self::RAW_OUTPUT_COMMANDS, true);
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -142,6 +142,7 @@ final class DevTools extends Application
         $noLogo = (bool) $input->getParameterOption('--no-logo', null, true)
             || (bool) $input->hasParameterOption('--json', true)
             || (bool) $input->hasParameterOption('--pretty-json', true);
+        $noLogo = $noLogo || $this->isRawOutputCommand($input);
 
         if (! $noLogo) {
             $output->writeln(self::LOGO);
@@ -251,6 +252,19 @@ final class DevTools extends Application
     private function isSelfUpdateCommand(InputInterface $input): bool
     {
         return \in_array($input->getFirstArgument(), SelfUpdateCommand::getCommandNames(), true);
+    }
+
+    /**
+     * Identifies commands that must keep CLI output unprefixed by logos.
+     *
+     * @param InputInterface $input
+     */
+    private function isRawOutputCommand(InputInterface $input): bool
+    {
+        return \in_array((string) $input->getFirstArgument(), [
+            'changelog:next-version',
+            'changelog:show',
+        ], true);
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -47,8 +47,6 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
-    private const string NO_LOGO_OPTION = 'no-logo';
-
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -56,6 +54,8 @@ final class DevTools extends Application
         | |_| |  __/\ V /  | | (_) | (_) | \__ \
         |____/ \___| \_/   |_|\___/ \___/|_|___/
         LOGO;
+
+    private const string NO_LOGO_OPTION = 'no-logo';
 
     /**
      * @var ContainerInterface holds the static container instance for global access within the DevTools context
@@ -90,16 +90,6 @@ final class DevTools extends Application
     }
 
     /**
-     * Gets the help message for the DevTools application.
-     *
-     */
-    #[Override]
-    public function getHelp(): string
-    {
-        return parent::getHelp();
-    }
-
-    /**
      * Returns the application-level input definition with DevTools runtime options.
      *
      * @return InputDefinition the global application input definition
@@ -130,7 +120,7 @@ final class DevTools extends Application
         ));
 
         $definition->addOption(new InputOption(
-            name: self::NO_LOGO_OPTION,
+            name: 'no-logo',
             mode: InputOption::VALUE_NONE,
             description: 'Hide the startup ASCII logo.',
         ));
@@ -149,7 +139,9 @@ final class DevTools extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        if (! (bool) $input->getOption(self::NO_LOGO_OPTION)) {
+        $noLogo = (bool) $input->getParameterOption('--no-logo', null, true);
+
+        if (! $noLogo) {
             $output->writeln(self::LOGO);
         }
 
@@ -162,7 +154,7 @@ final class DevTools extends Application
             return Command::FAILURE;
         }
 
-        if (! $this->isSelfUpdateCommand($input)) {
+        if (! $noLogo && ! $this->isSelfUpdateCommand($input)) {
             $this->runAutoUpdateWhenRequested($input, $output);
             $this->versionCheckNotifier->notify($output);
         }

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -121,21 +121,14 @@ final readonly class ProcessBuilder implements ProcessBuilderInterface
             return false;
         }
 
-        if (0 === \count($command)) {
+        if ([] === $command) {
             return false;
         }
 
-        $binary = \str_replace('\\', '/', $command[0]);
-        $packageBinaryPath = \str_replace('\\', '/', DevToolsPathResolver::getBinaryPath());
+        $binary = str_replace('\\', '/', $command[0]);
+        $packageBinaryPath = str_replace('\\', '/', DevToolsPathResolver::getBinaryPath());
 
-        return $binary === $packageBinaryPath
-            || \str_starts_with($binary, 'vendor/bin/dev-tools')
-            || \str_starts_with($binary, './vendor/bin/dev-tools')
-            || \str_starts_with($binary, 'bin/dev-tools')
-            || \str_starts_with($binary, './bin/dev-tools')
-            || \str_ends_with($binary, '/vendor/bin/dev-tools')
-            || \str_ends_with($binary, '/vendor/fast-forward/dev-tools/bin/dev-tools')
-            || \str_ends_with($binary, '/bin/dev-tools');
+        return $binary === $packageBinaryPath;
     }
 
     /**
@@ -145,11 +138,11 @@ final readonly class ProcessBuilder implements ProcessBuilderInterface
      */
     private function prependLogoSuppressionArgument(array $command): array
     {
-        if (0 === \count($command)) {
+        if ([] === $command) {
             return $command;
         }
 
-        $binary = \array_shift($command);
+        $binary = array_shift($command);
 
         return [$binary, self::NO_LOGO_ARGUMENT, ...$command];
     }

--- a/src/Process/ProcessBuilder.php
+++ b/src/Process/ProcessBuilder.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Process;
 
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use Symfony\Component\Process\Process;
 
 /**
@@ -31,6 +32,8 @@ use Symfony\Component\Process\Process;
  */
 final readonly class ProcessBuilder implements ProcessBuilderInterface
 {
+    private const string NO_LOGO_ARGUMENT = '--no-logo';
+
     /**
      * Creates a new immutable process builder instance.
      *
@@ -94,10 +97,60 @@ final readonly class ProcessBuilder implements ProcessBuilderInterface
      */
     public function build(string|array $command): Process
     {
+        if (\is_array($command)) {
+            $command = array_values($command);
+        }
+
         if (\is_string($command)) {
             $command = explode(' ', $command);
         }
 
+        if ($this->shouldAddLogoSuppressionArgument($command)) {
+            $command = $this->prependLogoSuppressionArgument($command);
+        }
+
         return new Process(command: [...$command, ...$this->arguments], timeout: 0);
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function shouldAddLogoSuppressionArgument(array $command): bool
+    {
+        if (\in_array(self::NO_LOGO_ARGUMENT, $this->arguments, true)) {
+            return false;
+        }
+
+        if (0 === \count($command)) {
+            return false;
+        }
+
+        $binary = \str_replace('\\', '/', $command[0]);
+        $packageBinaryPath = \str_replace('\\', '/', DevToolsPathResolver::getBinaryPath());
+
+        return $binary === $packageBinaryPath
+            || \str_starts_with($binary, 'vendor/bin/dev-tools')
+            || \str_starts_with($binary, './vendor/bin/dev-tools')
+            || \str_starts_with($binary, 'bin/dev-tools')
+            || \str_starts_with($binary, './bin/dev-tools')
+            || \str_ends_with($binary, '/vendor/bin/dev-tools')
+            || \str_ends_with($binary, '/vendor/fast-forward/dev-tools/bin/dev-tools')
+            || \str_ends_with($binary, '/bin/dev-tools');
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @return list<string>
+     */
+    private function prependLogoSuppressionArgument(array $command): array
+    {
+        if (0 === \count($command)) {
+            return $command;
+        }
+
+        $binary = \array_shift($command);
+
+        return [$binary, self::NO_LOGO_ARGUMENT, ...$command];
     }
 }

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Tests\Console\Command;
 use FastForward\DevTools\Console\Command\DependenciesCommand;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -42,6 +43,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(DependenciesCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class DependenciesCommandTest extends TestCase

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -28,6 +28,7 @@ use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -48,6 +49,7 @@ use function Safe\getcwd;
 
 #[CoversClass(TestsCommand::class)]
 #[UsesClass(CoverageSummary::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesTrait(LogsCommandResults::class)]

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -366,6 +366,52 @@ final class DevToolsTest extends TestCase
      * @return void
      */
     #[Test]
+    public function doRunWillNotRenderLogoForRawChangelogCommands(): void
+    {
+        foreach (['changelog:next-version', 'changelog:show'] as $commandName) {
+            $this->commandLoader->has($commandName)
+                ->willReturn(true)
+                ->shouldBeCalledOnce();
+            $this->commandLoader->get($commandName)
+                ->willReturn(
+                    new class($commandName) extends Command {
+                        public function __construct(string $name)
+                        {
+                            parent::__construct($name);
+                        }
+
+                        protected function execute(InputInterface $input, OutputInterface $output): int
+                        {
+                            return Command::SUCCESS;
+                        }
+                    },
+                )
+                ->shouldBeCalledOnce();
+
+            $input = new ArrayInput([
+                'command' => $commandName,
+            ]);
+
+            $output = new BufferedOutput();
+
+            $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+                ->willReturn('');
+            $this->workingDirectorySwitcher->switchTo(null)
+                ->shouldBeCalledOnce();
+            $this->versionCheckNotifier->notify($output)
+                ->shouldNotBeCalled();
+
+            $result = $this->invokeDoRun($input, $output);
+
+            self::assertSame(Command::SUCCESS, $result);
+            self::assertStringNotContainsString('_____', $output->fetch());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function allWillReturnLoaderCommandsWithPreservedKeys(): void
     {
         $commands = [

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -218,7 +218,7 @@ final class DevToolsTest extends TestCase
         self::assertSame('w', $definition->getOption('workspace-dir')->getShortcut());
         self::assertTrue($definition->hasOption('auto-update'));
         self::assertTrue($definition->hasOption('no-logo'));
-        self::assertFalse($definition->getOption('no-logo')->acceptsValue());
+        self::assertFalse($definition->getOption('no-logo')->acceptValue());
     }
 
     /**

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -63,6 +63,7 @@ use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -268,6 +269,96 @@ final class DevToolsTest extends TestCase
 
         $this->invokeDoRun($input, $output);
 
+        self::assertStringNotContainsString('_____', $output->fetch());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function doRunWillNotRenderLogoWhenJsonOptionIsProvided(): void
+    {
+        $command = new class extends Command {
+            public function __construct()
+            {
+                parent::__construct('standards');
+            }
+
+            protected function configure(): void
+            {
+                $this->addOption(name: 'json', mode: InputOption::VALUE_NONE, description: 'Emit structured JSON output.');
+                $this->setCode(static fn(InputInterface $input, OutputInterface $output): int => Command::SUCCESS);
+            }
+        };
+
+        $this->commandLoader->has('standards')
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->commandLoader->get('standards')
+            ->willReturn($command)
+            ->shouldBeCalledOnce();
+        $input = new ArrayInput([
+            'command' => 'standards',
+            '--json' => true,
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldNotBeCalled();
+
+        $result = $this->invokeDoRun($input, $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertStringNotContainsString('_____', $output->fetch());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function doRunWillNotRenderLogoWhenPrettyJsonOptionIsProvided(): void
+    {
+        $command = new class extends Command {
+            public function __construct()
+            {
+                parent::__construct('standards');
+            }
+
+            protected function configure(): void
+            {
+                $this->addOption(name: 'pretty-json', mode: InputOption::VALUE_NONE, description: 'Emit pretty JSON output.');
+                $this->setCode(static fn(InputInterface $input, OutputInterface $output): int => Command::SUCCESS);
+            }
+        };
+
+        $this->commandLoader->has('standards')
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->commandLoader->get('standards')
+            ->willReturn($command)
+            ->shouldBeCalledOnce();
+        $input = new ArrayInput([
+            'command' => 'standards',
+            '--pretty-json' => true,
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldNotBeCalled();
+
+        $result = $this->invokeDoRun($input, $output);
+
+        self::assertSame(Command::SUCCESS, $result);
         self::assertStringNotContainsString('_____', $output->fetch());
     }
 

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -62,8 +62,10 @@ use Symfony\Component\Console\Command\DumpCompletionCommand;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 use function Safe\putenv;
 
@@ -215,6 +217,58 @@ final class DevToolsTest extends TestCase
         self::assertTrue($definition->hasOption('workspace-dir'));
         self::assertSame('w', $definition->getOption('workspace-dir')->getShortcut());
         self::assertTrue($definition->hasOption('auto-update'));
+        self::assertTrue($definition->hasOption('no-logo'));
+        self::assertFalse($definition->getOption('no-logo')->acceptsValue());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function doRunWillRenderLogoUnlessNoLogoOptionIsProvided(): void
+    {
+        $input = new ArrayInput([
+            'command' => 'list',
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldBeCalledOnce();
+
+        $result = $this->invokeDoRun($input, $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertStringContainsString('_____', $output->fetch());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function doRunWillNotRenderLogoWhenNoLogoOptionIsSet(): void
+    {
+        $input = new ArrayInput([
+            '--no-logo' => true,
+            'command' => 'list',
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldNotBeCalled();
+
+        $this->invokeDoRun($input, $output);
+
+        self::assertStringNotContainsString('_____', $output->fetch());
     }
 
     /**
@@ -403,5 +457,18 @@ final class DevToolsTest extends TestCase
     {
         $reflectionMethod = new ReflectionMethod($this->devTools, 'configureWorkspaceDirectory');
         $reflectionMethod->invoke($this->devTools, $input);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    private function invokeDoRun(InputInterface $input, OutputInterface $output): int
+    {
+        $reflectionMethod = new ReflectionMethod($this->devTools, 'doRun');
+
+        return (int) $reflectionMethod->invoke($this->devTools, $input, $output);
     }
 }

--- a/tests/Process/ProcessBuilderTest.php
+++ b/tests/Process/ProcessBuilderTest.php
@@ -22,12 +22,14 @@ namespace FastForward\DevTools\Tests\Process;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(ProcessBuilder::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 final class ProcessBuilderTest extends TestCase
 {
     use ProphecyTrait;

--- a/tests/Process/ProcessBuilderTest.php
+++ b/tests/Process/ProcessBuilderTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Process;
 
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -118,5 +119,49 @@ final class ProcessBuilderTest extends TestCase
 
         self::assertInstanceOf(Process::class, $process);
         self::assertSame("'php' 'artisan' 'serve' '--verbose' '--env=dev'", $process->getCommandLine());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function buildWillInjectNoLogoArgumentForDevToolsCommands(): void
+    {
+        $process = $this->builder
+            ->build(DevToolsPathResolver::getBinaryCommand('tests'));
+
+        self::assertSame(
+            "'" . DevToolsPathResolver::getBinaryPath() . "' '--no-logo' 'tests'",
+            $process->getCommandLine(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function buildWillKeepExistingNoLogoArgumentWhenProvidedInArguments(): void
+    {
+        $process = $this->builder
+            ->withArgument('--no-logo')
+            ->withArgument('--ansi')
+            ->build(DevToolsPathResolver::getBinaryCommand('tests'));
+
+        self::assertSame(
+            "'" . DevToolsPathResolver::getBinaryPath() . "' 'tests' '--no-logo' '--ansi'",
+            $process->getCommandLine(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function buildWillNotInjectNoLogoArgumentForNonDevToolsCommands(): void
+    {
+        $process = $this->builder
+            ->build('vendor/bin/phpunit');
+
+        self::assertSame("'vendor/bin/phpunit'", $process->getCommandLine());
     }
 }


### PR DESCRIPTION
## Summary
Implemented a central logo rendering decision in the DevTools console entrypoint and applied it so command output uses the ASCII banner only for non-raw flows.

## Changes
- Added central `shouldRenderLogo()` logic in `DevTools` to compute logo visibility from command name and options.
- Added explicit raw-output command suppression for `changelog:next-version` and `changelog:show`, which previously relied on raw output contracts and now do not print banner.
- Added option-based suppression for `--no-logo`, `--json`, and `--pretty-json` before any output rendering.
- Updated unit coverage around run-time behavior in `tests/Console/DevToolsTest.php` to validate that raw changelog commands skip the logo.

## Testing
- Focused tests: `vendor/bin/phpunit tests/Console/DevToolsTest.php`.
- Additional verification: existing targeted command tests for changelog JSON/raw behaviors in the suite.

## Review note
Logo gating is centralized in `DevTools::doRun()` via `shouldRenderLogo(InputInterface $input)`.

Closes #277


**Implementation note:** raw/changelog-raw behavior is now controlled at the command-boot layer (`isRawOutputCommand`) so each command avoids per-command output flags and remains orchestrator-safe.
