### PR TITLE
[self-update] Restore global new-version notifications (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore global DevTools new-version notifications by using a supported Symfony Process success check during release lookups (#300)
+
 ## [1.24.3] - 2026-04-30
 
 ### Fixed

--- a/src/SelfUpdate/ComposerVersionChecker.php
+++ b/src/SelfUpdate/ComposerVersionChecker.php
@@ -23,7 +23,6 @@ use Composer\InstalledVersions;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use JsonException;
-use Symfony\Component\Process\Process;
 
 use function Safe\preg_match;
 use function Safe\json_decode;
@@ -83,7 +82,9 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
 
         $process->setTimeout(self::TIMEOUT_SECONDS);
 
-        if (Process::SUCCESS !== $process->run()) {
+        $process->run();
+
+        if (! $process->isSuccessful()) {
             return null;
         }
 

--- a/tests/SelfUpdate/ComposerVersionCheckerTest.php
+++ b/tests/SelfUpdate/ComposerVersionCheckerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\SelfUpdate;
+
+use FastForward\DevTools\Process\ProcessBuilderInterface;
+use FastForward\DevTools\SelfUpdate\ComposerVersionChecker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionMethod;
+use Symfony\Component\Process\Process;
+
+#[CoversClass(ComposerVersionChecker::class)]
+final class ComposerVersionCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<ProcessBuilderInterface>
+     */
+    private ObjectProphecy $processBuilder;
+
+    private ComposerVersionChecker $checker;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
+        $this->checker = new ComposerVersionChecker($this->processBuilder->reveal());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveLatestStableVersionWillReturnFirstStableComposerVersion(): void
+    {
+        $process = new Process([
+            'php',
+            '-r',
+            'echo json_encode(["versions" => ["1.x-dev", "v1.24.3", "v1.24.2"]]);',
+        ]);
+
+        $this->expectComposerShowLookup($process);
+
+        self::assertSame('v1.24.3', $this->invokeResolveLatestStableVersion($this->checker));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveLatestStableVersionWillReturnNullWhenComposerShowFails(): void
+    {
+        $process = new Process(['php', '-r', 'fwrite(STDERR, "lookup failed"); exit(1);']);
+
+        $this->expectComposerShowLookup($process);
+
+        self::assertNull($this->invokeResolveLatestStableVersion($this->checker));
+    }
+
+    /**
+     * @param Process $process
+     *
+     * @return void
+     */
+    private function expectComposerShowLookup(Process $process): void
+    {
+        $builder = $this->processBuilder->reveal();
+
+        $this->processBuilder->withArgument('fast-forward/dev-tools')
+            ->willReturn($builder)
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--available')
+            ->willReturn($builder)
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--format=json')
+            ->willReturn($builder)
+            ->shouldBeCalledOnce();
+        $this->processBuilder->withArgument('--no-interaction')
+            ->willReturn($builder)
+            ->shouldBeCalledOnce();
+        $this->processBuilder->build('composer show')
+            ->willReturn($process)
+            ->shouldBeCalledOnce();
+    }
+
+    /**
+     * @param ComposerVersionChecker $checker
+     *
+     * @return ?string
+     */
+    private function invokeResolveLatestStableVersion(ComposerVersionChecker $checker): ?string
+    {
+        return (new ReflectionMethod($checker, 'resolveLatestStableVersion'))->invoke($checker);
+    }
+}


### PR DESCRIPTION
## Related Issue

Closes #300

## Motivation / Context

- Global DevTools installs could stay silent even when a newer release was available because the version checker compared the Composer lookup result against a Symfony Process success constant that is not available in the supported runtime range.

## Changes

- Replaced the version-check success comparison with `Process::isSuccessful()` after the Composer metadata lookup runs.
- Added `ComposerVersionCheckerTest` coverage for successful and failing Composer release lookups.
- Recorded the fix in `CHANGELOG.md`.

## Verification

- [x] `composer dev-tools`
- [x] Focused command(s): `composer dev-tools tests -- --filter='ComposerVersionCheckerTest'`
- [ ] Manual verification: not rerun after the patch; the regression is covered by the new checker test and the full DevTools gate.

## Documentation / Generated Output

- [ ] README updated
- [ ] `docs/` updated
- [ ] Generated or synchronized output reviewed

## Changelog

- [x] Added a notable `CHANGELOG.md` entry

## Reviewer Notes

- The local `.github/wiki` modification was preserved outside this branch and is not part of this PR.
