### PR TITLE
[path] Add runtime-aware tooling binary fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prefer project-local tooling binaries when available and fall back to the active DevTools runtime for `php-cs-fixer`, Rector, ECS, Jack, and Composer Dependency Analyser during global `dev-tools` runs (#292)
+
 ## [1.24.1] - 2026-04-30
 
 ### Fixed

--- a/src/Console/Command/CodeStyleCommand.php
+++ b/src/Console/Command/CodeStyleCommand.php
@@ -149,7 +149,7 @@ final class CodeStyleCommand extends Command
             $processBuilder = $processBuilder->withArgument('--fix');
         }
 
-        $ecs = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('ecs'));
+        $ecs = $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('ecs')]);
 
         $this->processQueue->add(process: $composerUpdate, label: 'Refreshing Composer Lock');
         $this->processQueue->add(

--- a/src/Console/Command/CodeStyleCommand.php
+++ b/src/Console/Command/CodeStyleCommand.php
@@ -21,6 +21,7 @@ namespace FastForward\DevTools\Console\Command;
 
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasJsonOption;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use Psr\Log\LoggerInterface;
@@ -148,7 +149,7 @@ final class CodeStyleCommand extends Command
             $processBuilder = $processBuilder->withArgument('--fix');
         }
 
-        $ecs = $processBuilder->build('vendor/bin/ecs');
+        $ecs = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('ecs'));
 
         $this->processQueue->add(process: $composerUpdate, label: 'Refreshing Composer Lock');
         $this->processQueue->add(

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Console\Command;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use InvalidArgumentException;
@@ -199,7 +200,9 @@ final class DependenciesCommand extends Command
         }
 
         $showShadowDependencies = (bool) $input->getOption('show-shadow-dependencies');
-        $process = $processBuilder->build('vendor/bin/composer-dependency-analyser');
+        $process = $processBuilder->build(
+            DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')
+        );
         $process->setEnv([
             ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES => $showShadowDependencies ? '1' : '0',
         ]);
@@ -217,7 +220,7 @@ final class DependenciesCommand extends Command
      */
     private function getJackBreakpointCommand(InputInterface $input, int $maximumOutdated): Process
     {
-        $command = 'vendor/bin/jack breakpoint';
+        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' breakpoint';
 
         if ((bool) $input->getOption('dev')) {
             $command .= ' --dev';
@@ -239,7 +242,7 @@ final class DependenciesCommand extends Command
      */
     private function getOpenVersionsCommand(InputInterface $input): Process
     {
-        $command = 'vendor/bin/jack open-versions';
+        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' open-versions';
 
         if ((bool) $input->getOption('dev')) {
             $command .= ' --dev';
@@ -261,7 +264,7 @@ final class DependenciesCommand extends Command
      */
     private function getRaiseToInstalledCommand(InputInterface $input): Process
     {
-        $command = 'vendor/bin/jack raise-to-installed';
+        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' raise-to-installed';
 
         if ((bool) $input->getOption('dev')) {
             $command .= ' --dev';

--- a/src/Console/Command/DependenciesCommand.php
+++ b/src/Console/Command/DependenciesCommand.php
@@ -201,7 +201,7 @@ final class DependenciesCommand extends Command
 
         $showShadowDependencies = (bool) $input->getOption('show-shadow-dependencies');
         $process = $processBuilder->build(
-            DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')
+            [DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')]
         );
         $process->setEnv([
             ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES => $showShadowDependencies ? '1' : '0',
@@ -220,17 +220,17 @@ final class DependenciesCommand extends Command
      */
     private function getJackBreakpointCommand(InputInterface $input, int $maximumOutdated): Process
     {
-        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' breakpoint';
+        $processBuilder = $this->processBuilder;
 
         if ((bool) $input->getOption('dev')) {
-            $command .= ' --dev';
+            $processBuilder = $processBuilder->withArgument('--dev');
         }
 
         if (! $this->shouldIgnoreOutdatedFailures($maximumOutdated)) {
-            $command .= ' --limit ' . $maximumOutdated;
+            $processBuilder = $processBuilder->withArgument('--limit', (string) $maximumOutdated);
         }
 
-        return $this->processBuilder->build($command);
+        return $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'breakpoint']);
     }
 
     /**
@@ -242,17 +242,17 @@ final class DependenciesCommand extends Command
      */
     private function getOpenVersionsCommand(InputInterface $input): Process
     {
-        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' open-versions';
+        $processBuilder = $this->processBuilder;
 
         if ((bool) $input->getOption('dev')) {
-            $command .= ' --dev';
+            $processBuilder = $processBuilder->withArgument('--dev');
         }
 
         if (! (bool) $input->getOption('upgrade')) {
-            $command .= ' --dry-run';
+            $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        return $this->processBuilder->build($command);
+        return $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'open-versions']);
     }
 
     /**
@@ -264,17 +264,17 @@ final class DependenciesCommand extends Command
      */
     private function getRaiseToInstalledCommand(InputInterface $input): Process
     {
-        $command = DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' raise-to-installed';
+        $processBuilder = $this->processBuilder;
 
         if ((bool) $input->getOption('dev')) {
-            $command .= ' --dev';
+            $processBuilder = $processBuilder->withArgument('--dev');
         }
 
         if (! (bool) $input->getOption('upgrade')) {
-            $command .= ' --dry-run';
+            $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        return $this->processBuilder->build($command);
+        return $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'raise-to-installed']);
     }
 
     /**

--- a/src/Console/Command/PhpDocCommand.php
+++ b/src/Console/Command/PhpDocCommand.php
@@ -186,7 +186,7 @@ final class PhpDocCommand extends Command
             $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        $phpCsFixer = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer') . ' fix');
+        $phpCsFixer = $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer'), 'fix']);
 
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')
@@ -207,7 +207,7 @@ final class PhpDocCommand extends Command
             $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        $rector = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector') . ' process');
+        $rector = $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('rector'), 'process']);
 
         $this->processQueue->add(process: $phpCsFixer, label: 'Fixing PHPDoc File Headers with PHP-CS-Fixer');
         $this->processQueue->add(process: $rector, label: 'Adding Missing PHPDoc with Rector');

--- a/src/Console/Command/PhpDocCommand.php
+++ b/src/Console/Command/PhpDocCommand.php
@@ -24,6 +24,7 @@ use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -185,7 +186,7 @@ final class PhpDocCommand extends Command
             $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        $phpCsFixer = $processBuilder->build('vendor/bin/php-cs-fixer fix');
+        $phpCsFixer = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer') . ' fix');
 
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')
@@ -206,7 +207,7 @@ final class PhpDocCommand extends Command
             $processBuilder = $processBuilder->withArgument('--dry-run');
         }
 
-        $rector = $processBuilder->build('vendor/bin/rector process');
+        $rector = $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector') . ' process');
 
         $this->processQueue->add(process: $phpCsFixer, label: 'Fixing PHPDoc File Headers with PHP-CS-Fixer');
         $this->processQueue->add(process: $rector, label: 'Adding Missing PHPDoc with Rector');

--- a/src/Console/Command/RefactorCommand.php
+++ b/src/Console/Command/RefactorCommand.php
@@ -125,7 +125,6 @@ final class RefactorCommand extends Command
         ]);
 
         $processBuilder = $this->processBuilder
-            ->withArgument('process')
             ->withArgument('--ansi')
             ->withArgument('--config')
             ->withArgument($this->fileLocator->locate(self::CONFIG));
@@ -144,7 +143,7 @@ final class RefactorCommand extends Command
         }
 
         $this->processQueue->add(
-            process: $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector')),
+            process: $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('rector'), 'process']),
             label: 'Refactoring Code with Rector',
         );
 

--- a/src/Console/Command/RefactorCommand.php
+++ b/src/Console/Command/RefactorCommand.php
@@ -21,6 +21,7 @@ namespace FastForward\DevTools\Console\Command;
 
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasJsonOption;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use Psr\Log\LoggerInterface;
@@ -143,7 +144,7 @@ final class RefactorCommand extends Command
         }
 
         $this->processQueue->add(
-            process: $processBuilder->build('vendor/bin/rector'),
+            process: $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector')),
             label: 'Refactoring Code with Rector',
         );
 

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -170,7 +170,7 @@ final class ReportsCommand extends Command
             $docsBuilder = $docsBuilder->withArgument('--pretty-json');
         }
 
-        $docs = $docsBuilder->build(DevToolsPathResolver::getBinaryCommand('docs'));
+        $docs = $docsBuilder->build([DevToolsPathResolver::getBinaryPath(), 'docs']);
 
         if (null !== $cacheArgument) {
             $coverageBuilder = $coverageBuilder->withArgument($cacheArgument);
@@ -192,7 +192,7 @@ final class ReportsCommand extends Command
             $coverageBuilder = $coverageBuilder->withArgument('--pretty-json');
         }
 
-        $coverage = $coverageBuilder->build(DevToolsPathResolver::getBinaryCommand('tests'));
+        $coverage = $coverageBuilder->build([DevToolsPathResolver::getBinaryPath(), 'tests']);
 
         if ($progress) {
             $metricsBuilder = $metricsBuilder->withArgument('--progress');
@@ -206,7 +206,7 @@ final class ReportsCommand extends Command
             $metricsBuilder = $metricsBuilder->withArgument('--pretty-json');
         }
 
-        $metrics = $metricsBuilder->build(DevToolsPathResolver::getBinaryCommand('metrics'));
+        $metrics = $metricsBuilder->build([DevToolsPathResolver::getBinaryPath(), 'metrics']);
 
         $this->processQueue->add(process: $docs, detached: true, label: 'Generating API Docs Report');
         $this->processQueue->add(process: $coverage, label: 'Generating Coverage Report');

--- a/src/Console/Command/StandardsCommand.php
+++ b/src/Console/Command/StandardsCommand.php
@@ -150,7 +150,7 @@ final class StandardsCommand extends Command
             }
 
             $this->processQueue->add(
-                process: $processBuilder->build(DevToolsPathResolver::getBinaryCommand($command)),
+                process: $processBuilder->build([DevToolsPathResolver::getBinaryPath(), $command]),
                 label: $this->getProcessLabel($command),
             );
         }

--- a/src/Console/Command/SyncCommand.php
+++ b/src/Console/Command/SyncCommand.php
@@ -230,7 +230,7 @@ final class SyncCommand extends Command
             $processBuilder = $processBuilder->withArgument($argument);
         }
 
-        $process = $processBuilder->build(DevToolsPathResolver::getBinaryPath());
+        $process = $processBuilder->build([DevToolsPathResolver::getBinaryPath()]);
 
         $this->processQueue->add(process: $process, detached: $detached, label: 'Running DevTools Sync Hook');
     }

--- a/src/Path/DevToolsPathResolver.php
+++ b/src/Path/DevToolsPathResolver.php
@@ -109,6 +109,52 @@ final class DevToolsPathResolver
     }
 
     /**
+     * Returns the active Composer runtime binary path for the current DevTools installation mode.
+     *
+     * Repository checkouts use the package-local `vendor/bin/<binary>`, while
+     * dependency installs resolve binaries from the active Composer vendor root.
+     *
+     * @param string $binary the binary name relative to `vendor/bin`
+     * @param string $packagePath an optional package root path; defaults to the current package root
+     */
+    public static function getRuntimeToolBinaryPath(string $binary, string $packagePath = ''): string
+    {
+        $packagePath = Path::canonicalize('' === $packagePath ? self::getPackagePath() : $packagePath);
+
+        if (self::isInstalledAsDependency($packagePath)) {
+            return Path::canonicalize(Path::join($packagePath, '..', '..', 'bin', $binary));
+        }
+
+        return Path::join($packagePath, 'vendor', 'bin', $binary);
+    }
+
+    /**
+     * Returns the preferred tooling binary path for the active project and DevTools runtime.
+     *
+     * Consumer projects SHOULD take precedence when they provide a local
+     * `vendor/bin/<binary>` entry. If the binary is absent locally, the method
+     * MUST fall back to the active DevTools runtime binary path.
+     *
+     * @param string $binary the binary name relative to `vendor/bin`
+     * @param string $projectPath an optional project root path; defaults to the working project root
+     * @param string $packagePath an optional package root path; defaults to the current package root
+     */
+    public static function getPreferredToolBinaryPath(
+        string $binary,
+        string $projectPath = '',
+        string $packagePath = '',
+    ): string {
+        $projectPath = '' === $projectPath ? WorkingProjectPathResolver::getProjectPath() : $projectPath;
+        $projectBinaryPath = Path::join($projectPath, 'vendor', 'bin', $binary);
+
+        if (file_exists($projectBinaryPath)) {
+            return $projectBinaryPath;
+        }
+
+        return self::getRuntimeToolBinaryPath($binary, $packagePath);
+    }
+
+    /**
      * Detects whether the provided path belongs to an installed vendor copy of DevTools.
      *
      * @param string $packagePath an optional path within the package; defaults to the package root

--- a/tests/Console/Command/CodeStyleCommandTest.php
+++ b/tests/Console/Command/CodeStyleCommandTest.php
@@ -21,10 +21,13 @@ namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\CodeStyleCommand;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
+use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -39,6 +42,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(CodeStyleCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class CodeStyleCommandTest extends TestCase
 {
@@ -111,6 +116,9 @@ final class CodeStyleCommandTest extends TestCase
     #[Test]
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
+        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('ecs'))
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalled();
         $this->processQueue->run(Argument::type('object'))
             ->willReturn(CodeStyleCommand::SUCCESS)
             ->shouldBeCalled();

--- a/tests/Console/Command/CodeStyleCommandTest.php
+++ b/tests/Console/Command/CodeStyleCommandTest.php
@@ -116,7 +116,7 @@ final class CodeStyleCommandTest extends TestCase
     #[Test]
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
-        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('ecs'))
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('ecs')])
             ->willReturn($this->process->reveal())
             ->shouldBeCalled();
         $this->processQueue->run(Argument::type('object'))

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -23,6 +23,7 @@ use FastForward\DevTools\Console\Command\DependenciesCommand;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
@@ -44,6 +45,7 @@ use Symfony\Component\Process\Process;
 
 #[CoversClass(DependenciesCommand::class)]
 #[UsesClass(DevToolsPathResolver::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class DependenciesCommandTest extends TestCase
@@ -225,7 +227,9 @@ final class DependenciesCommandTest extends TestCase
         $processBuilder->withArgument('--config', '/app/composer-dependency-analyser.php')
             ->willReturn($configuredProcessBuilder->reveal())
             ->shouldBeCalledOnce();
-        $configuredProcessBuilder->build('vendor/bin/composer-dependency-analyser')
+        $configuredProcessBuilder->build(
+            DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')
+        )
             ->willReturn($process->reveal())
             ->shouldBeCalledOnce();
         $process->setEnv([
@@ -234,6 +238,77 @@ final class DependenciesCommandTest extends TestCase
             ->shouldBeCalledOnce();
 
         (new ReflectionMethod($command, 'getComposerDependencyAnalyserCommand'))
+            ->invoke($command, $this->input->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function jackBreakpointProcessWillUseTheResolvedJackBinary(): void
+    {
+        $processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $process = $this->prophesize(Process::class);
+        $command = new DependenciesCommand(
+            $processBuilder->reveal(),
+            $this->processQueue->reveal(),
+            $this->fileLocator->reveal(),
+            $this->logger->reveal(),
+        );
+
+        $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' breakpoint --limit 5')
+            ->willReturn($process->reveal())
+            ->shouldBeCalledOnce();
+
+        (new ReflectionMethod($command, 'getJackBreakpointCommand'))
+            ->invoke($command, $this->input->reveal(), 5);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function openVersionsProcessWillUseTheResolvedJackBinary(): void
+    {
+        $processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $process = $this->prophesize(Process::class);
+        $command = new DependenciesCommand(
+            $processBuilder->reveal(),
+            $this->processQueue->reveal(),
+            $this->fileLocator->reveal(),
+            $this->logger->reveal(),
+        );
+
+        $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' open-versions --dry-run')
+            ->willReturn($process->reveal())
+            ->shouldBeCalledOnce();
+
+        (new ReflectionMethod($command, 'getOpenVersionsCommand'))
+            ->invoke($command, $this->input->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function raiseToInstalledProcessWillUseTheResolvedJackBinary(): void
+    {
+        $processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $process = $this->prophesize(Process::class);
+        $command = new DependenciesCommand(
+            $processBuilder->reveal(),
+            $this->processQueue->reveal(),
+            $this->fileLocator->reveal(),
+            $this->logger->reveal(),
+        );
+
+        $processBuilder->build(
+            DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' raise-to-installed --dry-run'
+        )
+            ->willReturn($process->reveal())
+            ->shouldBeCalledOnce();
+
+        (new ReflectionMethod($command, 'getRaiseToInstalledCommand'))
             ->invoke($command, $this->input->reveal());
     }
 }

--- a/tests/Console/Command/DependenciesCommandTest.php
+++ b/tests/Console/Command/DependenciesCommandTest.php
@@ -228,7 +228,7 @@ final class DependenciesCommandTest extends TestCase
             ->willReturn($configuredProcessBuilder->reveal())
             ->shouldBeCalledOnce();
         $configuredProcessBuilder->build(
-            DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')
+            [DevToolsPathResolver::getPreferredToolBinaryPath('composer-dependency-analyser')]
         )
             ->willReturn($process->reveal())
             ->shouldBeCalledOnce();
@@ -256,7 +256,10 @@ final class DependenciesCommandTest extends TestCase
             $this->logger->reveal(),
         );
 
-        $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' breakpoint --limit 5')
+        $processBuilder->withArgument('--limit', '5')
+            ->willReturn($processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'breakpoint'])
             ->willReturn($process->reveal())
             ->shouldBeCalledOnce();
 
@@ -279,7 +282,10 @@ final class DependenciesCommandTest extends TestCase
             $this->logger->reveal(),
         );
 
-        $processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' open-versions --dry-run')
+        $processBuilder->withArgument('--dry-run')
+            ->willReturn($processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'open-versions'])
             ->willReturn($process->reveal())
             ->shouldBeCalledOnce();
 
@@ -302,9 +308,10 @@ final class DependenciesCommandTest extends TestCase
             $this->logger->reveal(),
         );
 
-        $processBuilder->build(
-            DevToolsPathResolver::getPreferredToolBinaryPath('jack') . ' raise-to-installed --dry-run'
-        )
+        $processBuilder->withArgument('--dry-run')
+            ->willReturn($processBuilder->reveal())
+            ->shouldBeCalledOnce();
+        $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('jack'), 'raise-to-installed'])
             ->willReturn($process->reveal())
             ->shouldBeCalledOnce();
 

--- a/tests/Console/Command/PhpDocCommandTest.php
+++ b/tests/Console/Command/PhpDocCommandTest.php
@@ -28,9 +28,11 @@ use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\PhpDocCommand;
 use FastForward\DevTools\Console\Command\RefactorCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -53,6 +55,8 @@ use Twig\Environment;
 #[UsesClass(Author::class)]
 #[UsesClass(Support::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(DevToolsPathResolver::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class PhpDocCommandTest extends TestCase
 {
@@ -176,6 +180,12 @@ final class PhpDocCommandTest extends TestCase
     public function executeWillCreateDocHeaderAndRunPhpDocProcesses(): void
     {
         $this->filesystem->dumpFile(PhpDocCommand::FILENAME, 'docheader')->shouldBeCalled();
+        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer') . ' fix')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalled();
+        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector') . ' process')
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalled();
         $this->processBuilder->withArgument('--using-cache=yes')
             ->willReturn($this->processBuilder->reveal())
             ->shouldBeCalled();

--- a/tests/Console/Command/PhpDocCommandTest.php
+++ b/tests/Console/Command/PhpDocCommandTest.php
@@ -180,10 +180,10 @@ final class PhpDocCommandTest extends TestCase
     public function executeWillCreateDocHeaderAndRunPhpDocProcesses(): void
     {
         $this->filesystem->dumpFile(PhpDocCommand::FILENAME, 'docheader')->shouldBeCalled();
-        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer') . ' fix')
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('php-cs-fixer'), 'fix'])
             ->willReturn($this->process->reveal())
             ->shouldBeCalled();
-        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector') . ' process')
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('rector'), 'process'])
             ->willReturn($this->process->reveal())
             ->shouldBeCalled();
         $this->processBuilder->withArgument('--using-cache=yes')

--- a/tests/Console/Command/RefactorCommandTest.php
+++ b/tests/Console/Command/RefactorCommandTest.php
@@ -113,7 +113,7 @@ final class RefactorCommandTest extends TestCase
     #[Test]
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
-        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector'))
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('rector'), 'process'])
             ->willReturn($this->process->reveal())
             ->shouldBeCalled();
         $this->processQueue->run($this->output->reveal())

--- a/tests/Console/Command/RefactorCommandTest.php
+++ b/tests/Console/Command/RefactorCommandTest.php
@@ -21,10 +21,13 @@ namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\RefactorCommand;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
+use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -39,6 +42,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(RefactorCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class RefactorCommandTest extends TestCase
 {
@@ -108,6 +113,9 @@ final class RefactorCommandTest extends TestCase
     #[Test]
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
+        $this->processBuilder->build(DevToolsPathResolver::getPreferredToolBinaryPath('rector'))
+            ->willReturn($this->process->reveal())
+            ->shouldBeCalled();
         $this->processQueue->run($this->output->reveal())
             ->willReturn(RefactorCommand::SUCCESS)
             ->shouldBeCalled();

--- a/tests/Path/DevToolsPathResolverTest.php
+++ b/tests/Path/DevToolsPathResolverTest.php
@@ -21,11 +21,20 @@ namespace FastForward\DevTools\Tests\Path;
 
 use InvalidArgumentException;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
+use function Safe\file_put_contents;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
+
 #[CoversClass(DevToolsPathResolver::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 final class DevToolsPathResolverTest extends TestCase
 {
     /**
@@ -38,6 +47,10 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertSame(\dirname(__DIR__, 2) . '/bin/dev-tools', DevToolsPathResolver::getBinaryPath());
         self::assertSame(\dirname(__DIR__, 2) . '/resources', DevToolsPathResolver::getResourcesPath());
         self::assertSame(\dirname(__DIR__, 2) . '/vendor/autoload.php', DevToolsPathResolver::getRuntimeAutoloadPath());
+        self::assertSame(
+            \dirname(__DIR__, 2) . '/vendor/bin/ecs',
+            DevToolsPathResolver::getRuntimeToolBinaryPath('ecs')
+        );
         self::assertSame(
             \dirname(__DIR__, 2) . '/resources/phpdocumentor.xml',
             DevToolsPathResolver::getResourcesPath('phpdocumentor.xml')
@@ -68,9 +81,7 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertFalse(DevToolsPathResolver::isInstalledAsDependency('/workspaces/dev-tools/src'));
 
         self::assertTrue(
-            DevToolsPathResolver::isInstalledAsDependency(
-                'C:/workspaces/project/vendor/fast-forward/dev-tools/src'
-            )
+            DevToolsPathResolver::isInstalledAsDependency('C:/workspaces/project/vendor/fast-forward/dev-tools/src')
         );
         self::assertTrue(DevToolsPathResolver::isRepositoryCheckout('/workspaces/dev-tools/src'));
         self::assertFalse(
@@ -91,6 +102,74 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertSame(
             '/workspaces/project/vendor/autoload.php',
             DevToolsPathResolver::getRuntimeAutoloadPath('/workspaces/project/vendor/fast-forward/dev-tools')
+        );
+    }
+
+    /**
+     * @param string $binary
+     *
+     * @return void
+     */
+    #[Test]
+    #[TestWith(['php-cs-fixer'])]
+    #[TestWith(['rector'])]
+    #[TestWith(['ecs'])]
+    #[TestWith(['jack'])]
+    #[TestWith(['composer-dependency-analyser'])]
+    public function itWillResolveRuntimeToolBinaryPathsForRepositoryAndDependencyInstalls(string $binary): void
+    {
+        self::assertSame(
+            '/workspaces/dev-tools/vendor/bin/' . $binary,
+            DevToolsPathResolver::getRuntimeToolBinaryPath($binary, '/workspaces/dev-tools')
+        );
+        self::assertSame(
+            '/workspaces/project/vendor/bin/' . $binary,
+            DevToolsPathResolver::getRuntimeToolBinaryPath($binary, '/workspaces/project/vendor/fast-forward/dev-tools')
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function itWillPreferProjectToolBinariesWhenTheyExist(): void
+    {
+        $projectPath = sys_get_temp_dir() . '/dev-tools-path-resolver-' . bin2hex(random_bytes(4));
+        $binaryPath = $projectPath . '/vendor/bin/ecs';
+
+        mkdir($projectPath . '/vendor/bin', 0o777, true);
+        file_put_contents($binaryPath, '#!/usr/bin/env php');
+
+        try {
+            self::assertSame(
+                $binaryPath,
+                DevToolsPathResolver::getPreferredToolBinaryPath(
+                    'ecs',
+                    $projectPath,
+                    '/Users/example/.composer/vendor/fast-forward/dev-tools'
+                )
+            );
+        } finally {
+            unlink($binaryPath);
+            rmdir($projectPath . '/vendor/bin');
+            rmdir($projectPath . '/vendor');
+            rmdir($projectPath);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function itWillFallbackToRuntimeToolBinariesWhenTheProjectDoesNotProvideThem(): void
+    {
+        self::assertSame(
+            '/Users/example/.composer/vendor/bin/jack',
+            DevToolsPathResolver::getPreferredToolBinaryPath(
+                'jack',
+                '/workspaces/project',
+                '/Users/example/.composer/vendor/fast-forward/dev-tools'
+            )
         );
     }
 }

--- a/tests/Process/ProcessBuilderTest.php
+++ b/tests/Process/ProcessBuilderTest.php
@@ -142,6 +142,21 @@ final class ProcessBuilderTest extends TestCase
      * @return void
      */
     #[Test]
+    public function buildWillInjectNoLogoArgumentForDevToolsCommandArrays(): void
+    {
+        $process = $this->builder
+            ->build([DevToolsPathResolver::getBinaryPath(), 'tests']);
+
+        self::assertSame(
+            "'" . DevToolsPathResolver::getBinaryPath() . "' '--no-logo' 'tests'",
+            $process->getCommandLine(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function buildWillKeepExistingNoLogoArgumentWhenProvidedInArguments(): void
     {
         $process = $this->builder


### PR DESCRIPTION
## Related Issue

Closes #292

## Motivation / Context

- global `dev-tools` runs still assumed the consumer repository provided every tooling binary under `vendor/bin`
- repositories such as `changelog` do not install `php-cs-fixer`, `rector`, `ecs`, `jack`, or `composer-dependency-analyser` locally, so global runs could not start those processes

## Changes

- added runtime-aware tooling binary resolution to `DevToolsPathResolver`, preferring the working project's `vendor/bin/<tool>` when present and falling back to the active DevTools runtime binary path otherwise
- updated `code-style`, `phpdoc`, `refactor`, and `dependencies` to use the shared resolver instead of hardcoded `vendor/bin/...` strings
- expanded resolver and command tests to cover repository-checkout and installed/dependency resolution scenarios, including Jack subcommands

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s): `composer dev-tools tests -- --filter='(DevToolsPathResolverTest|CodeStyleCommandTest|RefactorCommandTest|PhpDocCommandTest|DependenciesCommandTest)'`, `composer dev-tools phpdoc`, `composer dev-tools code-style`
- [ ] Manual verification: not run against a separately updated global install in this workspace; covered via resolver tests for dependency installs

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- the new resolver keeps command behavior unchanged for repositories that already provide local tooling binaries while adding a global-install fallback path for the packaged tools