### PR TITLE
[path] Complete runtime-aware binary fallbacks for remaining commands (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Keep global `dev-tools:sync` runs machine-independent by removing only deprecated DevTools-managed Composer GrumPHP default-path metadata while wiring packaged Git hooks to prefer a project-local `grumphp.yml` and otherwise use the active packaged DevTools config path resolved at sync time (#288)
+- Complete global runtime binary fallback support for phpdoc, phpunit, and phpmetrics commands (#297)
 
 ## [1.24.2] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Keep global `dev-tools:sync` runs machine-independent by removing only deprecated DevTools-managed Composer GrumPHP default-path metadata while wiring packaged Git hooks to prefer a project-local `grumphp.yml` and otherwise use the active packaged DevTools config path resolved at sync time (#288)
-- Complete global runtime binary fallback support for phpdoc, phpunit, and phpmetrics commands (#297)
+- Complete global runtime fallback support for phpdoc, phpunit, and phpmetrics commands, including packaged phpDocumentor templates used by `docs` and `wiki` (#297)
 
 ## [1.24.2] - 2026-04-30
 

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -25,6 +25,7 @@ use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use Twig\Environment;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -167,7 +168,7 @@ final class DocsCommand extends Command
             $processBuilder = $processBuilder->withArgument('--no-progress');
         }
 
-        $phpdoc = $processBuilder->build('vendor/bin/phpdoc');
+        $phpdoc = $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('phpdoc')]);
 
         $this->processQueue->add(process: $phpdoc, label: 'Generating API Docs with phpDocumentor');
 

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -59,6 +59,11 @@ final class DocsCommand extends Command
     use LogsCommandResults;
 
     /**
+     * @var string the default phpDocumentor template path relative to the consumer project
+     */
+    private const string DEFAULT_TEMPLATE = 'vendor/fast-forward/phpdoc-bootstrap-template';
+
+    /**
      * Creates a new DocsCommand instance.
      *
      * @param ProcessBuilderInterface $processBuilder the process builder for executing phpDocumentor
@@ -115,7 +120,7 @@ final class DocsCommand extends Command
                 name: 'template',
                 mode: InputOption::VALUE_OPTIONAL,
                 description: 'Path to the template directory for the generated HTML documentation.',
-                default: 'vendor/fast-forward/phpdoc-bootstrap-template',
+                default: self::DEFAULT_TEMPLATE,
             );
     }
 
@@ -137,6 +142,11 @@ final class DocsCommand extends Command
         $source = $this->filesystem->getAbsolutePath($input->getOption('source'));
         $target = $this->filesystem->getAbsolutePath($input->getOption('target'));
         $cacheDir = $this->filesystem->getAbsolutePath($input->getOption('cache-dir'));
+        $template = (string) $input->getOption('template');
+
+        if (self::DEFAULT_TEMPLATE === $template) {
+            $template = DevToolsPathResolver::getPreferredVendorPath(self::DEFAULT_TEMPLATE);
+        }
 
         $this->logger->info('Generating API documentation...', [
             'input' => $input,
@@ -151,7 +161,7 @@ final class DocsCommand extends Command
         $config = $this->createPhpDocumentorConfig(
             source: $source,
             target: $target,
-            template: $input->getOption('template'),
+            template: $template,
             cacheDir: $cacheEnabled ? $cacheDir : sys_get_temp_dir(),
         );
 

--- a/src/Console/Command/MetricsCommand.php
+++ b/src/Console/Command/MetricsCommand.php
@@ -21,6 +21,7 @@ namespace FastForward\DevTools\Console\Command;
 
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasJsonOption;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -45,9 +46,9 @@ final class MetricsCommand extends Command
     use LogsCommandResults;
 
     /**
-     * @var string the bundled PhpMetrics binary path relative to the consumer root
+     * @var string the PhpMetrics binary name resolved through the runtime-aware tooling lookup
      */
-    private const string BINARY = 'vendor/bin/phpmetrics';
+    private const string BINARY = 'phpmetrics';
 
     /**
      * @var int the PHP error reporting mask that suppresses deprecations emitted by PhpMetrics internals
@@ -161,7 +162,7 @@ final class MetricsCommand extends Command
                     \PHP_BINARY,
                     '-derror_reporting=' . self::PHP_ERROR_REPORTING,
                     '-ddefault_socket_timeout=' . self::PHP_DEFAULT_SOCKET_TIMEOUT,
-                    self::BINARY,
+                    DevToolsPathResolver::getPreferredToolBinaryPath(self::BINARY),
                 ]),
             label: 'Generating Metrics with PhpMetrics',
         );

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -24,6 +24,7 @@ use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
 use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
@@ -209,7 +210,7 @@ final class TestsCommand extends Command
         $this->processQueue->add(
             process: $processBuilder
                 ->withArgument($input->getArgument('path'))
-                ->build('vendor/bin/phpunit'),
+                ->build([DevToolsPathResolver::getPreferredToolBinaryPath('phpunit')]),
             label: 'Running PHPUnit Tests',
         );
 

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -56,6 +56,11 @@ final class WikiCommand extends Command
     use LogsCommandResults;
 
     /**
+     * @var string the default phpDocumentor Markdown template path relative to the consumer project
+     */
+    private const string DEFAULT_TEMPLATE = 'vendor/saggre/phpdocumentor-markdown/themes/markdown';
+
+    /**
      * Creates a new WikiCommand instance.
      *
      * @param ComposerJsonInterface $composer the composer.json accessor
@@ -139,7 +144,7 @@ final class WikiCommand extends Command
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')
             ->withArgument('--visibility', 'public,protected')
-            ->withArgument('--template', 'vendor/saggre/phpdocumentor-markdown/themes/markdown')
+            ->withArgument('--template', DevToolsPathResolver::getPreferredVendorPath(self::DEFAULT_TEMPLATE))
             ->withArgument('--title', $this->composer->getDescription())
             ->withArgument('--target', $target);
 

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -25,6 +25,7 @@ use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Git\GitClientInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -157,7 +158,7 @@ final class WikiCommand extends Command
         }
 
         $this->processQueue->add(
-            process: $processBuilder->build('vendor/bin/phpdoc'),
+            process: $processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('phpdoc')]),
             label: 'Generating Wiki with phpDocumentor',
         );
 

--- a/src/Path/DevToolsPathResolver.php
+++ b/src/Path/DevToolsPathResolver.php
@@ -129,6 +129,27 @@ final class DevToolsPathResolver
     }
 
     /**
+     * Returns the active Composer vendor path for the current DevTools installation mode.
+     *
+     * Relative vendor paths MAY be passed either with or without a leading
+     * `vendor/` prefix.
+     *
+     * @param string $path the vendor-relative path to resolve
+     * @param string $packagePath an optional package root path; defaults to the current package root
+     */
+    public static function getRuntimeVendorPath(string $path, string $packagePath = ''): string
+    {
+        $packagePath = Path::canonicalize('' === $packagePath ? self::getPackagePath() : $packagePath);
+        $vendorPath = self::normalizeVendorRelativePath($path);
+
+        if (self::isInstalledAsDependency($packagePath)) {
+            return Path::canonicalize(Path::join($packagePath, '..', '..', $vendorPath));
+        }
+
+        return Path::join($packagePath, 'vendor', $vendorPath);
+    }
+
+    /**
      * Returns the preferred tooling binary path for the active project and DevTools runtime.
      *
      * Consumer projects SHOULD take precedence when they provide a local
@@ -155,6 +176,33 @@ final class DevToolsPathResolver
     }
 
     /**
+     * Returns the preferred Composer vendor path for the active project and DevTools runtime.
+     *
+     * Consumer projects SHOULD take precedence when they provide the requested
+     * vendor path locally. If the path is absent locally, the method MUST fall
+     * back to the active DevTools runtime vendor path.
+     *
+     * @param string $path the vendor-relative path to resolve
+     * @param string $projectPath an optional project root path; defaults to the working project root
+     * @param string $packagePath an optional package root path; defaults to the current package root
+     */
+    public static function getPreferredVendorPath(
+        string $path,
+        string $projectPath = '',
+        string $packagePath = '',
+    ): string {
+        $projectPath = '' === $projectPath ? WorkingProjectPathResolver::getProjectPath() : $projectPath;
+        $vendorPath = self::normalizeVendorRelativePath($path);
+        $projectVendorPath = Path::join($projectPath, 'vendor', $vendorPath);
+
+        if (file_exists($projectVendorPath)) {
+            return $projectVendorPath;
+        }
+
+        return self::getRuntimeVendorPath($vendorPath, $packagePath);
+    }
+
+    /**
      * Detects whether the provided path belongs to an installed vendor copy of DevTools.
      *
      * @param string $packagePath an optional path within the package; defaults to the package root
@@ -174,5 +222,21 @@ final class DevToolsPathResolver
     public static function isRepositoryCheckout(string $packagePath = ''): bool
     {
         return ! self::isInstalledAsDependency($packagePath);
+    }
+
+    /**
+     * Normalizes a path relative to the Composer vendor root.
+     *
+     * @param string $path the vendor-relative path to normalize
+     */
+    private static function normalizeVendorRelativePath(string $path): string
+    {
+        $path = Path::canonicalize($path);
+
+        if (str_starts_with($path, 'vendor/')) {
+            return substr($path, 7);
+        }
+
+        return $path;
     }
 }

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -23,9 +23,11 @@ use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\DocsCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -43,7 +45,9 @@ use Symfony\Component\Process\Process;
 use Twig\Environment;
 
 #[CoversClass(DocsCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class DocsCommandTest extends TestCase
 {
@@ -133,7 +137,7 @@ final class DocsCommandTest extends TestCase
         $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn(
             $this->processBuilder->reveal()
         );
-        $this->processBuilder->build('vendor/bin/phpdoc')
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('phpdoc')])
             ->willReturn($this->process->reveal());
 
         $this->command = new DocsCommand(

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -132,7 +132,14 @@ final class DocsCommandTest extends TestCase
             ]);
         $this->composer->getName()
             ->willReturn('fast-forward/dev-tools');
-        $this->renderer->render('phpdocumentor.xml', Argument::type('array'))->willReturn('<phpdocumentor />');
+        $this->renderer->render(
+            'phpdocumentor.xml',
+            Argument::that(
+                static fn(array $context): bool => DevToolsPathResolver::getPreferredVendorPath(
+                    'vendor/fast-forward/phpdoc-bootstrap-template'
+                ) === $context['template']
+            )
+        )->willReturn('<phpdocumentor />');
         $this->processBuilder->withArgument(Argument::any())->willReturn($this->processBuilder->reveal());
         $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn(
             $this->processBuilder->reveal()

--- a/tests/Console/Command/MetricsCommandTest.php
+++ b/tests/Console/Command/MetricsCommandTest.php
@@ -21,9 +21,11 @@ namespace FastForward\DevTools\Tests\Console\Command;
 
 use FastForward\DevTools\Console\Command\MetricsCommand;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -42,7 +44,9 @@ use Symfony\Component\Process\Process;
 use function Safe\putenv;
 
 #[CoversClass(MetricsCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class MetricsCommandTest extends TestCase
 {
@@ -99,7 +103,8 @@ final class MetricsCommandTest extends TestCase
         $this->processBuilder->build(Argument::that(static fn(array $command): bool => \PHP_BINARY === $command[0]
             && str_starts_with((string) $command[1], '-derror_reporting=')
             && '-ddefault_socket_timeout=1' === $command[2]
-            && 'vendor/bin/phpmetrics' === $command[3]))->willReturn($this->process->reveal());
+            && DevToolsPathResolver::getPreferredToolBinaryPath('phpmetrics') === $command[3]))
+            ->willReturn($this->process->reveal());
         $this->command = new MetricsCommand(
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -30,6 +30,7 @@ use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -54,6 +55,7 @@ use function Safe\getcwd;
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class TestsCommandTest extends TestCase
 {
@@ -147,6 +149,9 @@ final class TestsCommandTest extends TestCase
             ) && str_contains(
                 $process->getCommandLine(),
                 '--bootstrap=' . $generatedBootstrapPath,
+            ) && str_contains(
+                $process->getCommandLine(),
+                DevToolsPathResolver::getPreferredToolBinaryPath('phpunit'),
             ) && str_contains($process->getCommandLine(), '--cache-result') && str_contains(
                 $process->getCommandLine(),
                 '--cache-directory=' . getcwd() . '/.dev-tools/cache/phpunit',

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -131,6 +131,12 @@ final class WikiCommandTest extends TestCase
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
         $this->processBuilder->withArgument(
+            '--template',
+            DevToolsPathResolver::getPreferredVendorPath('vendor/saggre/phpdocumentor-markdown/themes/markdown')
+        )
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalled();
+        $this->processBuilder->withArgument(
             '--cache-folder',
             ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPDOC)
         )

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -24,9 +24,11 @@ use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\WikiCommand;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Git\GitClientInterface;
+use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -42,7 +44,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[CoversClass(WikiCommand::class)]
+#[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class WikiCommandTest extends TestCase
 {
@@ -107,7 +111,8 @@ final class WikiCommandTest extends TestCase
         $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn(
             $this->processBuilder->reveal()
         );
-        $this->processBuilder->build(Argument::any())->willReturn($this->process->reveal());
+        $this->processBuilder->build([DevToolsPathResolver::getPreferredToolBinaryPath('phpdoc')])
+            ->willReturn($this->process->reveal());
 
         $this->command = new WikiCommand(
             $this->processBuilder->reveal(),

--- a/tests/Path/DevToolsPathResolverTest.php
+++ b/tests/Path/DevToolsPathResolverTest.php
@@ -52,6 +52,10 @@ final class DevToolsPathResolverTest extends TestCase
             DevToolsPathResolver::getRuntimeToolBinaryPath('ecs')
         );
         self::assertSame(
+            \dirname(__DIR__, 2) . '/vendor/fast-forward/phpdoc-bootstrap-template',
+            DevToolsPathResolver::getRuntimeVendorPath('vendor/fast-forward/phpdoc-bootstrap-template')
+        );
+        self::assertSame(
             \dirname(__DIR__, 2) . '/resources/phpdocumentor.xml',
             DevToolsPathResolver::getResourcesPath('phpdocumentor.xml')
         );
@@ -93,7 +97,7 @@ final class DevToolsPathResolverTest extends TestCase
      * @return void
      */
     #[Test]
-    public function itWillResolveRuntimeAutoloadPathsForRepositoryAndDependencyInstalls(): void
+    public function itWillResolveRuntimeAutoloadAndVendorPathsForRepositoryAndDependencyInstalls(): void
     {
         self::assertSame(
             '/workspaces/dev-tools/vendor/autoload.php',
@@ -102,6 +106,13 @@ final class DevToolsPathResolverTest extends TestCase
         self::assertSame(
             '/workspaces/project/vendor/autoload.php',
             DevToolsPathResolver::getRuntimeAutoloadPath('/workspaces/project/vendor/fast-forward/dev-tools')
+        );
+        self::assertSame(
+            '/workspaces/project/vendor/saggre/phpdocumentor-markdown/themes/markdown',
+            DevToolsPathResolver::getRuntimeVendorPath(
+                'vendor/saggre/phpdocumentor-markdown/themes/markdown',
+                '/workspaces/project/vendor/fast-forward/dev-tools'
+            )
         );
     }
 
@@ -170,6 +181,52 @@ final class DevToolsPathResolverTest extends TestCase
             '/Users/example/.composer/vendor/bin/jack',
             DevToolsPathResolver::getPreferredToolBinaryPath(
                 'jack',
+                '/workspaces/project',
+                '/Users/example/.composer/vendor/fast-forward/dev-tools'
+            )
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function itWillPreferProjectVendorPathsWhenTheyExist(): void
+    {
+        $projectPath = sys_get_temp_dir() . '/dev-tools-vendor-path-resolver-' . bin2hex(random_bytes(4));
+        $vendorPath = $projectPath . '/vendor/saggre/phpdocumentor-markdown/themes/markdown';
+
+        mkdir($vendorPath, 0o777, true);
+
+        try {
+            self::assertSame(
+                $vendorPath,
+                DevToolsPathResolver::getPreferredVendorPath(
+                    'vendor/saggre/phpdocumentor-markdown/themes/markdown',
+                    $projectPath,
+                    '/Users/example/.composer/vendor/fast-forward/dev-tools'
+                )
+            );
+        } finally {
+            rmdir($vendorPath);
+            rmdir($projectPath . '/vendor/saggre/phpdocumentor-markdown/themes');
+            rmdir($projectPath . '/vendor/saggre/phpdocumentor-markdown');
+            rmdir($projectPath . '/vendor/saggre');
+            rmdir($projectPath . '/vendor');
+            rmdir($projectPath);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function itWillFallbackToRuntimeVendorPathsWhenTheProjectDoesNotProvideThem(): void
+    {
+        self::assertSame(
+            '/Users/example/.composer/vendor/fast-forward/phpdoc-bootstrap-template',
+            DevToolsPathResolver::getPreferredVendorPath(
+                'vendor/fast-forward/phpdoc-bootstrap-template',
                 '/workspaces/project',
                 '/Users/example/.composer/vendor/fast-forward/dev-tools'
             )

--- a/tests/Path/DevToolsPathResolverTest.php
+++ b/tests/Path/DevToolsPathResolverTest.php
@@ -112,6 +112,9 @@ final class DevToolsPathResolverTest extends TestCase
      */
     #[Test]
     #[TestWith(['php-cs-fixer'])]
+    #[TestWith(['phpdoc'])]
+    #[TestWith(['phpmetrics'])]
+    #[TestWith(['phpunit'])]
     #[TestWith(['rector'])]
     #[TestWith(['ecs'])]
     #[TestWith(['jack'])]


### PR DESCRIPTION
## Related Issue

Closes #297

## Motivation / Context

- Global `fast-forward/dev-tools` installs still failed in the remaining command flows that hardcoded `vendor/bin/phpdoc`, `vendor/bin/phpunit`, or `vendor/bin/phpmetrics`.
- Consumer repositories that do not install those binaries locally should still be able to use the active DevTools runtime fallback.

## Changes

- Route `DocsCommand`, `WikiCommand`, `TestsCommand`, and `MetricsCommand` through `DevToolsPathResolver::getPreferredToolBinaryPath(...)`.
- Keep process command arrays explicit so runtime binary paths are not split on spaces.
- Extend command and path resolver coverage for the remaining `phpdoc`, `phpunit`, and `phpmetrics` flows.
- Add a `CHANGELOG.md` entry for the automation-facing fix.

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s): `composer dev-tools tests -- --filter='(DocsCommandTest|WikiCommandTest|MetricsCommandTest|TestsCommandTest|DevToolsPathResolverTest)'`
- [ ] Manual verification: not run separately; covered by the command and resolver test coverage added here.

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [x] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- This completes the runtime-aware binary fallback follow-up from `#292` for the remaining phpDocumentor, PHPUnit, and PhpMetrics command paths.
