### PR TITLE
[command] Respect raw output when rendering DevTools banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option and automatically suppressing the banner for `--json` / `--pretty-json` invocations (including automatic forwarding of `--no-logo` to internal DevTools subprocesses) to avoid banner repetition in orchestrated command queues (#277)
-
 ### Added
 
 - Add a configurable DevTools generated artifact workspace through `--workspace-dir` and `FAST_FORWARD_WORKSPACE_DIR`, keeping explicit output/cache command options authoritative (#274)
 - Add a standalone DevTools `self-update` command plus global `--working-dir` and `--auto-update` binary options for local or global installations (#272)
+
+### Fixed
+
+- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option and automatically suppressing the banner for `--json` / `--pretty-json` invocations (including automatic forwarding of `--no-logo` to internal DevTools subprocesses) to avoid banner repetition in orchestrated command queues (#277)
 
 ## [1.23.0] - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a configurable DevTools generated artifact workspace through `--workspace-dir` and `FAST_FORWARD_WORKSPACE_DIR`, keeping explicit output/cache command options authoritative (#274)
 - Add a standalone DevTools `self-update` command plus global `--working-dir` and `--auto-update` binary options for local or global installations (#272)
+- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option and automatically suppressing the banner for `--json` / `--pretty-json` invocations (including automatic forwarding of `--no-logo` to internal DevTools subprocesses) to avoid banner repetition in orchestrated command queues (#277)
 
 ### Fixed
 
-- Show the DevTools ASCII logo by default on all top-level command executions, while adding a `--no-logo` global option and automatically suppressing the banner for `--json` / `--pretty-json` invocations (including automatic forwarding of `--no-logo` to internal DevTools subprocesses) to avoid banner repetition in orchestrated command queues (#277)
+- Prevent DevTools from breaking changelog workflows by keeping raw output clean for `changelog:show` and `changelog:next-version` (suppressing the startup ASCII logo when these commands run without explicit `--json`/`--pretty-json`) (#280)
 
 ## [1.23.0] - 2026-04-26
 

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -58,6 +58,16 @@ final class DevTools extends Application
         LOGO;
 
     /**
+     * Commands that require raw output and therefore must not render the logo.
+     *
+     * @var list<string>
+     */
+    private const array RAW_OUTPUT_COMMANDS = [
+        'changelog:next-version',
+        'changelog:show',
+    ];
+
+    /**
      * @var ContainerInterface holds the static container instance for global access within the DevTools context
      */
     private static ?ContainerInterface $container = null;
@@ -139,11 +149,7 @@ final class DevTools extends Application
     #[Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $noLogo = (bool) $input->getParameterOption('--no-logo', null, true)
-            || (bool) $input->hasParameterOption('--json', true)
-            || (bool) $input->hasParameterOption('--pretty-json', true);
-
-        if (! $noLogo) {
+        if ($this->shouldRenderLogo($input)) {
             $output->writeln(self::LOGO);
         }
 
@@ -156,7 +162,7 @@ final class DevTools extends Application
             return Command::FAILURE;
         }
 
-        if (! $noLogo && ! $this->isSelfUpdateCommand($input)) {
+        if ($this->shouldRenderLogo($input) && ! $this->isSelfUpdateCommand($input)) {
             $this->runAutoUpdateWhenRequested($input, $output);
             $this->versionCheckNotifier->notify($output);
         }
@@ -241,6 +247,40 @@ final class DevTools extends Application
         if (Command::SUCCESS !== $statusCode) {
             $output->writeln('<comment>DevTools auto-update failed; continuing with the requested command.</comment>');
         }
+    }
+
+    /**
+     * Determines whether the startup logo should be rendered for this invocation.
+     *
+     * @param InputInterface $input the application input
+     */
+    private function shouldRenderLogo(InputInterface $input): bool
+    {
+        if ((bool) $input->getParameterOption('--no-logo', null, true)) {
+            return false;
+        }
+
+        if ((bool) $input->hasParameterOption('--json', true) || (bool) $input->hasParameterOption('--pretty-json', true)) {
+            return false;
+        }
+
+        return ! $this->isRawOutputCommand($input);
+    }
+
+    /**
+     * Checks whether the current command is designed for raw output mode.
+     *
+     * @param InputInterface $input the application input
+     */
+    private function isRawOutputCommand(InputInterface $input): bool
+    {
+        $commandName = $input->getFirstArgument();
+
+        if (! is_string($commandName)) {
+            return false;
+        }
+
+        return \in_array($commandName, self::RAW_OUTPUT_COMMANDS, true);
     }
 
     /**

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -49,6 +49,7 @@ use FastForward\DevTools\ServiceProvider\DevToolsServiceProvider;
 use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -345,6 +346,50 @@ final class DevToolsTest extends TestCase
         $input = new ArrayInput([
             'command' => 'standards',
             '--pretty-json' => true,
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldNotBeCalled();
+
+        $result = $this->invokeDoRun($input, $output);
+
+        self::assertSame(Command::SUCCESS, $result);
+        self::assertStringNotContainsString('_____', $output->fetch());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    #[TestWith(['changelog:show'])]
+    #[TestWith(['changelog:next-version'])]
+    public function doRunWillNotRenderLogoWhenRawOutputCommandIsRequested(string $commandName): void
+    {
+        $command = new class extends Command {
+            public function __construct()
+            {
+                parent::__construct('placeholder');
+                $this->setCode(static fn(InputInterface $input, OutputInterface $output): int => Command::SUCCESS);
+            }
+        };
+
+        $command->setName($commandName);
+
+        $this->commandLoader->has($commandName)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+        $this->commandLoader->get($commandName)
+            ->willReturn($command)
+            ->shouldBeCalledOnce();
+
+        $input = new ArrayInput([
+            'command' => $commandName,
         ]);
 
         $output = new BufferedOutput();


### PR DESCRIPTION
## Related Issue

Closes #277

## Motivation / Context

- Keep the top-level DevTools banner behavior consistent for raw changelog flows used by automations.
- Avoid breaking plain-text consumers of `changelog:show` and `changelog:next-version` output.

## Changes

- Centralized logo rendering in `DevTools::shouldRenderLogo()`.
- Added explicit raw-command suppression for `changelog:show` and `changelog:next-version`.
- Kept suppression behavior for `--no-logo`, `--json`, and `--pretty-json`.
- Added focused `DevToolsTest` coverage for raw changelog commands.
- Adjusted `CHANGELOG.md` ordering in `Unreleased` section.

## Verification

- [x] `tests/Console/DevToolsTest.php` focused scenario added.
- [ ] `composer dev-tools` (environment missing composer)

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [ ] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- Command output for `changelog:show` and `changelog:next-version` is now banner-free in raw flows.
