### PR TITLE
Rebuild release wiki refreshes from the main pointer

### DIFF
--- a/.github/actions/wiki/refresh-release-pointer/run.sh
+++ b/.github/actions/wiki/refresh-release-pointer/run.sh
@@ -9,26 +9,15 @@ publish_branch="${INPUT_PUBLISH_BRANCH:-master}"
 commit_message="${INPUT_COMMIT_MESSAGE:-Refresh wiki docs after merged release}"
 
 git -C "${target}" fetch origin "${publish_branch}"
-
-if ! git -C "${target}" switch -C "${publish_branch}" --track "origin/${publish_branch}" >/dev/null 2>&1; then
-    git -C "${target}" switch "${publish_branch}" >/dev/null 2>&1
-fi
-
-git -C "${target}" reset --hard "origin/${publish_branch}"
+git -C "${target}" reset --hard HEAD
 git -C "${target}" clean -fd
 
 dev-tools wiki --target="${target}"
 
 if [ -z "$(git -C "${target}" status --porcelain)" ]; then
-    pointer_changed="false"
-
-    if ! git diff --quiet -- "${target}"; then
-        pointer_changed="true"
-    fi
-
     {
         echo "published=false"
-        echo "pointer-changed=${pointer_changed}"
+        echo "pointer-changed=false"
         echo "publish-sha=$(git -C "${target}" rev-parse HEAD)"
     } >> "${GITHUB_OUTPUT}"
 
@@ -39,7 +28,7 @@ git -C "${target}" config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
 git -C "${target}" config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
 git -C "${target}" add -A
 git -C "${target}" commit -m "${commit_message}"
-git -C "${target}" push origin "HEAD:${publish_branch}"
+git -C "${target}" push --force-with-lease origin "HEAD:${publish_branch}"
 
 pointer_changed="false"
 

--- a/.github/workflows/wiki-maintenance.yml
+++ b/.github/workflows/wiki-maintenance.yml
@@ -120,13 +120,14 @@ jobs:
       - name: Explain release publish handling
         env:
           RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          SOURCE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           {
             printf '## Wiki Publish Summary\n\n'
-            printf -- '- Publish branch: `master`\n'
+            printf -- '- Source branch: `%s`\n' "$SOURCE_BRANCH"
             printf -- '- Preview branch: `%s`\n' "${WIKI_PREVIEW_BRANCH}"
             printf -- '- Release branch: `%s`\n' "$RELEASE_BRANCH"
-            printf -- '- Action: skipped preview-branch publication because merged release branches are refreshed from the authoritative released state by `changelog.yml`.\n'
+            printf -- '- Action: skipped preview-branch publication because merged release branches are rebuilt from the `.github/wiki` pointer recorded on `%s` by `changelog.yml`.\n' "$SOURCE_BRANCH"
             printf -- '- Preview cleanup: `%s`\n' "${{ steps.cleanup_preview.outputs.deleted == 'true' && 'deleted immediately' || 'not present' }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Keep reusable-workflow retry automation from failing on unreadable child-job logs, while moving release-branch wiki publication to changelog-driven release refreshes that republish wiki content and reconcile the parent `.github/wiki` pointer from the authoritative released state (#309)
+- Rebuild release-time wiki publication from the `.github/wiki` pointer already recorded on `main`, force-push the regenerated wiki branch only when the rebuilt content changes, and align merged-release wiki maintenance summaries with `main` as the source branch (#312)
 
 ## [1.24.5] - 2026-04-30
 

--- a/tests/GitHubActions/RefreshReleaseWikiPointerActionTest.php
+++ b/tests/GitHubActions/RefreshReleaseWikiPointerActionTest.php
@@ -123,7 +123,7 @@ final class RefreshReleaseWikiPointerActionTest extends TestCase
      * @return void
      */
     #[Test]
-    public function refreshWillReportPointerDriftWhenTheWikiRemoteAdvancedWithoutNewRenderedChanges(): void
+    public function refreshWillIgnoreRemotePointerDriftWhenTheRenderedWikiDoesNotChange(): void
     {
         $workspace = $this->createWorkspaceWithWikiSubmodule();
         $this->advanceWikiRemote();
@@ -136,7 +136,33 @@ final class RefreshReleaseWikiPointerActionTest extends TestCase
         $status = $this->runProcess(['git', 'status', '--short', '.github/wiki'], $workspace);
 
         self::assertSame('false', $outputs['published']);
+        self::assertSame('false', $outputs['pointer-changed']);
+        self::assertSame('', trim($status->getOutput()));
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function refreshWillRepublishFromTheCheckedInPointerWhenThePublishedWikiBranchAdvanced(): void
+    {
+        $workspace = $this->createWorkspaceWithWikiSubmodule();
+        $this->advanceWikiRemote();
+        $this->createMockDevToolsBinary(true);
+        $outputFile = $this->workspace . '/github-output';
+
+        $this->runAction($workspace, $outputFile);
+
+        $outputs = $this->parseKeyValueFile($outputFile);
+        $status = $this->runProcess(['git', 'status', '--short', '.github/wiki'], $workspace);
+        $remoteHead = $this->runProcess(
+            ['git', 'rev-parse', 'refs/heads/master'],
+            $this->workspace . '/wiki-remote.git',
+        );
+
+        self::assertSame('true', $outputs['published']);
         self::assertSame('true', $outputs['pointer-changed']);
+        self::assertSame(trim($outputs['publish-sha']), trim($remoteHead->getOutput()));
         self::assertStringContainsString('.github/wiki', $status->getOutput());
     }
 


### PR DESCRIPTION
## Summary
- rebuild release-time wiki publication from the `.github/wiki` pointer already checked into `main`
- stop treating remote wiki branch drift as authoritative when rebuilt content is unchanged
- align merged-release wiki maintenance summaries with `main` as the source branch and cover the release refresh behavior with regression tests

## Validation
- `vendor/bin/phpunit tests/GitHubActions/RefreshReleaseWikiPointerActionTest.php`
- `vendor/bin/grumphp run --tasks=yamllint`
- `composer dev-tools code-style`
- `composer dev-tools`

Closes #312