### PR TITLE
Keep release wiki preview refreshes installing phpDocumentor

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -270,7 +270,7 @@ jobs:
               with:
                   php-version: ${{ needs.resolve_php.outputs.php-version }}
                   root-version: ${{ format('dev-{0}{1}', env.RELEASE_BRANCH_PREFIX, steps.version.outputs.value) }}
-                  install-options: --prefer-dist --no-progress --no-interaction --no-plugins --no-scripts
+                  install-options: --prefer-dist --no-progress --no-interaction --no-scripts
                   safe-directories: |
                       ${{ github.workspace }}/.github/wiki
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep release-preparation wiki preview refreshes installing Composer plugins so `phpdocumentor/shim` still exposes `phpdoc` when release pull request creation rebuilds `.github/wiki` (#318)
 - Keep release-preparation pull requests refreshing their wiki preview and parent `.github/wiki` pointer before merge, then publish merged release wikis from that preview branch so branch protection no longer requires direct post-merge pointer commits to `main` (#315)
 
 ## [1.24.6] - 2026-04-30

--- a/tests/GitHubActions/ChangelogWorkflowTest.php
+++ b/tests/GitHubActions/ChangelogWorkflowTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\GitHubActions;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+final class ChangelogWorkflowTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function prepareReleasePullRequestWillKeepComposerPluginsEnabledForWikiPreviewRefresh(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/changelog.yml');
+        $steps = $workflow['jobs']['prepare_release_pull_request']['steps'] ?? null;
+
+        self::assertIsArray($steps);
+
+        $setupComposerStep = null;
+
+        foreach ($steps as $step) {
+            if (! \is_array($step)) {
+                continue;
+            }
+
+            if (($step['name'] ?? null) !== 'Setup PHP and install dependencies') {
+                continue;
+            }
+
+            if (($step['if'] ?? null) !== '${{ steps.create_pr.outputs.pull-request-number != \'\' }}') {
+                continue;
+            }
+
+            $setupComposerStep = $step;
+
+            break;
+        }
+
+        self::assertIsArray($setupComposerStep);
+        self::assertSame(
+            '--prefer-dist --no-progress --no-interaction --no-scripts',
+            $setupComposerStep['with']['install-options'] ?? null,
+        );
+        self::assertStringNotContainsString(
+            '--no-plugins',
+            (string) ($setupComposerStep['with']['install-options'] ?? ''),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- keep the release PR wiki preview refresh using Composer plugins so `phpdocumentor/shim` still exposes `phpdoc`
- add a workflow regression test that locks the release-preparation install options to the plugin-enabled variant
- document the fix in the changelog

## Testing

- `vendor/bin/phpunit tests/GitHubActions/ChangelogWorkflowTest.php tests/GitHubActions/RefreshPreviewPointerActionTest.php tests/GitHubActions/SetupComposerActionTest.php`
- `vendor/bin/yaml-lint .github/workflows/changelog.yml`
- `composer dev-tools code-style`
- `composer dev-tools changelog:check -- --file=CHANGELOG.md --against=origin/main`

Closes #318
