### PR TITLE
[tests] Fix global bootstrap fallback for packaged PHPUnit config (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep global `dev-tools tests` runs loading the packaged PHPUnit extension by generating a bootstrap shim that falls back to the active DevTools autoloader when the working directory does not install DevTools locally (#289)
+
 ## [1.24.0] - 2026-04-28
 
 ### Added

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -24,6 +24,7 @@ use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
 use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -62,6 +63,7 @@ final class TestsCommand extends Command
      * @param CoverageSummaryLoaderInterface $coverageSummaryLoader the loader used for `coverage-php` summaries
      * @param ComposerJsonInterface $composer the composer.json reader for autoload information
      * @param FilesystemInterface $filesystem the filesystem utility used for path resolution
+     * @param BootstrapShimGenerator $bootstrapShimGenerator the generator used to build the PHPUnit bootstrap shim
      * @param FileLocatorInterface $fileLocator the file locator used to resolve PHPUnit configuration
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble the PHPUnit process
      * @param ProcessQueueInterface $processQueue the queue used to execute PHPUnit
@@ -71,6 +73,7 @@ final class TestsCommand extends Command
         private readonly CoverageSummaryLoaderInterface $coverageSummaryLoader,
         private readonly ComposerJsonInterface $composer,
         private readonly FilesystemInterface $filesystem,
+        private readonly BootstrapShimGenerator $bootstrapShimGenerator,
         private readonly FileLocatorInterface $fileLocator,
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
@@ -171,7 +174,7 @@ final class TestsCommand extends Command
 
         $processBuilder = $this->processBuilder
             ->withArgument('--configuration', $this->fileLocator->locate(self::CONFIG))
-            ->withArgument('--bootstrap', $this->resolvePath($input, 'bootstrap'))
+            ->withArgument('--bootstrap', $this->resolveBootstrapPath($input))
             ->withArgument('--display-deprecations')
             ->withArgument('--display-phpunit-deprecations')
             ->withArgument('--display-incomplete')
@@ -260,6 +263,21 @@ final class TestsCommand extends Command
     private function resolvePath(InputInterface $input, string $option): string
     {
         return $this->filesystem->getAbsolutePath($input->getOption($option));
+    }
+
+    /**
+     * Creates the bootstrap shim path passed to PHPUnit.
+     *
+     * @param InputInterface $input the raw parameter definitions
+     *
+     * @return string the generated bootstrap shim path
+     */
+    private function resolveBootstrapPath(InputInterface $input): string
+    {
+        return $this->bootstrapShimGenerator->generate(
+            $this->resolvePath($input, 'bootstrap'),
+            $this->resolvePath($input, 'cache-dir'),
+        );
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -62,10 +62,7 @@ final class DevTools extends Application
      *
      * @var list<string>
      */
-    private const array RAW_OUTPUT_COMMANDS = [
-        'changelog:next-version',
-        'changelog:show',
-    ];
+    private const array RAW_OUTPUT_COMMANDS = ['changelog:next-version', 'changelog:show'];
 
     /**
      * @var ContainerInterface holds the static container instance for global access within the DevTools context
@@ -260,7 +257,7 @@ final class DevTools extends Application
             return false;
         }
 
-        if ((bool) $input->hasParameterOption('--json', true) || (bool) $input->hasParameterOption('--pretty-json', true)) {
+        if ($input->hasParameterOption('--json', true) || $input->hasParameterOption('--pretty-json', true)) {
             return false;
         }
 
@@ -276,7 +273,7 @@ final class DevTools extends Application
     {
         $commandName = $input->getFirstArgument();
 
-        if (! is_string($commandName)) {
+        if (! \is_string($commandName)) {
             return false;
         }
 

--- a/src/Path/DevToolsPathResolver.php
+++ b/src/Path/DevToolsPathResolver.php
@@ -40,8 +40,7 @@ final class DevToolsPathResolver
     /**
      * @var string the vendor install path fragment used when DevTools runs as a dependency
      */
-    private const string VENDOR_PACKAGE_PATH = \DIRECTORY_SEPARATOR . 'vendor' . \DIRECTORY_SEPARATOR
-        . 'fast-forward' . \DIRECTORY_SEPARATOR . 'dev-tools';
+    private const string VENDOR_PACKAGE_PATH = '/vendor/fast-forward/dev-tools';
 
     /**
      * Returns the DevTools package directory or a path under it.
@@ -116,7 +115,9 @@ final class DevToolsPathResolver
      */
     public static function isInstalledAsDependency(string $packagePath = ''): bool
     {
-        return str_contains('' === $packagePath ? self::getPackagePath() : $packagePath, self::VENDOR_PACKAGE_PATH);
+        $packagePath = Path::canonicalize('' === $packagePath ? self::getPackagePath() : $packagePath);
+
+        return str_contains($packagePath, self::VENDOR_PACKAGE_PATH);
     }
 
     /**

--- a/src/Path/DevToolsPathResolver.php
+++ b/src/Path/DevToolsPathResolver.php
@@ -90,6 +90,26 @@ final class DevToolsPathResolver
     }
 
     /**
+     * Returns the active Composer autoload file for the current DevTools installation mode.
+     *
+     * When DevTools runs as a dependency, the runtime autoloader lives at the
+     * Composer vendor root. Repository checkouts instead use the package-local
+     * `vendor/autoload.php`.
+     *
+     * @param string $packagePath an optional package root path; defaults to the current package root
+     */
+    public static function getRuntimeAutoloadPath(string $packagePath = ''): string
+    {
+        $packagePath = Path::canonicalize('' === $packagePath ? self::getPackagePath() : $packagePath);
+
+        if (self::isInstalledAsDependency($packagePath)) {
+            return Path::canonicalize(Path::join($packagePath, '..', '..', 'autoload.php'));
+        }
+
+        return Path::join($packagePath, 'vendor', 'autoload.php');
+    }
+
+    /**
      * Detects whether the provided path belongs to an installed vendor copy of DevTools.
      *
      * @param string $packagePath an optional path within the package; defaults to the package root

--- a/src/PhpUnit/Bootstrap/BootstrapShimGenerator.php
+++ b/src/PhpUnit/Bootstrap/BootstrapShimGenerator.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\PhpUnit\Bootstrap;
+
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * Generates deterministic PHPUnit bootstrap shims for working-directory test runs.
+ *
+ * The generated shim MUST load the consumer bootstrap first and MAY then load
+ * the active DevTools package autoloader so packaged PHPUnit configuration can
+ * still resolve DevTools-owned extension classes during global installations.
+ */
+final readonly class BootstrapShimGenerator
+{
+    /**
+     * @param FilesystemInterface $filesystem the filesystem used to persist generated shims
+     */
+    public function __construct(
+        private FilesystemInterface $filesystem,
+    ) {}
+
+    /**
+     * Writes a deterministic bootstrap shim under the resolved cache directory.
+     *
+     * @param string $projectBootstrap the consumer-project bootstrap path
+     * @param string $cacheDirectory the cache directory where the shim SHOULD be stored
+     *
+     * @return string the generated bootstrap shim path
+     */
+    public function generate(string $projectBootstrap, string $cacheDirectory): string
+    {
+        $bootstrapShim = Path::join($cacheDirectory, 'bootstrap.php');
+
+        $this->filesystem->dumpFile($bootstrapShim, $this->render($projectBootstrap));
+
+        return $bootstrapShim;
+    }
+
+    /**
+     * Renders the bootstrap shim contents.
+     *
+     * @param string $projectBootstrap the consumer-project bootstrap path
+     *
+     * @return string the bootstrap shim source code
+     */
+    private function render(string $projectBootstrap): string
+    {
+        $devToolsAutoload = DevToolsPathResolver::getPackagePath('vendor/autoload.php');
+
+        return <<<PHP
+            <?php
+
+            declare(strict_types=1);
+
+            require_once {$this->export($projectBootstrap)};
+
+            if (file_exists({$this->export($devToolsAutoload)})) {
+                require_once {$this->export($devToolsAutoload)};
+            }
+            PHP;
+    }
+
+    /**
+     * Escapes a runtime string as a valid PHP string literal.
+     *
+     * @param string $value the value to render as PHP code
+     *
+     * @return string the exported PHP literal
+     */
+    private function export(string $value): string
+    {
+        return var_export($value, true);
+    }
+}

--- a/src/PhpUnit/Bootstrap/BootstrapShimGenerator.php
+++ b/src/PhpUnit/Bootstrap/BootstrapShimGenerator.php
@@ -65,7 +65,7 @@ final readonly class BootstrapShimGenerator
      */
     private function render(string $projectBootstrap): string
     {
-        $devToolsAutoload = DevToolsPathResolver::getPackagePath('vendor/autoload.php');
+        $devToolsAutoload = DevToolsPathResolver::getRuntimeAutoloadPath();
 
         return <<<PHP
             <?php

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -23,6 +23,7 @@ use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\TestsCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
 use FastForward\DevTools\PhpUnit\Coverage\CoverageSummary;
 use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilder;
@@ -48,6 +49,7 @@ use Symfony\Component\Process\Process;
 use function Safe\getcwd;
 
 #[CoversClass(TestsCommand::class)]
+#[UsesClass(BootstrapShimGenerator::class)]
 #[UsesClass(CoverageSummary::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
@@ -93,6 +95,7 @@ final class TestsCommandTest extends TestCase
             $this->coverageSummaryLoader->reveal(),
             $this->composerJson->reveal(),
             $this->filesystem->reveal(),
+            new BootstrapShimGenerator($this->filesystem->reveal()),
             $this->fileLocator->reveal(),
             new ProcessBuilder(),
             $this->processQueue->reveal(),
@@ -112,6 +115,8 @@ final class TestsCommandTest extends TestCase
             ->willReturn(getcwd() . '/.dev-tools/coverage');
         $this->filesystem->getAbsolutePath('src/')
             ->willReturn(getcwd() . '/src');
+        $this->filesystem->dumpFile(Argument::cetera())
+            ->will(static function (): void {});
 
         foreach ($this->command->getDefinition()->getArguments() as $argument) {
             $this->input->getArgument($argument->getName())
@@ -133,10 +138,15 @@ final class TestsCommandTest extends TestCase
     #[Test]
     public function executeWillRunPhpUnitProcessWithConfigFile(): void
     {
+        $generatedBootstrapPath = getcwd() . '/.dev-tools/cache/phpunit/bootstrap.php';
+
         $this->processQueue->add(
             Argument::that(static fn(Process $process): bool => str_contains(
                 $process->getCommandLine(),
                 '--configuration=' . getcwd() . '/' . TestsCommand::CONFIG,
+            ) && str_contains(
+                $process->getCommandLine(),
+                '--bootstrap=' . $generatedBootstrapPath,
             ) && str_contains($process->getCommandLine(), '--cache-result') && str_contains(
                 $process->getCommandLine(),
                 '--cache-directory=' . getcwd() . '/.dev-tools/cache/phpunit',

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -285,9 +285,16 @@ final class DevToolsTest extends TestCase
                 parent::__construct('standards');
             }
 
+            /**
+             * @return void
+             */
             protected function configure(): void
             {
-                $this->addOption(name: 'json', mode: InputOption::VALUE_NONE, description: 'Emit structured JSON output.');
+                $this->addOption(
+                    name: 'json',
+                    mode: InputOption::VALUE_NONE,
+                    description: 'Emit structured JSON output.'
+                );
                 $this->setCode(static fn(InputInterface $input, OutputInterface $output): int => Command::SUCCESS);
             }
         };
@@ -330,9 +337,16 @@ final class DevToolsTest extends TestCase
                 parent::__construct('standards');
             }
 
+            /**
+             * @return void
+             */
             protected function configure(): void
             {
-                $this->addOption(name: 'pretty-json', mode: InputOption::VALUE_NONE, description: 'Emit pretty JSON output.');
+                $this->addOption(
+                    name: 'pretty-json',
+                    mode: InputOption::VALUE_NONE,
+                    description: 'Emit pretty JSON output.'
+                );
                 $this->setCode(static fn(InputInterface $input, OutputInterface $output): int => Command::SUCCESS);
             }
         };

--- a/tests/Path/DevToolsPathResolverTest.php
+++ b/tests/Path/DevToolsPathResolverTest.php
@@ -37,6 +37,7 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertSame(\dirname(__DIR__, 2), DevToolsPathResolver::getPackagePath());
         self::assertSame(\dirname(__DIR__, 2) . '/bin/dev-tools', DevToolsPathResolver::getBinaryPath());
         self::assertSame(\dirname(__DIR__, 2) . '/resources', DevToolsPathResolver::getResourcesPath());
+        self::assertSame(\dirname(__DIR__, 2) . '/vendor/autoload.php', DevToolsPathResolver::getRuntimeAutoloadPath());
         self::assertSame(
             \dirname(__DIR__, 2) . '/resources/phpdocumentor.xml',
             DevToolsPathResolver::getResourcesPath('phpdocumentor.xml')
@@ -68,6 +69,22 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertTrue(DevToolsPathResolver::isRepositoryCheckout('/workspaces/dev-tools/src'));
         self::assertFalse(
             DevToolsPathResolver::isRepositoryCheckout('/workspaces/project/vendor/fast-forward/dev-tools/src')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function itWillResolveRuntimeAutoloadPathsForRepositoryAndDependencyInstalls(): void
+    {
+        self::assertSame(
+            '/workspaces/dev-tools/vendor/autoload.php',
+            DevToolsPathResolver::getRuntimeAutoloadPath('/workspaces/dev-tools')
+        );
+        self::assertSame(
+            '/workspaces/project/vendor/autoload.php',
+            DevToolsPathResolver::getRuntimeAutoloadPath('/workspaces/project/vendor/fast-forward/dev-tools')
         );
     }
 }

--- a/tests/Path/DevToolsPathResolverTest.php
+++ b/tests/Path/DevToolsPathResolverTest.php
@@ -66,6 +66,12 @@ final class DevToolsPathResolverTest extends TestCase
             DevToolsPathResolver::isInstalledAsDependency('/workspaces/project/vendor/fast-forward/dev-tools/src')
         );
         self::assertFalse(DevToolsPathResolver::isInstalledAsDependency('/workspaces/dev-tools/src'));
+
+        self::assertTrue(
+            DevToolsPathResolver::isInstalledAsDependency(
+                'C:/workspaces/project/vendor/fast-forward/dev-tools/src'
+            )
+        );
         self::assertTrue(DevToolsPathResolver::isRepositoryCheckout('/workspaces/dev-tools/src'));
         self::assertFalse(
             DevToolsPathResolver::isRepositoryCheckout('/workspaces/project/vendor/fast-forward/dev-tools/src')

--- a/tests/PhpUnit/Bootstrap/BootstrapShimGeneratorTest.php
+++ b/tests/PhpUnit/Bootstrap/BootstrapShimGeneratorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\PhpUnit\Bootstrap;
+
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+#[CoversClass(BootstrapShimGenerator::class)]
+#[UsesClass(DevToolsPathResolver::class)]
+final class BootstrapShimGeneratorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy $filesystem;
+
+    private BootstrapShimGenerator $generator;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->prophesize(FilesystemInterface::class);
+        $this->generator = new BootstrapShimGenerator($this->filesystem->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function generateWillWriteBootstrapShimWithProjectAndDevToolsAutoloaders(): void
+    {
+        $projectBootstrap = '/repo/vendor/autoload.php';
+        $cacheDirectory = '/repo/.dev-tools/cache/phpunit';
+        $generatedBootstrapPath = '/repo/.dev-tools/cache/phpunit/bootstrap.php';
+        $devToolsAutoload = DevToolsPathResolver::getPackagePath('vendor/autoload.php');
+        $exportedProjectBootstrap = var_export($projectBootstrap, true);
+        $exportedDevToolsAutoload = var_export($devToolsAutoload, true);
+        $expectedContent = <<<PHP
+            <?php
+
+            declare(strict_types=1);
+
+            require_once {$exportedProjectBootstrap};
+
+            if (file_exists({$exportedDevToolsAutoload})) {
+                require_once {$exportedDevToolsAutoload};
+            }
+            PHP;
+
+        $this->filesystem->dumpFile($generatedBootstrapPath, $expectedContent)
+            ->shouldBeCalledOnce();
+
+        self::assertSame($generatedBootstrapPath, $this->generator->generate($projectBootstrap, $cacheDirectory));
+    }
+}

--- a/tests/PhpUnit/Bootstrap/BootstrapShimGeneratorTest.php
+++ b/tests/PhpUnit/Bootstrap/BootstrapShimGeneratorTest.php
@@ -57,7 +57,7 @@ final class BootstrapShimGeneratorTest extends TestCase
         $projectBootstrap = '/repo/vendor/autoload.php';
         $cacheDirectory = '/repo/.dev-tools/cache/phpunit';
         $generatedBootstrapPath = '/repo/.dev-tools/cache/phpunit/bootstrap.php';
-        $devToolsAutoload = DevToolsPathResolver::getPackagePath('vendor/autoload.php');
+        $devToolsAutoload = DevToolsPathResolver::getRuntimeAutoloadPath();
         $exportedProjectBootstrap = var_export($projectBootstrap, true);
         $exportedDevToolsAutoload = var_export($devToolsAutoload, true);
         $expectedContent = <<<PHP


### PR DESCRIPTION
## Related Issue

Closes #289

## Motivation / Context

- Global `dev-tools tests` runs can fall back to the packaged `phpunit.xml`.
- When the working directory does not install `fast-forward/dev-tools`, that packaged config still references the DevTools PHPUnit extension class.
- The command previously passed only the working-directory bootstrap to PHPUnit, so the packaged extension class was missing and the run failed in global-install scenarios.

## Changes

- Add a dedicated `BootstrapShimGenerator` that writes a deterministic PHPUnit bootstrap shim into the managed workspace cache.
- Update `TestsCommand` to pass the generated bootstrap shim to PHPUnit instead of the raw working-directory bootstrap path.
- Keep the shim loading the project bootstrap first and then `require_once` the active DevTools autoloader when it exists.
- Cover the shim generation and command orchestration paths with focused PHPUnit coverage.
- Add the missing PHPDoc/style cleanup in `DevTools.php` and `DevToolsTest.php` required for the repository validation gate.
- Add an `Unreleased` changelog entry for the global bootstrap fallback fix.

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s):
  - `composer dev-tools phpdoc`
  - `composer dev-tools code-style`
  - `composer dev-tools tests -- --filter='(TestsCommandTest|BootstrapShimGeneratorTest|DevToolsTest)'`
- [x] Manual verification:
  - `/Users/mentordosnerds/Sites/github.com/php-fast-forward/dev-tools/bin/dev-tools --working-dir=/Users/mentordosnerds/Sites/github.com/php-fast-forward/changelog tests --filter=ChangelogTest`

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The extra `DevTools.php` / `DevToolsTest.php` changes are style-only cleanup needed to keep the repository gate green on this branch.
