### PR TITLE
Handle guide-only repositories across reports tooling

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -60,6 +60,11 @@ jobs:
         if: github.event_name != 'schedule' && !(github.event_name == 'workflow_dispatch' && inputs.cleanup-previews) && (github.event_name != 'pull_request' || github.event.action != 'closed')
         name: Generate Reports
         runs-on: ubuntu-latest
+        outputs:
+            any_generated: ${{ steps.detect_reports.outputs.any_generated }}
+            coverage_generated: ${{ steps.detect_reports.outputs.coverage_generated }}
+            docs_generated: ${{ steps.detect_reports.outputs.docs_generated }}
+            metrics_generated: ${{ steps.detect_reports.outputs.metrics_generated }}
         permissions:
             contents: write
 
@@ -102,6 +107,38 @@ jobs:
 
             - name: Remove repository-local caches from published output
               run: rm -rf "${REPORTS_TARGET}/cache"
+
+            - name: Detect generated report surfaces
+              id: detect_reports
+              run: |
+                docs_generated=false
+                coverage_generated=false
+                metrics_generated=false
+
+                if [ -f "${REPORTS_TARGET}/index.html" ]; then
+                  docs_generated=true
+                fi
+
+                if [ -f "${REPORTS_TARGET}/coverage/index.html" ]; then
+                  coverage_generated=true
+                fi
+
+                if [ -f "${REPORTS_TARGET}/metrics/index.html" ]; then
+                  metrics_generated=true
+                fi
+
+                any_generated=false
+
+                if [ "$docs_generated" = 'true' ] || [ "$coverage_generated" = 'true' ] || [ "$metrics_generated" = 'true' ]; then
+                  any_generated=true
+                fi
+
+                {
+                  echo "docs_generated=$docs_generated"
+                  echo "coverage_generated=$coverage_generated"
+                  echo "metrics_generated=$metrics_generated"
+                  echo "any_generated=$any_generated"
+                } >> "$GITHUB_OUTPUT"
 
             - name: Restore previews from gh-pages
               if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -157,14 +194,43 @@ jobs:
                 sparse-checkout: |
                   .github/actions
 
+            - name: Build deployment checks
+              id: build_checks
+              env:
+                COVERAGE_GENERATED: ${{ needs.reports.outputs.coverage_generated }}
+                DOCS_GENERATED: ${{ needs.reports.outputs.docs_generated }}
+                METRICS_GENERATED: ${{ needs.reports.outputs.metrics_generated }}
+              run: |
+                has_checks=false
+
+                {
+                  echo 'checks<<EOF'
+
+                  if [ "${DOCS_GENERATED}" = 'true' ]; then
+                    echo '/|Reports index'
+                    has_checks=true
+                  fi
+
+                  if [ "${COVERAGE_GENERATED}" = 'true' ]; then
+                    echo '/coverage/|Coverage report'
+                    has_checks=true
+                  fi
+
+                  if [ "${METRICS_GENERATED}" = 'true' ]; then
+                    echo '/metrics/|Metrics report'
+                    has_checks=true
+                  fi
+
+                  echo 'EOF'
+                  echo "has_checks=$has_checks"
+                } >> "$GITHUB_OUTPUT"
+
             - uses: ./.dev-tools-actions/.github/actions/github-pages/verify-deployment
+              if: steps.build_checks.outputs.has_checks == 'true'
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
                 title: Reports health check failed
-                checks: |
-                  /|Reports index
-                  /coverage/|Coverage report
-                  /metrics/|Metrics report
+                checks: ${{ steps.build_checks.outputs.checks }}
 
     verify_preview_reports:
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
@@ -183,14 +249,43 @@ jobs:
                 sparse-checkout: |
                   .github/actions
 
+            - name: Build preview deployment checks
+              id: build_checks
+              env:
+                COVERAGE_GENERATED: ${{ needs.reports.outputs.coverage_generated }}
+                DOCS_GENERATED: ${{ needs.reports.outputs.docs_generated }}
+                METRICS_GENERATED: ${{ needs.reports.outputs.metrics_generated }}
+              run: |
+                has_checks=false
+
+                {
+                  echo 'checks<<EOF'
+
+                  if [ "${DOCS_GENERATED}" = 'true' ]; then
+                    echo '/|Preview reports index'
+                    has_checks=true
+                  fi
+
+                  if [ "${COVERAGE_GENERATED}" = 'true' ]; then
+                    echo '/coverage/|Preview coverage report'
+                    has_checks=true
+                  fi
+
+                  if [ "${METRICS_GENERATED}" = 'true' ]; then
+                    echo '/metrics/|Preview metrics report'
+                    has_checks=true
+                  fi
+
+                  echo 'EOF'
+                  echo "has_checks=$has_checks"
+                } >> "$GITHUB_OUTPUT"
+
             - uses: ./.dev-tools-actions/.github/actions/github-pages/verify-deployment
+              if: steps.build_checks.outputs.has_checks == 'true'
               with:
                 base-url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}
                 title: Preview health check failed
-                checks: |
-                  /|Preview reports index
-                  /coverage/|Preview coverage report
-                  /metrics/|Preview metrics report
+                checks: ${{ steps.build_checks.outputs.checks }}
 
     comment_preview:
         if: github.event_name == 'pull_request' && github.event.action != 'closed'
@@ -203,16 +298,45 @@ jobs:
             pull-requests: write
 
         steps:
+            - name: Build preview comment
+              id: build_comment
+              env:
+                COVERAGE_GENERATED: ${{ needs.reports.outputs.coverage_generated }}
+                DOCS_GENERATED: ${{ needs.reports.outputs.docs_generated }}
+                METRICS_GENERATED: ${{ needs.reports.outputs.metrics_generated }}
+              run: |
+                has_links=false
+
+                {
+                  echo 'message<<EOF'
+                  echo '🚀 Preview is available for this pull request.'
+                  echo
+
+                  if [ "${DOCS_GENERATED}" = 'true' ]; then
+                    echo "- Docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/"
+                    has_links=true
+                  fi
+
+                  if [ "${COVERAGE_GENERATED}" = 'true' ]; then
+                    echo "- Coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/coverage/"
+                    has_links=true
+                  fi
+
+                  if [ "${METRICS_GENERATED}" = 'true' ]; then
+                    echo "- Metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/metrics/"
+                    has_links=true
+                  fi
+
+                  echo 'EOF'
+                  echo "has_links=$has_links"
+                } >> "$GITHUB_OUTPUT"
+
             - name: Comment preview URLs on pull request
+              if: steps.build_comment.outputs.has_links == 'true'
               uses: marocchino/sticky-pull-request-comment@v3
               with:
                 header: pr-preview
-                message: |
-                  🚀 Preview is available for this pull request.
-
-                  - Docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/
-                  - Coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/coverage/
-                  - Metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/metrics/
+                message: ${{ steps.build_comment.outputs.message }}
 
     cleanup_preview:
         if: github.event_name == 'pull_request' && github.event.action == 'closed'
@@ -313,6 +437,9 @@ jobs:
 
             - id: build_summary
               env:
+                COVERAGE_GENERATED: ${{ needs.reports.outputs.coverage_generated }}
+                DOCS_GENERATED: ${{ needs.reports.outputs.docs_generated }}
+                METRICS_GENERATED: ${{ needs.reports.outputs.metrics_generated }}
                 TRIGGER_LABEL: ${{ github.event_name }}${{ github.event.action && format(':{0}', github.event.action) || '' }}
               run: |
                 {
@@ -329,16 +456,28 @@ jobs:
                   echo "- Trigger: \`${TRIGGER_LABEL}\`"
 
                   if [ "${{ github.event_name }}" = "push" ] || { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.cleanup-previews }}" != "true" ]; }; then
-                    echo "- Docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
-                    echo "- Coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/"
-                    echo "- Metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/metrics/"
+                    if [ "${DOCS_GENERATED}" = 'true' ]; then
+                      echo "- Docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+                    fi
+                    if [ "${COVERAGE_GENERATED}" = 'true' ]; then
+                      echo "- Coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/"
+                    fi
+                    if [ "${METRICS_GENERATED}" = 'true' ]; then
+                      echo "- Metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/metrics/"
+                    fi
                     echo "- Deployment verification: \`${{ needs.verify_main_reports.result }}\`"
                   fi
 
                   if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.action }}" != "closed" ]; then
-                    echo "- Preview docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/"
-                    echo "- Preview coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/coverage/"
-                    echo "- Preview metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/metrics/"
+                    if [ "${DOCS_GENERATED}" = 'true' ]; then
+                      echo "- Preview docs: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/"
+                    fi
+                    if [ "${COVERAGE_GENERATED}" = 'true' ]; then
+                      echo "- Preview coverage: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/coverage/"
+                    fi
+                    if [ "${METRICS_GENERATED}" = 'true' ]; then
+                      echo "- Preview metrics: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/metrics/"
+                    fi
                     echo "- Preview verification: \`${{ needs.verify_preview_reports.result }}\`"
                   fi
 

--- a/.github/workflows/wiki-maintenance.yml
+++ b/.github/workflows/wiki-maintenance.yml
@@ -39,12 +39,23 @@ jobs:
           sparse-checkout: |
             .github/actions
 
+      - name: Detect wiki repository
+        id: detect_wiki
+        run: |
+          if [ -e .github/wiki ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Mark workspace as safe for git
+        if: steps.detect_wiki.outputs.exists == 'true'
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Prepare wiki publish branch from preview branch
+        if: steps.detect_wiki.outputs.exists == 'true'
         id: prepare_publish
         uses: ./.dev-tools-actions/.github/actions/wiki/prepare-publish-branch
         with:
@@ -52,10 +63,12 @@ jobs:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
 
       - name: Push wiki publish branch
+        if: steps.detect_wiki.outputs.exists == 'true'
         working-directory: .github/wiki
         run: git push --force-with-lease origin HEAD:"${WIKI_PUBLISH_BRANCH}"
 
       - name: Validate wiki publish branch
+        if: steps.detect_wiki.outputs.exists == 'true'
         uses: ./.dev-tools-actions/.github/actions/wiki/validate-publish-branch
         with:
           publish-branch: ${{ env.WIKI_PUBLISH_BRANCH }}
@@ -63,6 +76,7 @@ jobs:
           expected-preview-sha: ${{ steps.prepare_publish.outputs.expected-preview-sha }}
 
       - name: Delete wiki preview branch
+        if: steps.detect_wiki.outputs.exists == 'true'
         uses: ./.dev-tools-actions/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
@@ -74,9 +88,10 @@ jobs:
 
             - Publish branch: `${{ env.WIKI_PUBLISH_BRANCH }}`
             - Preview branch: `${{ env.WIKI_PREVIEW_BRANCH }}`
-            - Expected preview SHA: `${{ steps.prepare_publish.outputs.expected-preview-sha }}`
-            - Publish validation: completed
-            - Preview cleanup: `${{ env.WIKI_PREVIEW_BRANCH }}` deleted
+            - Wiki repository detected: `${{ steps.detect_wiki.outputs.exists }}`
+            - Expected preview SHA: `${{ steps.detect_wiki.outputs.exists == 'true' && steps.prepare_publish.outputs.expected-preview-sha || 'skipped' }}`
+            - Publish validation: `${{ steps.detect_wiki.outputs.exists == 'true' && 'completed' || 'skipped' }}`
+            - Preview cleanup: `${{ steps.detect_wiki.outputs.exists == 'true' && format('{0} deleted', env.WIKI_PREVIEW_BRANCH) || 'skipped' }}`
 
   cleanup_closed_preview:
     name: Delete Closed PR Wiki Preview
@@ -105,10 +120,21 @@ jobs:
           sparse-checkout: |
             .github/actions
 
+      - name: Detect wiki repository
+        id: detect_wiki
+        run: |
+          if [ -e .github/wiki ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Mark wiki workspace as safe for git
+        if: steps.detect_wiki.outputs.exists == 'true'
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki preview branch
+        if: steps.detect_wiki.outputs.exists == 'true'
         uses: ./.dev-tools-actions/.github/actions/wiki/delete-preview-branch
         with:
           preview-branch: ${{ env.WIKI_PREVIEW_BRANCH }}
@@ -118,8 +144,9 @@ jobs:
           markdown: |
             ## Wiki Preview Cleanup Summary
 
-            - Deleted preview branch: `${{ env.WIKI_PREVIEW_BRANCH }}`
-            - Trigger: closed pull request without merge
+            - Wiki repository detected: `${{ steps.detect_wiki.outputs.exists }}`
+            - Deleted preview branch: `${{ steps.detect_wiki.outputs.exists == 'true' && env.WIKI_PREVIEW_BRANCH || 'skipped' }}`
+            - Trigger: `${{ steps.detect_wiki.outputs.exists == 'true' && 'closed pull request without merge' || 'wiki repository not present' }}`
 
   cleanup_orphaned_previews:
     name: Delete Orphaned Wiki Previews
@@ -146,10 +173,21 @@ jobs:
           sparse-checkout: |
             .github/actions
 
+      - name: Detect wiki repository
+        id: detect_wiki
+        run: |
+          if [ -e .github/wiki ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Mark wiki workspace as safe for git
+        if: steps.detect_wiki.outputs.exists == 'true'
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE/.github/wiki"
 
       - name: Delete wiki branches for closed pull requests
+        if: steps.detect_wiki.outputs.exists == 'true'
         id: cleanup
         uses: ./.dev-tools-actions/.github/actions/wiki/cleanup-orphaned-previews
 
@@ -158,6 +196,7 @@ jobs:
           markdown: |
             ## Wiki Orphan Cleanup Summary
 
-            - Deleted preview branches: `${{ steps.cleanup.outputs.deleted || '0' }}`
-            - Retained preview branches: `${{ steps.cleanup.outputs.skipped || '0' }}`
-            - Unresolved preview branches: `${{ steps.cleanup.outputs.unresolved || '0' }}`
+            - Wiki repository detected: `${{ steps.detect_wiki.outputs.exists }}`
+            - Deleted preview branches: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.cleanup.outputs.deleted || '0') || '0' }}`
+            - Retained preview branches: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.cleanup.outputs.skipped || '0') || '0' }}`
+            - Unresolved preview branches: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.cleanup.outputs.unresolved || '0') || '0' }}`

--- a/.github/workflows/wiki-preview.yml
+++ b/.github/workflows/wiki-preview.yml
@@ -61,7 +61,17 @@ jobs:
           ref: ${{ github.repository == 'php-fast-forward/dev-tools' && (github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha) || 'main' }}
           path: .dev-tools-actions
 
+      - name: Detect wiki repository
+        id: detect_wiki
+        run: |
+          if [ -e .github/wiki ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup PHP and install dependencies
+        if: steps.detect_wiki.outputs.exists == 'true'
         uses: ./.dev-tools-actions/.github/actions/php/setup-composer
         with:
           php-version: ${{ needs.resolve_php.outputs.php-version }}
@@ -70,6 +80,7 @@ jobs:
             ${{ github.workspace }}/.github/wiki
 
       - name: Refresh wiki preview pointer
+        if: steps.detect_wiki.outputs.exists == 'true'
         id: refresh_preview
         env:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.pull_request.head.ref }}
@@ -79,7 +90,7 @@ jobs:
           commit-message: Update wiki docs for PR #${{ github.event.pull_request.number }}
 
       - name: Commit parent repo submodule pointer
-        if: steps.refresh_preview.outputs.pointer-changed == 'true'
+        if: steps.detect_wiki.outputs.exists == 'true' && steps.refresh_preview.outputs.pointer-changed == 'true'
         id: parent_commit
         uses: EndBug/add-and-commit@v10
         with:
@@ -90,7 +101,7 @@ jobs:
           push: true
 
       - name: Dispatch tests for wiki pointer commit
-        if: steps.refresh_preview.outputs.pointer-changed == 'true'
+        if: steps.detect_wiki.outputs.exists == 'true' && steps.refresh_preview.outputs.pointer-changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -102,7 +113,8 @@ jobs:
             ## Wiki Preview Summary
 
             - Preview branch: `${{ env.WIKI_PREVIEW_BRANCH }}`
-            - Preview refresh: `${{ steps.refresh_preview.outputs.published == 'true' && 'published' || 'unchanged' }}`
-            - Submodule pointer changed: `${{ steps.refresh_preview.outputs.pointer-changed }}`
-            - Parent repository pointer commit result: `${{ steps.refresh_preview.outputs.pointer-changed == 'true' && 'updated' || 'unchanged' }}`
-            - Tests dispatch result: `${{ steps.refresh_preview.outputs.pointer-changed == 'true' && 'requested' || 'not needed' }}`
+            - Wiki repository detected: `${{ steps.detect_wiki.outputs.exists }}`
+            - Preview refresh: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.refresh_preview.outputs.published == 'true' && 'published' || 'unchanged') || 'skipped' }}`
+            - Submodule pointer changed: `${{ steps.detect_wiki.outputs.exists == 'true' && steps.refresh_preview.outputs.pointer-changed || 'false' }}`
+            - Parent repository pointer commit result: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.refresh_preview.outputs.pointer-changed == 'true' && 'updated' || 'unchanged') || 'skipped' }}`
+            - Tests dispatch result: `${{ steps.detect_wiki.outputs.exists == 'true' && (steps.refresh_preview.outputs.pointer-changed == 'true' && 'requested' || 'not needed') || 'skipped' }}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Let `wiki`, `docs`, `tests`, `metrics`, and `reports` skip gracefully for guide-only repositories while keeping wiki/report workflows and published preview links aligned with the artifacts that were actually generated (#325)
+
 ## [1.25.0] - 2026-05-01
 
 ### Changed

--- a/resources/phpdocumentor.xml
+++ b/resources/phpdocumentor.xml
@@ -14,9 +14,10 @@
     </paths>
 
     <version number="latest">
+{% if apiDirectories is not empty %}
         <api>
             <source dsn="{{ workingDirectory }}">
-{% for path in paths %}
+{% for path in apiDirectories %}
                 <path>{{ path }}</path>
 {% endfor %}
             </source>
@@ -29,13 +30,18 @@
             <extensions>
                 <extension>php</extension>
             </extensions>
+{% if defaultPackageName %}
             <default-package-name>{{ defaultPackageName }}</default-package-name>
+{% endif %}
         </api>
+{% endif %}
+{% if guidePath %}
         <guide>
             <source dsn="{{ workingDirectory }}">
                 <path>{{ guidePath }}</path>
             </source>
             <output>.</output>
         </guide>
+{% endif %}
     </version>
 </phpdocumentor>

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -161,7 +161,7 @@ final class DocsCommand extends Command
 
         if (
             ! $projectCapabilities->hasGuideDirectory()
-            && ProjectCapabilitiesResolverInterface::DEFAULT_GUIDE_DIRECTORY !== $sourceOption
+            && ! $this->isDefaultGuideSource($sourceOption)
         ) {
             return $this->failure('Source directory not found: {source}', $input, [
                 'source' => $source,
@@ -252,5 +252,37 @@ final class DocsCommand extends Command
         $this->filesystem->dumpFile(filename: 'phpdocumentor.xml', content: $content, path: $cacheDir);
 
         return $this->filesystem->getAbsolutePath('phpdocumentor.xml', $cacheDir);
+    }
+
+    /**
+     * Detects whether a source option still points at the default guide directory.
+     *
+     * @param string $sourceOption the guide source option received from the CLI
+     *
+     * @return bool true when the provided path is equivalent to the default guide directory
+     */
+    private function isDefaultGuideSource(string $sourceOption): bool
+    {
+        return $this->normalizeProjectRelativePath($sourceOption) === $this->normalizeProjectRelativePath(
+            ProjectCapabilitiesResolverInterface::DEFAULT_GUIDE_DIRECTORY
+        );
+    }
+
+    /**
+     * Normalizes a project-relative path for resilient default-option comparisons.
+     *
+     * @param string $path the project-relative path to normalize
+     *
+     * @return string the normalized project-relative path
+     */
+    private function normalizeProjectRelativePath(string $path): string
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        while (str_starts_with($normalizedPath, './')) {
+            $normalizedPath = substr($normalizedPath, 2);
+        }
+
+        return rtrim($normalizedPath, '/');
     }
 }

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -29,7 +29,10 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -71,6 +74,7 @@ final class DocsCommand extends Command
      * @param Environment $renderer
      * @param FilesystemInterface $filesystem the filesystem for handling file operations
      * @param ComposerJsonInterface $composer the composer.json handler for accessing project metadata
+     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
      * @param LoggerInterface $logger the output-aware logger
      */
     public function __construct(
@@ -79,6 +83,7 @@ final class DocsCommand extends Command
         private readonly Environment $renderer,
         private readonly FilesystemInterface $filesystem,
         private readonly ComposerJsonInterface $composer,
+        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -114,7 +119,7 @@ final class DocsCommand extends Command
                 shortcut: 's',
                 mode: InputOption::VALUE_OPTIONAL,
                 description: 'Path to the source directory for the generated HTML documentation.',
-                default: 'docs',
+                default: ProjectCapabilitiesResolverInterface::DEFAULT_GUIDE_DIRECTORY,
             )
             ->addOption(
                 name: 'template',
@@ -143,6 +148,9 @@ final class DocsCommand extends Command
         $target = $this->filesystem->getAbsolutePath($input->getOption('target'));
         $cacheDir = $this->filesystem->getAbsolutePath($input->getOption('cache-dir'));
         $template = (string) $input->getOption('template');
+        $projectCapabilities = $this->projectCapabilitiesResolver->resolve(
+            guideDirectory: (string) $input->getOption('source'),
+        );
 
         if (self::DEFAULT_TEMPLATE === $template) {
             $template = DevToolsPathResolver::getPreferredVendorPath(self::DEFAULT_TEMPLATE);
@@ -152,10 +160,13 @@ final class DocsCommand extends Command
             'input' => $input,
         ]);
 
-        if (! $this->filesystem->exists($source)) {
-            return $this->failure('Source directory not found: {source}', $input, [
-                'source' => $source,
-            ]);
+        if (! $projectCapabilities->canGenerateDocs()) {
+            return $this->success(
+                'Skipping API documentation generation because no guide source or autoloaded PHP API directories were detected.',
+                $input,
+                [],
+                LogLevel::WARNING,
+            );
         }
 
         $config = $this->createPhpDocumentorConfig(
@@ -163,6 +174,7 @@ final class DocsCommand extends Command
             target: $target,
             template: $template,
             cacheDir: $cacheEnabled ? $cacheDir : sys_get_temp_dir(),
+            projectCapabilities: $projectCapabilities,
         );
 
         $processBuilder = $this->processBuilder
@@ -202,6 +214,7 @@ final class DocsCommand extends Command
      * @param string $target the output directory for the generated documentation
      * @param string $template the phpDocumentor template name or path
      * @param string $cacheDir the cache directory for phpDocumentor
+     * @param ProjectCapabilities $projectCapabilities the resolved project capability snapshot
      *
      * @return string the absolute path to the generated configuration
      */
@@ -209,12 +222,13 @@ final class DocsCommand extends Command
         string $source,
         string $target,
         string $template,
-        string $cacheDir
+        string $cacheDir,
+        ProjectCapabilities $projectCapabilities,
     ): string {
         $workingDirectory = getcwd();
-        $autoload = $this->composer->getAutoload('psr-4');
-        $guidePath = $this->filesystem->makePathRelative($source);
-        $defaultPackageName = array_key_first($autoload) ?: '';
+        $guidePath = $projectCapabilities->hasGuideDirectory()
+            ? $this->filesystem->makePathRelative($source)
+            : null;
 
         $content = $this->renderer->render('phpdocumentor.xml', [
             'title' => $this->composer->getName(),
@@ -222,9 +236,9 @@ final class DocsCommand extends Command
             'target' => $target,
             'cacheDir' => $cacheDir,
             'workingDirectory' => $workingDirectory,
-            'paths' => $autoload,
+            'apiDirectories' => $projectCapabilities->getApiDirectories(),
             'guidePath' => $guidePath,
-            'defaultPackageName' => rtrim($defaultPackageName, '\\'),
+            'defaultPackageName' => $projectCapabilities->getDefaultPackageName(),
         ]);
 
         $this->filesystem->dumpFile(filename: 'phpdocumentor.xml', content: $content, path: $cacheDir);

--- a/src/Console/Command/DocsCommand.php
+++ b/src/Console/Command/DocsCommand.php
@@ -144,13 +144,12 @@ final class DocsCommand extends Command
         $progress = ! $jsonOutput && (bool) $input->getOption('progress');
         $cacheEnabled = $this->isCacheEnabled($input);
 
-        $source = $this->filesystem->getAbsolutePath($input->getOption('source'));
+        $sourceOption = (string) $input->getOption('source');
+        $source = $this->filesystem->getAbsolutePath($sourceOption);
         $target = $this->filesystem->getAbsolutePath($input->getOption('target'));
         $cacheDir = $this->filesystem->getAbsolutePath($input->getOption('cache-dir'));
         $template = (string) $input->getOption('template');
-        $projectCapabilities = $this->projectCapabilitiesResolver->resolve(
-            guideDirectory: (string) $input->getOption('source'),
-        );
+        $projectCapabilities = $this->projectCapabilitiesResolver->resolve(guideDirectory: $sourceOption);
 
         if (self::DEFAULT_TEMPLATE === $template) {
             $template = DevToolsPathResolver::getPreferredVendorPath(self::DEFAULT_TEMPLATE);
@@ -159,6 +158,15 @@ final class DocsCommand extends Command
         $this->logger->info('Generating API documentation...', [
             'input' => $input,
         ]);
+
+        if (
+            ! $projectCapabilities->hasGuideDirectory()
+            && ProjectCapabilitiesResolverInterface::DEFAULT_GUIDE_DIRECTORY !== $sourceOption
+        ) {
+            return $this->failure('Source directory not found: {source}', $input, [
+                'source' => $source,
+            ]);
+        }
 
         if (! $projectCapabilities->canGenerateDocs()) {
             return $this->success(

--- a/src/Console/Command/MetricsCommand.php
+++ b/src/Console/Command/MetricsCommand.php
@@ -25,9 +25,7 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
-use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -79,13 +77,11 @@ final class MetricsCommand extends Command
     /**
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble the PhpMetrics process
      * @param ProcessQueueInterface $processQueue the queue used to execute the PhpMetrics process
-     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
      * @param LoggerInterface $logger the output-aware logger
      */
     public function __construct(
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
-        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -142,17 +138,6 @@ final class MetricsCommand extends Command
         $this->logger->info('Running code metrics analysis...', [
             'input' => $input,
         ]);
-
-        if (! $this->projectCapabilitiesResolver->resolve()->canGenerateMetrics()) {
-            return $this->success(
-                'Skipping code metrics analysis because no tests directory or PHP source files were detected.',
-                $input,
-                [
-                    'output' => $processOutput,
-                ],
-                LogLevel::WARNING,
-            );
-        }
 
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')

--- a/src/Console/Command/MetricsCommand.php
+++ b/src/Console/Command/MetricsCommand.php
@@ -25,7 +25,9 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -77,11 +79,13 @@ final class MetricsCommand extends Command
     /**
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble the PhpMetrics process
      * @param ProcessQueueInterface $processQueue the queue used to execute the PhpMetrics process
+     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
      * @param LoggerInterface $logger the output-aware logger
      */
     public function __construct(
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
+        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -138,6 +142,17 @@ final class MetricsCommand extends Command
         $this->logger->info('Running code metrics analysis...', [
             'input' => $input,
         ]);
+
+        if (! $this->projectCapabilitiesResolver->resolve()->canGenerateMetrics()) {
+            return $this->success(
+                'Skipping code metrics analysis because no tests directory or PHP source files were detected.',
+                $input,
+                [
+                    'output' => $processOutput,
+                ],
+                LogLevel::WARNING,
+            );
+        }
 
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -177,9 +177,17 @@ final class TestsCommand extends Command
             ]);
         }
 
-        if (! $this->projectCapabilitiesResolver->resolve(
-            testsPath: (string) $input->getArgument('path'),
-        )->canRunTests()) {
+        $testsPath = (string) $input->getArgument('path');
+        $projectCapabilities = $this->projectCapabilitiesResolver->resolve(testsPath: $testsPath);
+
+        if (! $projectCapabilities->hasTestsPath() && ! $this->isDefaultTestsPath($testsPath)) {
+            return $this->failure('Tests path not found: {path}', $input, [
+                'output' => $processOutput,
+                'path' => $this->filesystem->getAbsolutePath($testsPath),
+            ]);
+        }
+
+        if (! $projectCapabilities->canRunTests()) {
             return $this->success(
                 'Skipping PHPUnit tests because no tests directory or PHP source files were detected.',
                 $input,
@@ -281,6 +289,38 @@ final class TestsCommand extends Command
     private function resolvePath(InputInterface $input, string $option): string
     {
         return $this->filesystem->getAbsolutePath($input->getOption($option));
+    }
+
+    /**
+     * Detects whether a tests path option still points at the default project tests directory.
+     *
+     * @param string $testsPath the tests path argument received from the CLI
+     *
+     * @return bool true when the provided path is equivalent to the default tests directory
+     */
+    private function isDefaultTestsPath(string $testsPath): bool
+    {
+        return $this->normalizeProjectRelativePath($testsPath) === $this->normalizeProjectRelativePath(
+            ProjectCapabilitiesResolverInterface::DEFAULT_TESTS_PATH
+        );
+    }
+
+    /**
+     * Normalizes a project-relative path for resilient default-option comparisons.
+     *
+     * @param string $path the project-relative path to normalize
+     *
+     * @return string the normalized project-relative path
+     */
+    private function normalizeProjectRelativePath(string $path): string
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        while (str_starts_with($normalizedPath, './')) {
+            $normalizedPath = substr($normalizedPath, 2);
+        }
+
+        return rtrim($normalizedPath, '/');
     }
 
     /**

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -30,8 +30,10 @@ use FastForward\DevTools\PhpUnit\Coverage\CoverageSummaryLoaderInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use RuntimeException;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -68,6 +70,7 @@ final class TestsCommand extends Command
      * @param FileLocatorInterface $fileLocator the file locator used to resolve PHPUnit configuration
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble the PHPUnit process
      * @param ProcessQueueInterface $processQueue the queue used to execute PHPUnit
+     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
      * @param LoggerInterface $logger the output-aware logger
      */
     public function __construct(
@@ -78,6 +81,7 @@ final class TestsCommand extends Command
         private readonly FileLocatorInterface $fileLocator,
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
+        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -105,7 +109,7 @@ final class TestsCommand extends Command
                 name: 'path',
                 mode: InputArgument::OPTIONAL,
                 description: 'Path to the tests directory.',
-                default: './tests',
+                default: ProjectCapabilitiesResolverInterface::DEFAULT_TESTS_PATH,
             )
             ->addOption(
                 name: 'bootstrap',
@@ -171,6 +175,19 @@ final class TestsCommand extends Command
             return $this->failure($invalidArgumentException->getMessage(), $input, [
                 'output' => $processOutput,
             ]);
+        }
+
+        if (! $this->projectCapabilitiesResolver->resolve(
+            testsPath: (string) $input->getArgument('path'),
+        )->canRunTests()) {
+            return $this->success(
+                'Skipping PHPUnit tests because no tests directory or PHP source files were detected.',
+                $input,
+                [
+                    'output' => $processOutput,
+                ],
+                LogLevel::WARNING,
+            );
         }
 
         $processBuilder = $this->processBuilder

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -133,7 +133,7 @@ final class WikiCommand extends Command
         $jsonOutput = $this->isJsonOutput($input);
         $processOutput = $jsonOutput ? new BufferedOutput() : $output;
         $target = (string) $input->getOption('target');
-        $isDefaultWikiTarget = ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET === $target;
+        $isDefaultWikiTarget = $this->isDefaultWikiTarget($target);
         $cacheEnabled = $this->isCacheEnabled($input);
 
         if ($input->getOption('init')) {
@@ -211,6 +211,38 @@ final class WikiCommand extends Command
             ],
             (string) $input->getOption('target'),
         );
+    }
+
+    /**
+     * Detects whether a target option still points at the default wiki target path.
+     *
+     * @param string $target the wiki target option received from the CLI
+     *
+     * @return bool true when the provided path is equivalent to the default wiki target
+     */
+    private function isDefaultWikiTarget(string $target): bool
+    {
+        return $this->normalizeProjectRelativePath($target) === $this->normalizeProjectRelativePath(
+            ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET
+        );
+    }
+
+    /**
+     * Normalizes a project-relative path for resilient default-option comparisons.
+     *
+     * @param string $path the project-relative path to normalize
+     *
+     * @return string the normalized project-relative path
+     */
+    private function normalizeProjectRelativePath(string $path): string
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        while (str_starts_with($normalizedPath, './')) {
+            $normalizedPath = substr($normalizedPath, 2);
+        }
+
+        return rtrim($normalizedPath, '/');
     }
 
     /**

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -179,7 +179,10 @@ final class WikiCommand extends Command
         }
 
         foreach ($projectCapabilities->getApiDirectories() as $path) {
-            $processBuilder = $processBuilder->withArgument('--directory', $path);
+            $processBuilder = $processBuilder->withArgument(
+                '--directory',
+                $this->filesystem->getAbsolutePath($path)
+            );
         }
 
         if (null !== $defaultPackageName = $projectCapabilities->getDefaultPackageName()) {

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -29,7 +29,9 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -68,6 +70,7 @@ final class WikiCommand extends Command
      * @param ProcessQueueInterface $processQueue
      * @param FilesystemInterface $filesystem the filesystem used to inspect the wiki target
      * @param GitClientInterface $gitClient
+     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
      * @param LoggerInterface $logger the output-aware logger
      */
     public function __construct(
@@ -76,6 +79,7 @@ final class WikiCommand extends Command
         private readonly ComposerJsonInterface $composer,
         private readonly FilesystemInterface $filesystem,
         private readonly GitClientInterface $gitClient,
+        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
@@ -104,7 +108,7 @@ final class WikiCommand extends Command
                 shortcut: 't',
                 mode: InputOption::VALUE_OPTIONAL,
                 description: 'Path to the output directory for the generated Markdown documentation.',
-                default: '.github/wiki'
+                default: ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET,
             )
             ->addOption(
                 name: 'init',
@@ -141,6 +145,28 @@ final class WikiCommand extends Command
             ]);
         }
 
+        $projectCapabilities = $this->projectCapabilitiesResolver->resolve(wikiTarget: $target);
+
+        if (! $projectCapabilities->hasWikiTarget()) {
+            return $this->success(
+                'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
+                $input,
+                [
+                    'target' => $target,
+                ],
+                LogLevel::WARNING,
+            );
+        }
+
+        if (! $projectCapabilities->canGenerateApiDocumentation()) {
+            return $this->success(
+                'Skipping wiki documentation generation because no autoloaded PHP API directories were detected.',
+                $input,
+                [],
+                LogLevel::WARNING,
+            );
+        }
+
         $processBuilder = $this->processBuilder
             ->withArgument('--ansi')
             ->withArgument('--visibility', 'public,protected')
@@ -152,13 +178,11 @@ final class WikiCommand extends Command
             $processBuilder = $processBuilder->withArgument('--cache-folder', $input->getOption('cache-dir'));
         }
 
-        $psr4Namespaces = $this->composer->getAutoload('psr-4');
-
-        foreach ($psr4Namespaces as $path) {
+        foreach ($projectCapabilities->getApiDirectories() as $path) {
             $processBuilder = $processBuilder->withArgument('--directory', $path);
         }
 
-        if ($defaultPackageName = array_key_first($psr4Namespaces)) {
+        if (null !== $defaultPackageName = $projectCapabilities->getDefaultPackageName()) {
             $processBuilder = $processBuilder->withArgument('--defaultpackagename', $defaultPackageName);
         }
 

--- a/src/Console/Command/WikiCommand.php
+++ b/src/Console/Command/WikiCommand.php
@@ -133,6 +133,7 @@ final class WikiCommand extends Command
         $jsonOutput = $this->isJsonOutput($input);
         $processOutput = $jsonOutput ? new BufferedOutput() : $output;
         $target = (string) $input->getOption('target');
+        $isDefaultWikiTarget = ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET === $target;
         $cacheEnabled = $this->isCacheEnabled($input);
 
         if ($input->getOption('init')) {
@@ -147,7 +148,7 @@ final class WikiCommand extends Command
 
         $projectCapabilities = $this->projectCapabilitiesResolver->resolve(wikiTarget: $target);
 
-        if (! $projectCapabilities->hasWikiTarget()) {
+        if ($isDefaultWikiTarget && ! $projectCapabilities->hasWikiTarget()) {
             return $this->success(
                 'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
                 $input,

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -20,8 +20,8 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Console;
 
 use FastForward\DevTools\Console\Command\SelfUpdateCommand;
-use Override;
 use FastForward\DevTools\Environment\EnvironmentInterface;
+use FastForward\DevTools\Environment\RuntimeEnvironmentInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\SelfUpdate\SelfUpdateRunnerInterface;
 use FastForward\DevTools\SelfUpdate\SelfUpdateScopeResolverInterface;
@@ -29,6 +29,7 @@ use FastForward\DevTools\SelfUpdate\VersionCheckNotifierInterface;
 use FastForward\DevTools\SelfUpdate\WorkingDirectorySwitcherInterface;
 use FastForward\DevTools\ServiceProvider\DevToolsServiceProvider;
 use DI\Container;
+use Override;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -81,6 +82,7 @@ final class DevTools extends Application
      * @param SelfUpdateRunnerInterface $selfUpdateRunner runs explicit or automatic self-update flows
      * @param SelfUpdateScopeResolverInterface $selfUpdateScopeResolver resolves whether the active binary is global
      * @param EnvironmentInterface $environment reads environment flags for optional auto-update behavior
+     * @param RuntimeEnvironmentInterface $runtimeEnvironment resolves runtime environment capabilities
      */
     public function __construct(
         CommandLoaderInterface $commandLoader,
@@ -89,6 +91,7 @@ final class DevTools extends Application
         private readonly SelfUpdateRunnerInterface $selfUpdateRunner,
         private readonly SelfUpdateScopeResolverInterface $selfUpdateScopeResolver,
         private readonly EnvironmentInterface $environment,
+        private readonly RuntimeEnvironmentInterface $runtimeEnvironment,
     ) {
         parent::__construct('Fast Forward Dev Tools');
 
@@ -253,6 +256,10 @@ final class DevTools extends Application
      */
     private function shouldRenderLogo(InputInterface $input): bool
     {
+        if ($this->runtimeEnvironment->isAgentPresent()) {
+            return false;
+        }
+
         if ((bool) $input->getParameterOption('--no-logo', null, true)) {
             return false;
         }

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -25,15 +25,21 @@ namespace FastForward\DevTools\Environment;
 final class Environment implements EnvironmentInterface
 {
     /**
-     * Reads an environment variable.
+     * Reads an environment variable or the current environment map.
      *
-     * @param string $name the environment variable name
-     * @param string|null $default the value returned when the variable is not defined
+     * @param string|null $name the environment variable name, or null to read the current environment map
+     * @param string|null $default the value returned when the named variable is not defined
      *
-     * @return string|null the variable value, or the default when it is not defined
+     * @return array<string, string>|string|null the environment map, variable value, or default fallback
      */
-    public function get(string $name, ?string $default = null): ?string
+    public function get(?string $name = null, ?string $default = null): array|string|null
     {
+        if (null === $name) {
+            $environment = getenv();
+
+            return \is_array($environment) ? $environment : [];
+        }
+
         $value = getenv($name);
 
         if (false === $value) {

--- a/src/Environment/EnvironmentInterface.php
+++ b/src/Environment/EnvironmentInterface.php
@@ -25,12 +25,12 @@ namespace FastForward\DevTools\Environment;
 interface EnvironmentInterface
 {
     /**
-     * Reads an environment variable.
+     * Reads an environment variable or, when no name is provided, the current environment map.
      *
-     * @param string $name the environment variable name
-     * @param string|null $default the value returned when the variable is not defined
+     * @param string|null $name the environment variable name, or null to read the current environment map
+     * @param string|null $default the value returned when the named variable is not defined
      *
-     * @return string|null the variable value, or the default when it is not defined
+     * @return array<string, string>|string|null the environment map, variable value, or default fallback
      */
-    public function get(string $name, ?string $default = null): ?string;
+    public function get(?string $name = null, ?string $default = null): array|string|null;
 }

--- a/src/Environment/RuntimeEnvironment.php
+++ b/src/Environment/RuntimeEnvironment.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Environment;
 
+use Ergebnis\AgentDetector\Detector;
+
 /**
  * Resolves common runtime-environment flags used by DevTools integrations.
  */
@@ -26,9 +28,11 @@ final readonly class RuntimeEnvironment implements RuntimeEnvironmentInterface
 {
     /**
      * @param EnvironmentInterface $environment reads raw process environment variables
+     * @param Detector $agentDetector detects known AI-agent environment markers
      */
     public function __construct(
         private EnvironmentInterface $environment,
+        private Detector $agentDetector,
     ) {}
 
     /**
@@ -67,5 +71,19 @@ final readonly class RuntimeEnvironment implements RuntimeEnvironmentInterface
     public function isComposerTestRun(): bool
     {
         return $this->isEnabled('COMPOSER_TESTS_ARE_RUNNING');
+    }
+
+    /**
+     * Returns whether the current process exposes known AI-agent environment markers.
+     */
+    public function isAgentPresent(): bool
+    {
+        $environment = $this->environment->get();
+
+        if (! \is_array($environment)) {
+            return false;
+        }
+
+        return $this->agentDetector->isAgentPresent($environment);
     }
 }

--- a/src/Environment/RuntimeEnvironmentInterface.php
+++ b/src/Environment/RuntimeEnvironmentInterface.php
@@ -47,4 +47,9 @@ interface RuntimeEnvironmentInterface
      * Returns whether the Composer test suite runtime flag is enabled.
      */
     public function isComposerTestRun(): bool;
+
+    /**
+     * Returns whether the current process exposes known AI-agent environment markers.
+     */
+    public function isAgentPresent(): bool;
 }

--- a/src/Project/ProjectCapabilities.php
+++ b/src/Project/ProjectCapabilities.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Project;
+
+/**
+ * Describes the documentation, testing, and wiki surfaces exposed by the current repository.
+ */
+final readonly class ProjectCapabilities
+{
+    /**
+     * @param list<string> $apiDirectories absolute directories that contain autoloaded PHP API source
+     * @param string|null $defaultPackageName the default package name derived from Composer namespaces when available
+     * @param bool $hasGuideDirectory whether the configured guide directory exists
+     * @param bool $hasTestsPath whether the configured tests path exists
+     * @param bool $hasWikiTarget whether the configured wiki target exists
+     * @param bool $hasPhpSourceFiles whether the repository contains PHP source files outside generated/vendor areas
+     */
+    public function __construct(
+        private array $apiDirectories,
+        private ?string $defaultPackageName,
+        private bool $hasGuideDirectory,
+        private bool $hasTestsPath,
+        private bool $hasWikiTarget,
+        private bool $hasPhpSourceFiles,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function getApiDirectories(): array
+    {
+        return $this->apiDirectories;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDefaultPackageName(): ?string
+    {
+        return $this->defaultPackageName;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasGuideDirectory(): bool
+    {
+        return $this->hasGuideDirectory;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTestsPath(): bool
+    {
+        return $this->hasTestsPath;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasWikiTarget(): bool
+    {
+        return $this->hasWikiTarget;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPhpSourceFiles(): bool
+    {
+        return $this->hasPhpSourceFiles;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateApiDocumentation(): bool
+    {
+        return [] !== $this->apiDirectories;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateDocs(): bool
+    {
+        return $this->hasGuideDirectory || $this->canGenerateApiDocumentation();
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateMetrics(): bool
+    {
+        return $this->hasTestsPath || $this->hasPhpSourceFiles;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canGenerateWiki(): bool
+    {
+        return $this->hasWikiTarget && $this->canGenerateApiDocumentation();
+    }
+
+    /**
+     * @return bool
+     */
+    public function canRunTests(): bool
+    {
+        return $this->hasTestsPath || $this->hasPhpSourceFiles;
+    }
+}

--- a/src/Project/ProjectCapabilities.php
+++ b/src/Project/ProjectCapabilities.php
@@ -32,7 +32,7 @@ final readonly class ProjectCapabilities
      * @param bool $hasGuideDirectory whether the configured guide directory exists
      * @param bool $hasTestsPath whether the configured tests path exists
      * @param bool $hasWikiTarget whether the configured wiki target exists
-     * @param bool $hasPhpSourceFiles whether the repository contains PHP source files outside generated/vendor areas
+     * @param bool $hasPhpSourceFiles whether the repository exposes autoloaded PHP source that can be tested
      */
     public function __construct(
         private array $apiDirectories,
@@ -84,7 +84,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * Detects whether the repository exposes PHP source files outside generated and vendor areas.
+     * Detects whether the repository exposes autoloaded PHP source that can be tested.
      */
     public function hasPhpSourceFiles(): bool
     {
@@ -108,11 +108,11 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * Detects whether metrics generation has PHP source or test inputs to analyse.
+     * Detects whether metrics generation can analyse repository history and package metadata.
      */
     public function canGenerateMetrics(): bool
     {
-        return $this->hasTestsPath || $this->hasPhpSourceFiles;
+        return true;
     }
 
     /**

--- a/src/Project/ProjectCapabilities.php
+++ b/src/Project/ProjectCapabilities.php
@@ -20,11 +20,13 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Project;
 
 /**
- * Describes the documentation, testing, and wiki surfaces exposed by the current repository.
+ * Captures which documentation, testing, and wiki surfaces are available for the current repository.
  */
 final readonly class ProjectCapabilities
 {
     /**
+     * Creates a repository capability snapshot for reporting and documentation commands.
+     *
      * @param list<string> $apiDirectories project-relative directories that contain autoloaded PHP API source
      * @param string|null $defaultPackageName the default package name derived from Composer namespaces when available
      * @param bool $hasGuideDirectory whether the configured guide directory exists
@@ -42,7 +44,7 @@ final readonly class ProjectCapabilities
     ) {}
 
     /**
-     * @return list<string>
+     * Returns the project-relative directories that expose autoloaded PHP API source.
      */
     public function getApiDirectories(): array
     {
@@ -50,7 +52,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return string|null
+     * Returns the default API package name when one can be derived from Composer namespaces.
      */
     public function getDefaultPackageName(): ?string
     {
@@ -58,7 +60,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the configured guide directory exists.
      */
     public function hasGuideDirectory(): bool
     {
@@ -66,7 +68,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the configured tests directory exists.
      */
     public function hasTestsPath(): bool
     {
@@ -74,7 +76,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the configured wiki target exists.
      */
     public function hasWikiTarget(): bool
     {
@@ -82,7 +84,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the repository exposes PHP source files outside generated and vendor areas.
      */
     public function hasPhpSourceFiles(): bool
     {
@@ -90,7 +92,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the repository exposes autoloaded PHP API source.
      */
     public function canGenerateApiDocumentation(): bool
     {
@@ -98,7 +100,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the repository can generate guides, API documentation, or both.
      */
     public function canGenerateDocs(): bool
     {
@@ -106,7 +108,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether metrics generation has PHP source or test inputs to analyse.
      */
     public function canGenerateMetrics(): bool
     {
@@ -114,7 +116,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether wiki generation can render API documentation into the configured wiki target.
      */
     public function canGenerateWiki(): bool
     {
@@ -122,7 +124,7 @@ final readonly class ProjectCapabilities
     }
 
     /**
-     * @return bool
+     * Detects whether the repository has enough PHP surface to justify running tests.
      */
     public function canRunTests(): bool
     {

--- a/src/Project/ProjectCapabilities.php
+++ b/src/Project/ProjectCapabilities.php
@@ -25,7 +25,7 @@ namespace FastForward\DevTools\Project;
 final readonly class ProjectCapabilities
 {
     /**
-     * @param list<string> $apiDirectories absolute directories that contain autoloaded PHP API source
+     * @param list<string> $apiDirectories project-relative directories that contain autoloaded PHP API source
      * @param string|null $defaultPackageName the default package name derived from Composer namespaces when available
      * @param bool $hasGuideDirectory whether the configured guide directory exists
      * @param bool $hasTestsPath whether the configured tests path exists

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -25,7 +25,10 @@ use FastForward\DevTools\Filesystem\FilesystemInterface;
 use function array_key_first;
 use function array_values;
 use function is_dir;
+use function is_file;
 use function rtrim;
+use function str_ends_with;
+use function strtolower;
 
 /**
  * Resolves which repository surfaces are available to documentation, testing, and wiki tooling.
@@ -69,7 +72,7 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
             $this->filesystem->exists($guideDirectory),
             $this->filesystem->exists($testsPath),
             $this->filesystem->exists($wikiTarget),
-            [] !== $apiDirectories,
+            $this->resolveHasPhpSourceFiles($apiDirectories),
         );
     }
 
@@ -131,6 +134,34 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
         }
 
         return $this->filesystem->makePathRelative($absolutePath);
+    }
+
+    /**
+     * Resolves whether Composer autoload metadata exposes testable PHP source for the repository.
+     *
+     * @param list<string> $apiDirectories the resolved API directories exposed by Composer autoload metadata
+     */
+    private function resolveHasPhpSourceFiles(array $apiDirectories): bool
+    {
+        if ([] !== $apiDirectories) {
+            return true;
+        }
+
+        foreach (self::API_AUTOLOAD_TYPES as $autoloadType) {
+            foreach ($this->normalizeAutoloadPaths($this->composer->getAutoload($autoloadType)) as $path) {
+                $absolutePath = $this->filesystem->getAbsolutePath($path);
+
+                if (! \is_string($absolutePath)) {
+                    continue;
+                }
+
+                if (is_file($absolutePath) && str_ends_with(strtolower($absolutePath), '.php')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -94,21 +94,37 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
 
         foreach (self::API_AUTOLOAD_TYPES as $autoloadType) {
             foreach ($this->normalizeAutoloadPaths($this->composer->getAutoload($autoloadType)) as $path) {
-                $absolutePath = $this->filesystem->getAbsolutePath($path);
+                $relativePath = $this->resolveRelativeApiDirectory($path);
 
-                if (! \is_string($absolutePath)) {
+                if (null === $relativePath) {
                     continue;
                 }
 
-                if (! is_dir($absolutePath)) {
-                    continue;
-                }
-
-                $directories[$absolutePath] = $absolutePath;
+                $directories[$relativePath] = $relativePath;
             }
         }
 
         return array_values($directories);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return string|null
+     */
+    private function resolveRelativeApiDirectory(string $path): ?string
+    {
+        $absolutePath = $this->filesystem->getAbsolutePath($path);
+
+        if (! \is_string($absolutePath)) {
+            return null;
+        }
+
+        if (! is_dir($absolutePath)) {
+            return null;
+        }
+
+        return $this->filesystem->makePathRelative($absolutePath);
     }
 
     /**

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -39,8 +39,10 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     private const array API_AUTOLOAD_TYPES = ['psr-4', 'psr-0', 'classmap'];
 
     /**
-     * @param ComposerJsonInterface $composer
-     * @param FilesystemInterface $filesystem
+     * Creates a capability resolver backed by Composer autoload metadata and filesystem checks.
+     *
+     * @param ComposerJsonInterface $composer the composer.json accessor for autoload metadata
+     * @param FilesystemInterface $filesystem the filesystem used to resolve project-relative paths
      */
     public function __construct(
         private ComposerJsonInterface $composer,
@@ -48,11 +50,11 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     ) {}
 
     /**
-     * @param string $testsPath
-     * @param string $guideDirectory
-     * @param string $wikiTarget
+     * Resolves which documentation, testing, and wiki surfaces are available for the current repository.
      *
-     * @return ProjectCapabilities
+     * @param string $testsPath the project-relative tests directory to inspect
+     * @param string $guideDirectory the project-relative guide directory to inspect
+     * @param string $wikiTarget the project-relative wiki output target to inspect
      */
     public function resolve(
         string $testsPath = ProjectCapabilitiesResolverInterface::DEFAULT_TESTS_PATH,
@@ -72,7 +74,9 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     }
 
     /**
-     * @param array<string, mixed> $psr4Autoload
+     * Resolves the default API package name from the first PSR-4 namespace entry when available.
+     *
+     * @param array<string, mixed> $psr4Autoload the PSR-4 autoload map from composer.json
      */
     private function resolveDefaultPackageName(array $psr4Autoload): ?string
     {
@@ -86,6 +90,8 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     }
 
     /**
+     * Resolves project-relative API directories exposed by Composer autoload configuration.
+     *
      * @return list<string>
      */
     private function resolveApiDirectories(): array
@@ -108,9 +114,9 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     }
 
     /**
-     * @param string $path
+     * Resolves a Composer autoload path into a project-relative API directory when it exists.
      *
-     * @return string|null
+     * @param string $path the Composer autoload path candidate
      */
     private function resolveRelativeApiDirectory(string $path): ?string
     {
@@ -128,7 +134,9 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
     }
 
     /**
-     * @param array<string, mixed> $autoload
+     * Flattens Composer autoload path definitions into a normalized list of non-empty paths.
+     *
+     * @param array<string, mixed> $autoload the Composer autoload section to normalize
      *
      * @return list<string>
      */

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -21,7 +21,6 @@ namespace FastForward\DevTools\Project;
 
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
-use FastForward\DevTools\Path\WorkingProjectPathResolver;
 
 use function array_key_first;
 use function array_values;
@@ -62,14 +61,15 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
         string $wikiTarget = ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET,
     ): ProjectCapabilities {
         $psr4Autoload = $this->composer->getAutoload('psr-4');
+        $apiDirectories = $this->resolveApiDirectories();
 
         return new ProjectCapabilities(
-            $this->resolveApiDirectories(),
+            $apiDirectories,
             $this->resolveDefaultPackageName($psr4Autoload),
             $this->filesystem->exists($guideDirectory),
             $this->filesystem->exists($testsPath),
             $this->filesystem->exists($wikiTarget),
-            [] !== WorkingProjectPathResolver::getToolingSourcePaths(),
+            [] !== $apiDirectories,
         );
     }
 

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Project;
+
+use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
+use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
+
+use function array_key_first;
+use function array_values;
+use function is_dir;
+use function rtrim;
+
+/**
+ * Resolves which repository surfaces are available to documentation, testing, and wiki tooling.
+ */
+final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesResolverInterface
+{
+    /**
+     * @var list<string> Composer autoload sections that MAY expose API source directories
+     */
+    private const array API_AUTOLOAD_TYPES = ['psr-4', 'psr-0', 'classmap'];
+
+    /**
+     * @param ComposerJsonInterface $composer
+     * @param FilesystemInterface $filesystem
+     */
+    public function __construct(
+        private ComposerJsonInterface $composer,
+        private FilesystemInterface $filesystem,
+    ) {}
+
+    /**
+     * @param string $testsPath
+     * @param string $guideDirectory
+     * @param string $wikiTarget
+     *
+     * @return ProjectCapabilities
+     */
+    public function resolve(
+        string $testsPath = ProjectCapabilitiesResolverInterface::DEFAULT_TESTS_PATH,
+        string $guideDirectory = ProjectCapabilitiesResolverInterface::DEFAULT_GUIDE_DIRECTORY,
+        string $wikiTarget = ProjectCapabilitiesResolverInterface::DEFAULT_WIKI_TARGET,
+    ): ProjectCapabilities {
+        $psr4Autoload = $this->composer->getAutoload('psr-4');
+
+        return new ProjectCapabilities(
+            $this->resolveApiDirectories(),
+            $this->resolveDefaultPackageName($psr4Autoload),
+            $this->filesystem->exists($guideDirectory),
+            $this->filesystem->exists($testsPath),
+            $this->filesystem->exists($wikiTarget),
+            [] !== WorkingProjectPathResolver::getToolingSourcePaths(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $psr4Autoload
+     */
+    private function resolveDefaultPackageName(array $psr4Autoload): ?string
+    {
+        $defaultPackageName = array_key_first($psr4Autoload);
+
+        if (! \is_string($defaultPackageName) || '' === $defaultPackageName) {
+            return null;
+        }
+
+        return rtrim($defaultPackageName, '\\');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveApiDirectories(): array
+    {
+        $directories = [];
+
+        foreach (self::API_AUTOLOAD_TYPES as $autoloadType) {
+            foreach ($this->normalizeAutoloadPaths($this->composer->getAutoload($autoloadType)) as $path) {
+                $absolutePath = $this->filesystem->getAbsolutePath($path);
+
+                if (! \is_string($absolutePath)) {
+                    continue;
+                }
+
+                if (! is_dir($absolutePath)) {
+                    continue;
+                }
+
+                $directories[$absolutePath] = $absolutePath;
+            }
+        }
+
+        return array_values($directories);
+    }
+
+    /**
+     * @param array<string, mixed> $autoload
+     *
+     * @return list<string>
+     */
+    private function normalizeAutoloadPaths(array $autoload): array
+    {
+        $paths = [];
+
+        foreach ($autoload as $path) {
+            if (\is_string($path) && '' !== $path) {
+                $paths[] = $path;
+
+                continue;
+            }
+
+            if (! \is_array($path)) {
+                continue;
+            }
+
+            foreach ($path as $nestedPath) {
+                if (! \is_string($nestedPath)) {
+                    continue;
+                }
+
+                if ('' === $nestedPath) {
+                    continue;
+                }
+
+                $paths[] = $nestedPath;
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/src/Project/ProjectCapabilitiesResolverInterface.php
+++ b/src/Project/ProjectCapabilitiesResolverInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Project;
+
+/**
+ * Resolves the effective documentation, testing, and wiki capabilities of the current repository.
+ */
+interface ProjectCapabilitiesResolverInterface
+{
+    public const string DEFAULT_TESTS_PATH = './tests';
+
+    public const string DEFAULT_GUIDE_DIRECTORY = 'docs';
+
+    public const string DEFAULT_WIKI_TARGET = '.github/wiki';
+
+    /**
+     * @param string $testsPath
+     * @param string $guideDirectory
+     * @param string $wikiTarget
+     *
+     * @return ProjectCapabilities
+     */
+    public function resolve(
+        string $testsPath = self::DEFAULT_TESTS_PATH,
+        string $guideDirectory = self::DEFAULT_GUIDE_DIRECTORY,
+        string $wikiTarget = self::DEFAULT_WIKI_TARGET,
+    ): ProjectCapabilities;
+}

--- a/src/Project/ProjectCapabilitiesResolverInterface.php
+++ b/src/Project/ProjectCapabilitiesResolverInterface.php
@@ -24,18 +24,27 @@ namespace FastForward\DevTools\Project;
  */
 interface ProjectCapabilitiesResolverInterface
 {
+    /**
+     * @var string the default project-relative test directory checked by repository capability discovery
+     */
     public const string DEFAULT_TESTS_PATH = './tests';
 
+    /**
+     * @var string the default project-relative guide directory checked by repository capability discovery
+     */
     public const string DEFAULT_GUIDE_DIRECTORY = 'docs';
 
+    /**
+     * @var string the default project-relative wiki target used for generated API wiki output
+     */
     public const string DEFAULT_WIKI_TARGET = '.github/wiki';
 
     /**
-     * @param string $testsPath
-     * @param string $guideDirectory
-     * @param string $wikiTarget
+     * Resolves which documentation, testing, and wiki surfaces are available for the current repository.
      *
-     * @return ProjectCapabilities
+     * @param string $testsPath the project-relative tests directory to inspect
+     * @param string $guideDirectory the project-relative guide directory to inspect
+     * @param string $wikiTarget the project-relative wiki output target to inspect
      */
     public function resolve(
         string $testsPath = self::DEFAULT_TESTS_PATH,

--- a/src/ServiceProvider/DevToolsServiceProvider.php
+++ b/src/ServiceProvider/DevToolsServiceProvider.php
@@ -85,6 +85,8 @@ use FastForward\DevTools\Process\ProcessEnvironmentConfiguratorInterface;
 use FastForward\DevTools\Process\ProcessQueue;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Process\XdebugDisablingProcessEnvironmentConfigurator;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolver;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\SelfUpdate\ComposerSelfUpdateRunner;
 use FastForward\DevTools\SelfUpdate\ComposerSelfUpdateScopeResolver;
 use FastForward\DevTools\SelfUpdate\ComposerVersionChecker;
@@ -160,6 +162,9 @@ final class DevToolsServiceProvider implements ServiceProviderInterface
 
             // Composer
             ComposerJsonInterface::class => get(ComposerJson::class),
+
+            // Project
+            ProjectCapabilitiesResolverInterface::class => get(ProjectCapabilitiesResolver::class),
 
             // Changelog
             ChangelogManagerInterface::class => get(ChangelogManager::class),

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -32,6 +32,7 @@ use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
@@ -216,6 +217,43 @@ final class DocsCommandTest extends TestCase
         )->shouldBeCalled();
 
         self::assertSame(DocsCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    #[TestWith(['./docs'])]
+    #[TestWith(['docs/'])]
+    public function executeWillTreatEquivalentDefaultGuideSourcesAsDefault(string $sourceOption): void
+    {
+        $this->input->getOption('source')
+            ->willReturn($sourceOption);
+        $this->filesystem->getAbsolutePath($sourceOption)
+            ->willReturn('/repo/docs');
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities(['src/'], 'FastForward\\DevTools', false, false, false, true));
+        $this->filesystem->dumpFile('phpdocumentor.xml', '<phpdocumentor />', '/repo/.dev-tools/cache/phpdoc')
+            ->shouldBeCalled();
+        $this->processQueue->add($this->process->reveal(), Argument::cetera())
+            ->shouldBeCalled();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(DocsCommand::SUCCESS)
+            ->shouldBeCalled();
+        $this->logger->info('Generating API documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))
+            ->shouldBeCalled();
+        $this->logger->log(
+            'info',
+            'API documentation generated successfully.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface),
+        )->shouldBeCalled();
+        $this->logger->error(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        self::assertSame(DocsCommand::SUCCESS, $this->executeCommand());
     }
 
     /**

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -27,6 +27,8 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -47,6 +49,7 @@ use Twig\Environment;
 #[CoversClass(DocsCommand::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(ProjectCapabilities::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class DocsCommandTest extends TestCase
@@ -62,6 +65,8 @@ final class DocsCommandTest extends TestCase
     private ObjectProphecy $filesystem;
 
     private ObjectProphecy $composer;
+
+    private ObjectProphecy $projectCapabilitiesResolver;
 
     private ObjectProphecy $logger;
 
@@ -83,6 +88,7 @@ final class DocsCommandTest extends TestCase
         $this->renderer = $this->prophesize(Environment::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->composer = $this->prophesize(ComposerJsonInterface::class);
+        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -126,6 +132,15 @@ final class DocsCommandTest extends TestCase
             ->willReturn('docs');
         $this->filesystem->exists('/repo/docs')
             ->willReturn(true);
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities(
+                ['/repo/src'],
+                'FastForward\\DevTools',
+                true,
+                false,
+                false,
+                true,
+            ));
         $this->composer->getAutoload('psr-4')
             ->willReturn([
                 'FastForward\\DevTools\\' => 'src/',
@@ -139,7 +154,8 @@ final class DocsCommandTest extends TestCase
                     'vendor/fast-forward/phpdoc-bootstrap-template'
                 ) === $context['template']
             )
-        )->willReturn('<phpdocumentor />');
+        )
+            ->willReturn('<phpdocumentor />');
         $this->processBuilder->withArgument(Argument::any())->willReturn($this->processBuilder->reveal());
         $this->processBuilder->withArgument(Argument::any(), Argument::any())->willReturn(
             $this->processBuilder->reveal()
@@ -153,6 +169,7 @@ final class DocsCommandTest extends TestCase
             $this->renderer->reveal(),
             $this->filesystem->reveal(),
             $this->composer->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
     }
@@ -161,21 +178,23 @@ final class DocsCommandTest extends TestCase
      * @return void
      */
     #[Test]
-    public function executeWillFailWhenSourceDirectoryIsMissing(): void
+    public function executeWillSkipWhenGuideAndApiSourcesAreMissing(): void
     {
-        $this->filesystem->exists('/repo/docs')
-            ->willReturn(false);
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
         $this->logger->info('Generating API documentation...', Argument::that(
             static fn(array $context): bool => $context['input'] instanceof InputInterface
         ))
             ->shouldBeCalled();
-        $this->logger->error(
-            'Source directory not found: {source}',
-            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
-                && '/repo/docs' === $context['source']),
+        $this->logger->log(
+            'warning',
+            'Skipping API documentation generation because no guide source or autoloaded PHP API directories were detected.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface),
         )->shouldBeCalled();
 
-        self::assertSame(DocsCommand::FAILURE, $this->executeCommand());
+        self::assertSame(DocsCommand::SUCCESS, $this->executeCommand());
     }
 
     /**
@@ -220,6 +239,35 @@ final class DocsCommandTest extends TestCase
             ->shouldBeCalled();
         $this->processBuilder->withArgument('--cache-folder', Argument::cetera())
             ->shouldNotBeCalled();
+        $this->processQueue->add($this->process->reveal(), Argument::cetera())
+            ->shouldBeCalled();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(DocsCommand::SUCCESS)
+            ->shouldBeCalled();
+
+        self::assertSame(DocsCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillGenerateGuideOnlyDocumentationWhenNoApiSourceIsDetected(): void
+    {
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, true, false, false, false));
+        $this->renderer->render(
+            'phpdocumentor.xml',
+            Argument::that(
+                static fn(array $context): bool => [] === $context['apiDirectories']
+                    && 'docs' === $context['guidePath']
+                    && null === $context['defaultPackageName']
+            )
+        )
+            ->willReturn('<phpdocumentor />')
+            ->shouldBeCalled();
+        $this->filesystem->dumpFile('phpdocumentor.xml', '<phpdocumentor />', '/repo/.dev-tools/cache/phpdoc')
+            ->shouldBeCalled();
         $this->processQueue->add($this->process->reveal(), Argument::cetera())
             ->shouldBeCalled();
         $this->processQueue->run($this->output->reveal())

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -133,14 +133,7 @@ final class DocsCommandTest extends TestCase
         $this->filesystem->exists('/repo/docs')
             ->willReturn(true);
         $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
-            ->willReturn(new ProjectCapabilities(
-                ['/repo/src'],
-                'FastForward\\DevTools',
-                true,
-                false,
-                false,
-                true,
-            ));
+            ->willReturn(new ProjectCapabilities(['src/'], 'FastForward\\DevTools', true, false, false, true));
         $this->composer->getAutoload('psr-4')
             ->willReturn([
                 'FastForward\\DevTools\\' => 'src/',
@@ -153,6 +146,7 @@ final class DocsCommandTest extends TestCase
                 static fn(array $context): bool => DevToolsPathResolver::getPreferredVendorPath(
                     'vendor/fast-forward/phpdoc-bootstrap-template'
                 ) === $context['template']
+                    && ['src/'] === $context['apiDirectories']
             )
         )
             ->willReturn('<phpdocumentor />');
@@ -208,14 +202,7 @@ final class DocsCommandTest extends TestCase
         $this->filesystem->getAbsolutePath('missing-guides')
             ->willReturn('/repo/missing-guides');
         $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
-            ->willReturn(new ProjectCapabilities(
-                ['/repo/src'],
-                'FastForward\\DevTools',
-                false,
-                false,
-                false,
-                true,
-            ));
+            ->willReturn(new ProjectCapabilities(['src/'], 'FastForward\\DevTools', false, false, false, true));
         $this->processQueue->add(Argument::cetera())
             ->shouldNotBeCalled();
         $this->logger->info('Generating API documentation...', Argument::that(

--- a/tests/Console/Command/DocsCommandTest.php
+++ b/tests/Console/Command/DocsCommandTest.php
@@ -201,6 +201,40 @@ final class DocsCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function executeWillFailWhenCustomGuideSourceDoesNotExist(): void
+    {
+        $this->input->getOption('source')
+            ->willReturn('missing-guides');
+        $this->filesystem->getAbsolutePath('missing-guides')
+            ->willReturn('/repo/missing-guides');
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities(
+                ['/repo/src'],
+                'FastForward\\DevTools',
+                false,
+                false,
+                false,
+                true,
+            ));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->logger->info('Generating API documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))
+            ->shouldBeCalled();
+        $this->logger->error(
+            'Source directory not found: {source}',
+            Argument::that(static fn(array $context): bool => '/repo/missing-guides' === $context['source']
+                && $context['input'] instanceof InputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(DocsCommand::FAILURE, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWillReturnSuccessWhenProcessQueueSucceeds(): void
     {
         $this->filesystem->dumpFile('phpdocumentor.xml', '<phpdocumentor />', '/repo/.dev-tools/cache/phpdoc')

--- a/tests/Console/Command/MetricsCommandTest.php
+++ b/tests/Console/Command/MetricsCommandTest.php
@@ -26,6 +26,7 @@ use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
+use FastForward\DevTools\Project\ProjectCapabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/tests/Console/Command/MetricsCommandTest.php
+++ b/tests/Console/Command/MetricsCommandTest.php
@@ -25,8 +25,6 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
-use FastForward\DevTools\Project\ProjectCapabilities;
-use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -43,7 +41,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
-use function Safe\getcwd;
 use function Safe\putenv;
 
 #[CoversClass(MetricsCommand::class)]
@@ -59,8 +56,6 @@ final class MetricsCommandTest extends TestCase
     private ObjectProphecy $processBuilder;
 
     private ObjectProphecy $processQueue;
-
-    private ObjectProphecy $projectCapabilitiesResolver;
 
     private ObjectProphecy $logger;
 
@@ -79,7 +74,6 @@ final class MetricsCommandTest extends TestCase
     {
         $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
-        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -112,19 +106,9 @@ final class MetricsCommandTest extends TestCase
             && '-ddefault_socket_timeout=1' === $command[2]
             && DevToolsPathResolver::getPreferredToolBinaryPath('phpmetrics') === $command[3]))
             ->willReturn($this->process->reveal());
-        $this->projectCapabilitiesResolver->resolve()
-            ->willReturn(new ProjectCapabilities(
-                [getcwd() . '/src'],
-                'FastForward\\DevTools',
-                false,
-                true,
-                false,
-                true,
-            ));
         $this->command = new MetricsCommand(
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),
-            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
     }
@@ -234,7 +218,6 @@ final class MetricsCommandTest extends TestCase
         $command = new MetricsCommand(
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),
-            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
 
@@ -268,18 +251,18 @@ final class MetricsCommandTest extends TestCase
      * @return void
      */
     #[Test]
-    public function executeWillSkipWhenNoTestsOrPhpSourceExist(): void
+    public function executeWillRunEvenWhenNoTestsOrPhpSourceExist(): void
     {
-        $this->projectCapabilitiesResolver->resolve()
-            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
-        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
-        $this->processQueue->run(Argument::cetera())->shouldNotBeCalled();
+        $this->expectProcessQueued();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(MetricsCommand::SUCCESS)
+            ->shouldBeCalled();
         $this->logger->info('Running code metrics analysis...', Argument::that(
             static fn(array $context): bool => $context['input'] instanceof InputInterface
         ))->shouldBeCalled();
         $this->logger->log(
-            'warning',
-            'Skipping code metrics analysis because no tests directory or PHP source files were detected.',
+            'info',
+            'Code metrics analysis completed successfully.',
             Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
                 && $context['output'] instanceof OutputInterface),
         )->shouldBeCalled();

--- a/tests/Console/Command/MetricsCommandTest.php
+++ b/tests/Console/Command/MetricsCommandTest.php
@@ -25,6 +25,8 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -41,11 +43,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+use function Safe\getcwd;
 use function Safe\putenv;
 
 #[CoversClass(MetricsCommand::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(ProjectCapabilities::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class MetricsCommandTest extends TestCase
@@ -55,6 +59,8 @@ final class MetricsCommandTest extends TestCase
     private ObjectProphecy $processBuilder;
 
     private ObjectProphecy $processQueue;
+
+    private ObjectProphecy $projectCapabilitiesResolver;
 
     private ObjectProphecy $logger;
 
@@ -73,6 +79,7 @@ final class MetricsCommandTest extends TestCase
     {
         $this->processBuilder = $this->prophesize(ProcessBuilderInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
+        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -105,9 +112,19 @@ final class MetricsCommandTest extends TestCase
             && '-ddefault_socket_timeout=1' === $command[2]
             && DevToolsPathResolver::getPreferredToolBinaryPath('phpmetrics') === $command[3]))
             ->willReturn($this->process->reveal());
+        $this->projectCapabilitiesResolver->resolve()
+            ->willReturn(new ProjectCapabilities(
+                [getcwd() . '/src'],
+                'FastForward\\DevTools',
+                false,
+                true,
+                false,
+                true,
+            ));
         $this->command = new MetricsCommand(
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
     }
@@ -217,6 +234,7 @@ final class MetricsCommandTest extends TestCase
         $command = new MetricsCommand(
             $this->processBuilder->reveal(),
             $this->processQueue->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
 
@@ -244,5 +262,28 @@ final class MetricsCommandTest extends TestCase
     {
         $this->processQueue->add(Argument::type(Process::class), Argument::cetera())
             ->shouldBeCalled();
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWhenNoTestsOrPhpSourceExist(): void
+    {
+        $this->projectCapabilitiesResolver->resolve()
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->run(Argument::cetera())->shouldNotBeCalled();
+        $this->logger->info('Running code metrics analysis...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping code metrics analysis because no tests directory or PHP source files were detected.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(MetricsCommand::SUCCESS, $this->executeCommand());
     }
 }

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -324,6 +324,35 @@ final class TestsCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function executeWillFailWhenCustomTestsPathDoesNotExist(): void
+    {
+        $this->input->getArgument('path')
+            ->willReturn('missing-tests');
+        $this->filesystem->getAbsolutePath('missing-tests')
+            ->willReturn('/repo/missing-tests');
+        $this->projectCapabilitiesResolver->resolve(Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->processQueue->run(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->logger->info('Running PHPUnit tests...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->error(
+            'Tests path not found: {path}',
+            Argument::that(static fn(array $context): bool => '/repo/missing-tests' === $context['path']
+                && $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWithCoverageBelowMinimumWillReturnFailure(): void
     {
         $coverageReportPath = getcwd() . '/.dev-tools/cache/phpunit/coverage.php';

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -30,6 +30,8 @@ use FastForward\DevTools\Process\ProcessBuilder;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -55,6 +57,7 @@ use function Safe\getcwd;
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ProcessBuilder::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(ProjectCapabilities::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class TestsCommandTest extends TestCase
@@ -70,6 +73,8 @@ final class TestsCommandTest extends TestCase
     private ObjectProphecy $fileLocator;
 
     private ObjectProphecy $processQueue;
+
+    private ObjectProphecy $projectCapabilitiesResolver;
 
     private ObjectProphecy $logger;
 
@@ -89,6 +94,7 @@ final class TestsCommandTest extends TestCase
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
+        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -101,6 +107,7 @@ final class TestsCommandTest extends TestCase
             $this->fileLocator->reveal(),
             new ProcessBuilder(),
             $this->processQueue->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
 
@@ -108,6 +115,15 @@ final class TestsCommandTest extends TestCase
             ->willReturn([
                 'FastForward\\DevTools\\' => 'src/',
             ]);
+        $this->projectCapabilitiesResolver->resolve(Argument::any())
+            ->willReturn(new ProjectCapabilities(
+                [getcwd() . '/src'],
+                'FastForward\\DevTools',
+                false,
+                true,
+                false,
+                true,
+            ));
         $this->fileLocator->locate(TestsCommand::CONFIG)->willReturn(getcwd() . '/' . TestsCommand::CONFIG);
         $this->filesystem->getAbsolutePath('./vendor/autoload.php')
             ->willReturn(getcwd() . '/vendor/autoload.php');
@@ -279,6 +295,29 @@ final class TestsCommandTest extends TestCase
         )->shouldBeCalled();
 
         self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWhenNoTestsDirectoryOrPhpSourceExists(): void
+    {
+        $this->projectCapabilitiesResolver->resolve(Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+        $this->processQueue->run(Argument::cetera())->shouldNotBeCalled();
+        $this->logger->info('Running PHPUnit tests...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping PHPUnit tests because no tests directory or PHP source files were detected.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(TestsCommand::SUCCESS, $this->invokeExecute());
     }
 
     /**

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -28,6 +28,8 @@ use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -43,9 +45,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+use function Safe\getcwd;
+
 #[CoversClass(WikiCommand::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(ProjectCapabilities::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
 final class WikiCommandTest extends TestCase
@@ -61,6 +66,8 @@ final class WikiCommandTest extends TestCase
     private ObjectProphecy $filesystem;
 
     private ObjectProphecy $gitClient;
+
+    private ObjectProphecy $projectCapabilitiesResolver;
 
     private ObjectProphecy $logger;
 
@@ -82,6 +89,7 @@ final class WikiCommandTest extends TestCase
         $this->composer = $this->prophesize(ComposerJsonInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->gitClient = $this->prophesize(GitClientInterface::class);
+        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
@@ -93,6 +101,15 @@ final class WikiCommandTest extends TestCase
             ->willReturn([
                 'FastForward\\DevTools\\' => 'src/',
             ]);
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities(
+                [getcwd() . '/src'],
+                'FastForward\\DevTools',
+                false,
+                false,
+                true,
+                true,
+            ));
         $this->input->getOption('target')
             ->willReturn('.github/wiki');
         $this->input->getOption('cache-dir')
@@ -120,6 +137,7 @@ final class WikiCommandTest extends TestCase
             $this->composer->reveal(),
             $this->filesystem->reveal(),
             $this->gitClient->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
             $this->logger->reveal(),
         );
     }
@@ -176,6 +194,51 @@ final class WikiCommandTest extends TestCase
         $this->processQueue->run($this->output->reveal())
             ->willReturn(WikiCommand::SUCCESS)
             ->shouldBeCalled();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWhenWikiTargetDoesNotExist(): void
+    {
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->logger->info('Generating wiki documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
+            Argument::that(static fn(array $context): bool => '.github/wiki' === $context['target']
+                && $context['input'] instanceof InputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWhenNoApiDirectoriesAreDetected(): void
+    {
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, true, false));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->logger->info('Generating wiki documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping wiki documentation generation because no autoloaded PHP API directories were detected.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface),
+        )->shouldBeCalled();
 
         self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
     }

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -230,6 +230,48 @@ final class WikiCommandTest extends TestCase
      * @return void
      */
     #[Test]
+    public function executeWillGenerateWhenCustomWikiTargetDoesNotExist(): void
+    {
+        $this->input->getOption('target')
+            ->willReturn('build/wiki');
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities(['src/'], 'FastForward\\DevTools', false, false, false, true));
+        $this->filesystem->getAbsolutePath('src/')
+            ->willReturn(getcwd() . '/src')
+            ->shouldBeCalled();
+        $this->processBuilder->withArgument('--target', 'build/wiki')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalled();
+        $this->processBuilder->withArgument('--directory', getcwd() . '/src')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalled();
+        $this->processQueue->add($this->process->reveal(), Argument::cetera())
+            ->shouldBeCalled();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(WikiCommand::SUCCESS)
+            ->shouldBeCalled();
+        $this->logger->info('Generating wiki documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'info',
+            'Wiki documentation generated successfully.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface),
+        )->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
+            Argument::cetera(),
+        )->shouldNotBeCalled();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function executeWillSkipWhenNoApiDirectoriesAreDetected(): void
     {
         $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -102,14 +102,7 @@ final class WikiCommandTest extends TestCase
                 'FastForward\\DevTools\\' => 'src/',
             ]);
         $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
-            ->willReturn(new ProjectCapabilities(
-                [getcwd() . '/src'],
-                'FastForward\\DevTools',
-                false,
-                false,
-                true,
-                true,
-            ));
+            ->willReturn(new ProjectCapabilities(['src/'], 'FastForward\\DevTools', false, false, true, true));
         $this->input->getOption('target')
             ->willReturn('.github/wiki');
         $this->input->getOption('cache-dir')
@@ -160,6 +153,12 @@ final class WikiCommandTest extends TestCase
         )
             ->willReturn($this->processBuilder->reveal())
             ->shouldBeCalled();
+        $this->filesystem->getAbsolutePath('src/')
+            ->willReturn(getcwd() . '/src')
+            ->shouldBeCalled();
+        $this->processBuilder->withArgument('--directory', getcwd() . '/src')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalled();
         $this->processQueue->add($this->process->reveal(), Argument::cetera())
             ->shouldBeCalled();
         $this->processQueue->run($this->output->reveal())
@@ -189,6 +188,12 @@ final class WikiCommandTest extends TestCase
             ->willReturn(true);
         $this->processBuilder->withArgument('--cache-folder', Argument::cetera())
             ->shouldNotBeCalled();
+        $this->filesystem->getAbsolutePath('src/')
+            ->willReturn(getcwd() . '/src')
+            ->shouldBeCalled();
+        $this->processBuilder->withArgument('--directory', getcwd() . '/src')
+            ->willReturn($this->processBuilder->reveal())
+            ->shouldBeCalled();
         $this->processQueue->add($this->process->reveal(), Argument::cetera())
             ->shouldBeCalled();
         $this->processQueue->run($this->output->reveal())

--- a/tests/Console/Command/WikiCommandTest.php
+++ b/tests/Console/Command/WikiCommandTest.php
@@ -33,6 +33,7 @@ use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\TestCase;
@@ -220,6 +221,33 @@ final class WikiCommandTest extends TestCase
             'warning',
             'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
             Argument::that(static fn(array $context): bool => '.github/wiki' === $context['target']
+                && $context['input'] instanceof InputInterface),
+        )->shouldBeCalled();
+
+        self::assertSame(WikiCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    #[TestWith(['./.github/wiki'])]
+    #[TestWith(['.github/wiki/'])]
+    public function executeWillTreatEquivalentDefaultWikiTargetsAsDefault(string $target): void
+    {
+        $this->input->getOption('target')
+            ->willReturn($target);
+        $this->projectCapabilitiesResolver->resolve(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn(new ProjectCapabilities([], null, false, false, false, false));
+        $this->processQueue->add(Argument::cetera())
+            ->shouldNotBeCalled();
+        $this->logger->info('Generating wiki documentation...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))->shouldBeCalled();
+        $this->logger->log(
+            'warning',
+            'Skipping wiki documentation generation because the wiki target does not exist at {target}.',
+            Argument::that(static fn(array $context): bool => $target === $context['target']
                 && $context['input'] instanceof InputInterface),
         )->shouldBeCalled();
 

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -26,6 +26,7 @@ use FastForward\DevTools\Console\Formatter\LogLevelOutputFormatter;
 use FastForward\DevTools\Console\Output\GithubActionOutput;
 use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Environment\RuntimeEnvironment;
+use FastForward\DevTools\Environment\RuntimeEnvironmentInterface;
 use FastForward\DevTools\Filesystem\FinderFactory;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -127,6 +128,11 @@ final class DevToolsTest extends TestCase
      */
     private ObjectProphecy $environment;
 
+    /**
+     * @var ObjectProphecy<RuntimeEnvironmentInterface>
+     */
+    private ObjectProphecy $runtimeEnvironment;
+
     private DevTools $devTools;
 
     private string|false $originalWorkspaceDirectoryEnv;
@@ -147,6 +153,9 @@ final class DevToolsTest extends TestCase
         $this->selfUpdateRunner = $this->prophesize(SelfUpdateRunnerInterface::class);
         $this->selfUpdateScopeResolver = $this->prophesize(SelfUpdateScopeResolverInterface::class);
         $this->environment = $this->prophesize(EnvironmentInterface::class);
+        $this->runtimeEnvironment = $this->prophesize(RuntimeEnvironmentInterface::class);
+        $this->runtimeEnvironment->isAgentPresent()
+            ->willReturn(false);
         $this->originalWorkspaceDirectoryEnv = getenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
         $this->devTools = $this->createDevTools();
     }
@@ -270,6 +279,33 @@ final class DevToolsTest extends TestCase
 
         $this->invokeDoRun($input, $output);
 
+        self::assertStringNotContainsString('_____', $output->fetch());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function doRunWillNotRenderLogoWhenRunningInsideKnownAgentEnvironment(): void
+    {
+        $input = new ArrayInput([
+            'command' => 'list',
+        ]);
+
+        $output = new BufferedOutput();
+
+        $this->runtimeEnvironment->isAgentPresent()
+            ->willReturn(true);
+        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+            ->willReturn('');
+        $this->workingDirectorySwitcher->switchTo(null)
+            ->shouldBeCalledOnce();
+        $this->versionCheckNotifier->notify($output)
+            ->shouldNotBeCalled();
+
+        $result = $this->invokeDoRun($input, $output);
+
+        self::assertSame(Command::SUCCESS, $result);
         self::assertStringNotContainsString('_____', $output->fetch());
     }
 
@@ -556,6 +592,7 @@ final class DevToolsTest extends TestCase
             $this->selfUpdateRunner->reveal(),
             $this->selfUpdateScopeResolver->reveal(),
             $this->environment->reveal(),
+            $this->runtimeEnvironment->reveal(),
         );
     }
 

--- a/tests/Environment/EnvironmentTest.php
+++ b/tests/Environment/EnvironmentTest.php
@@ -75,6 +75,20 @@ final class EnvironmentTest extends TestCase
     /**
      * @return void
      */
+    #[Test]
+    public function getWithoutNameReturnsCurrentEnvironmentMap(): void
+    {
+        putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST=enabled');
+
+        $environment = $this->environment->get();
+
+        self::assertIsArray($environment);
+        self::assertSame('enabled', $environment['DEV_TOOLS_ENVIRONMENT_READER_TEST']);
+    }
+
+    /**
+     * @return void
+     */
     protected function tearDown(): void
     {
         if (false === $this->previousValue) {

--- a/tests/Environment/RuntimeEnvironmentTest.php
+++ b/tests/Environment/RuntimeEnvironmentTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Environment;
 
+use Ergebnis\AgentDetector\Detector;
 use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Environment\RuntimeEnvironment;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -85,7 +86,7 @@ final class RuntimeEnvironmentTest extends TestCase
     protected function setUp(): void
     {
         $this->environment = $this->prophesize(EnvironmentInterface::class);
-        $this->runtimeEnvironment = new RuntimeEnvironment($this->environment->reveal());
+        $this->runtimeEnvironment = new RuntimeEnvironment($this->environment->reveal(), new Detector());
     }
 
     /**
@@ -152,5 +153,19 @@ final class RuntimeEnvironmentTest extends TestCase
             ->willReturn('true');
 
         self::assertTrue($this->runtimeEnvironment->isComposerTestRun());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function isAgentPresentWillReturnWhetherKnownAgentVariablesExist(): void
+    {
+        $this->environment->get()
+            ->willReturn([
+                'CODEX_SANDBOX' => '1',
+            ]);
+
+        self::assertTrue($this->runtimeEnvironment->isAgentPresent());
     }
 }

--- a/tests/GitHubActions/ReportsWorkflowTest.php
+++ b/tests/GitHubActions/ReportsWorkflowTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\GitHubActions;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+final class ReportsWorkflowTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function reportsWorkflowWillDetectGeneratedReportSurfaces(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/reports.yml');
+        $steps = $workflow['jobs']['reports']['steps'] ?? null;
+
+        self::assertIsArray($steps);
+        self::assertSame(
+            'detect_reports',
+            $this->findStep($steps, 'Detect generated report surfaces')['id'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.detect_reports.outputs.docs_generated }}',
+            $workflow['jobs']['reports']['outputs']['docs_generated'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.detect_reports.outputs.coverage_generated }}',
+            $workflow['jobs']['reports']['outputs']['coverage_generated'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.detect_reports.outputs.metrics_generated }}',
+            $workflow['jobs']['reports']['outputs']['metrics_generated'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.detect_reports.outputs.any_generated }}',
+            $workflow['jobs']['reports']['outputs']['any_generated'] ?? null,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function reportsWorkflowWillOnlyVerifyGeneratedArtifacts(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/reports.yml');
+        $mainSteps = $workflow['jobs']['verify_main_reports']['steps'] ?? null;
+        $previewSteps = $workflow['jobs']['verify_preview_reports']['steps'] ?? null;
+
+        self::assertIsArray($mainSteps);
+        self::assertIsArray($previewSteps);
+        self::assertSame('build_checks', $this->findStep($mainSteps, 'Build deployment checks')['id'] ?? null);
+        self::assertSame(
+            "steps.build_checks.outputs.has_checks == 'true'",
+            $this->findVerifyDeploymentStep($mainSteps)['if'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.build_checks.outputs.checks }}',
+            $this->findVerifyDeploymentStep($mainSteps)['with']['checks'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.build_checks.outputs.checks }}',
+            $this->findVerifyDeploymentStep($previewSteps)['with']['checks'] ?? null,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function reportsWorkflowWillOnlyCommentAndSummarizeGeneratedArtifacts(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/reports.yml');
+        $commentSteps = $workflow['jobs']['comment_preview']['steps'] ?? null;
+        $summarySteps = $workflow['jobs']['summarize']['steps'] ?? null;
+
+        self::assertIsArray($commentSteps);
+        self::assertIsArray($summarySteps);
+        self::assertSame('build_comment', $this->findStep($commentSteps, 'Build preview comment')['id'] ?? null);
+        self::assertSame(
+            "steps.build_comment.outputs.has_links == 'true'",
+            $this->findStep($commentSteps, 'Comment preview URLs on pull request')['if'] ?? null,
+        );
+        self::assertSame(
+            '${{ steps.build_comment.outputs.message }}',
+            $this->findStep($commentSteps, 'Comment preview URLs on pull request')['with']['message'] ?? null,
+        );
+        self::assertStringContainsString(
+            'if [ "${DOCS_GENERATED}" = \'true\' ]; then',
+            (string) ($this->findStep($summarySteps, null, 'build_summary')['run'] ?? ''),
+        );
+        self::assertStringContainsString(
+            'if [ "${COVERAGE_GENERATED}" = \'true\' ]; then',
+            (string) ($this->findStep($summarySteps, null, 'build_summary')['run'] ?? ''),
+        );
+        self::assertStringContainsString(
+            'if [ "${METRICS_GENERATED}" = \'true\' ]; then',
+            (string) ($this->findStep($summarySteps, null, 'build_summary')['run'] ?? ''),
+        );
+    }
+
+    /**
+     * @param array<int, mixed> $steps
+     * @param string|null $name
+     * @param string|null $id
+     *
+     * @return array<string, mixed>
+     */
+    private function findStep(array $steps, ?string $name = null, ?string $id = null): array
+    {
+        foreach ($steps as $step) {
+            if (! \is_array($step)) {
+                continue;
+            }
+
+            if (null !== $name && ($step['name'] ?? null) !== $name) {
+                continue;
+            }
+
+            if (null !== $id && ($step['id'] ?? null) !== $id) {
+                continue;
+            }
+
+            return $step;
+        }
+
+        self::fail('Requested workflow step was not found.');
+    }
+
+    /**
+     * @param array<int, mixed> $steps
+     *
+     * @return array<string, mixed>
+     */
+    private function findVerifyDeploymentStep(array $steps): array
+    {
+        foreach ($steps as $step) {
+            if (! \is_array($step)) {
+                continue;
+            }
+
+            if (($step['uses'] ?? null) !== './.dev-tools-actions/.github/actions/github-pages/verify-deployment') {
+                continue;
+            }
+
+            return $step;
+        }
+
+        self::fail('Verify deployment step was not found.');
+    }
+}

--- a/tests/GitHubActions/ResolvePredictableConflictsActionTest.php
+++ b/tests/GitHubActions/ResolvePredictableConflictsActionTest.php
@@ -201,20 +201,6 @@ final class ResolvePredictableConflictsActionTest extends TestCase
     /**
      * @param array<int, string> $command
      * @param string $workingDirectory
-     *
-     * @return Process
-     */
-    private function runProcessAllowingFailure(array $command, string $workingDirectory): Process
-    {
-        $process = new Process($command, $workingDirectory);
-        $process->run();
-
-        return $process;
-    }
-
-    /**
-     * @param array<int, string> $command
-     * @param string $workingDirectory
      * @param string $input
      *
      * @return Process

--- a/tests/GitHubActions/WikiWorkflowsTest.php
+++ b/tests/GitHubActions/WikiWorkflowsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\GitHubActions;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+final class WikiWorkflowsTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    #[Test]
+    public function wikiPreviewWorkflowWillSkipWikiOperationsWhenNoWikiRepositoryExists(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/wiki-preview.yml');
+        $steps = $workflow['jobs']['preview']['steps'] ?? null;
+
+        self::assertIsArray($steps);
+        self::assertSame('detect_wiki', $this->findStep($steps, 'Detect wiki repository')['id'] ?? null);
+        self::assertSame(
+            "steps.detect_wiki.outputs.exists == 'true'",
+            $this->findStep($steps, 'Setup PHP and install dependencies')['if'] ?? null,
+        );
+        self::assertSame(
+            "steps.detect_wiki.outputs.exists == 'true'",
+            $this->findStep($steps, 'Refresh wiki preview pointer')['if'] ?? null,
+        );
+        self::assertStringContainsString('Wiki repository detected', $this->findSummaryMarkdown($steps) ?? '');
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function wikiMaintenanceWorkflowWillSkipWikiOperationsWhenNoWikiRepositoryExists(): void
+    {
+        $workflow = Yaml::parseFile(__DIR__ . '/../../.github/workflows/wiki-maintenance.yml');
+
+        self::assertIsArray($workflow['jobs']['publish']['steps'] ?? null);
+        self::assertSame(
+            "steps.detect_wiki.outputs.exists == 'true'",
+            $this->findStep(
+                $workflow['jobs']['publish']['steps'],
+                'Prepare wiki publish branch from preview branch'
+            )['if'] ?? null,
+        );
+        self::assertSame(
+            "steps.detect_wiki.outputs.exists == 'true'",
+            $this->findStep(
+                $workflow['jobs']['cleanup_closed_preview']['steps'],
+                'Delete wiki preview branch'
+            )['if'] ?? null,
+        );
+        self::assertSame(
+            "steps.detect_wiki.outputs.exists == 'true'",
+            $this->findStep(
+                $workflow['jobs']['cleanup_orphaned_previews']['steps'],
+                'Delete wiki branches for closed pull requests'
+            )['if'] ?? null,
+        );
+        self::assertStringContainsString(
+            'Wiki repository detected',
+            $this->findSummaryMarkdown($workflow['jobs']['publish']['steps']) ?? '',
+        );
+    }
+
+    /**
+     * @param array<int, mixed> $steps
+     * @param string $name
+     *
+     * @return array<string, mixed>
+     */
+    private function findStep(array $steps, string $name): array
+    {
+        foreach ($steps as $step) {
+            if (! \is_array($step)) {
+                continue;
+            }
+
+            if (($step['name'] ?? null) !== $name) {
+                continue;
+            }
+
+            return $step;
+        }
+
+        self::fail(\sprintf('Step "%s" was not found.', $name));
+    }
+
+    /**
+     * @param array<int, mixed> $steps
+     */
+    private function findSummaryMarkdown(array $steps): ?string
+    {
+        foreach ($steps as $step) {
+            if (! \is_array($step)) {
+                continue;
+            }
+
+            if (($step['uses'] ?? null) !== './.dev-tools-actions/.github/actions/summary/write') {
+                continue;
+            }
+
+            return $step['with']['markdown'] ?? null;
+        }
+
+        return null;
+    }
+}

--- a/tests/Project/ProjectCapabilitiesResolverTest.php
+++ b/tests/Project/ProjectCapabilitiesResolverTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fast Forward Development Tools for PHP projects.
+ *
+ * This file is part of fast-forward/dev-tools project.
+ *
+ * @author   Felipe Sayão Lobato Abreu <github@mentordosnerds.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ *
+ * @see      https://github.com/php-fast-forward/
+ * @see      https://github.com/php-fast-forward/dev-tools
+ * @see      https://github.com/php-fast-forward/dev-tools/issues
+ * @see      https://php-fast-forward.github.io/dev-tools/
+ * @see      https://datatracker.ietf.org/doc/html/rfc2119
+ */
+
+namespace FastForward\DevTools\Tests\Project;
+
+use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
+use FastForward\DevTools\Filesystem\Filesystem;
+use FastForward\DevTools\Path\ManagedWorkspace;
+use FastForward\DevTools\Path\WorkingProjectPathResolver;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+use function Safe\chdir;
+use function Safe\file_put_contents;
+use function Safe\getcwd;
+use function Safe\mkdir;
+use function Safe\realpath;
+
+#[CoversClass(ProjectCapabilitiesResolver::class)]
+#[UsesClass(Filesystem::class)]
+#[UsesClass(ManagedWorkspace::class)]
+#[UsesClass(ProjectCapabilities::class)]
+#[UsesClass(WorkingProjectPathResolver::class)]
+final class ProjectCapabilitiesResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy $composer;
+
+    private SymfonyFilesystem $filesystem;
+
+    private ProjectCapabilitiesResolver $resolver;
+
+    private string $workingDirectory;
+
+    private string $workspace;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->composer = $this->prophesize(ComposerJsonInterface::class);
+        $this->filesystem = new SymfonyFilesystem();
+        $this->workingDirectory = getcwd();
+        $this->workspace = sys_get_temp_dir() . '/dev-tools-project-capabilities-' . uniqid('', true);
+
+        $this->filesystem->mkdir($this->workspace);
+        chdir($this->workspace);
+
+        $this->resolver = new ProjectCapabilitiesResolver($this->composer->reveal(), new Filesystem());
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        chdir($this->workingDirectory);
+        $this->filesystem->remove($this->workspace);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveWillDetectGuideOnlyRepositoryCapabilities(): void
+    {
+        mkdir($this->workspace . '/docs', recursive: true);
+        file_put_contents($this->workspace . '/docs/index.rst', "Guide\n=====\n");
+
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([]);
+        $this->composer->getAutoload('psr-0')
+            ->willReturn([]);
+        $this->composer->getAutoload('classmap')
+            ->willReturn([]);
+
+        $capabilities = $this->resolver->resolve();
+
+        self::assertTrue($capabilities->hasGuideDirectory());
+        self::assertFalse($capabilities->hasTestsPath());
+        self::assertFalse($capabilities->hasWikiTarget());
+        self::assertFalse($capabilities->hasPhpSourceFiles());
+        self::assertFalse($capabilities->canGenerateApiDocumentation());
+        self::assertTrue($capabilities->canGenerateDocs());
+        self::assertFalse($capabilities->canRunTests());
+        self::assertFalse($capabilities->canGenerateMetrics());
+        self::assertFalse($capabilities->canGenerateWiki());
+        self::assertSame([], $capabilities->getApiDirectories());
+        self::assertNull($capabilities->getDefaultPackageName());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveWillDetectPhpPackageCapabilities(): void
+    {
+        mkdir($this->workspace . '/src', recursive: true);
+        mkdir($this->workspace . '/tests', recursive: true);
+        mkdir($this->workspace . '/docs', recursive: true);
+        mkdir($this->workspace . '/.github/wiki', recursive: true);
+
+        file_put_contents($this->workspace . '/src/Feature.php', "<?php\n\nnamespace App;\n\nfinal class Feature {}\n");
+        file_put_contents($this->workspace . '/tests/FeatureTest.php', "<?php\n\nfinal class FeatureTest {}\n");
+        file_put_contents($this->workspace . '/docs/index.rst', "Guide\n=====\n");
+
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([
+                'App\\' => 'src/',
+            ]);
+        $this->composer->getAutoload('psr-0')
+            ->willReturn([]);
+        $this->composer->getAutoload('classmap')
+            ->willReturn([]);
+
+        $capabilities = $this->resolver->resolve();
+
+        self::assertTrue($capabilities->hasGuideDirectory());
+        self::assertTrue($capabilities->hasTestsPath());
+        self::assertTrue($capabilities->hasWikiTarget());
+        self::assertTrue($capabilities->hasPhpSourceFiles());
+        self::assertTrue($capabilities->canGenerateApiDocumentation());
+        self::assertTrue($capabilities->canGenerateDocs());
+        self::assertTrue($capabilities->canRunTests());
+        self::assertTrue($capabilities->canGenerateMetrics());
+        self::assertTrue($capabilities->canGenerateWiki());
+        self::assertSame([realpath($this->workspace . '/src')], $capabilities->getApiDirectories());
+        self::assertSame('App', $capabilities->getDefaultPackageName());
+    }
+}

--- a/tests/Project/ProjectCapabilitiesResolverTest.php
+++ b/tests/Project/ProjectCapabilitiesResolverTest.php
@@ -137,6 +137,29 @@ final class ProjectCapabilitiesResolverTest extends TestCase
      * @return void
      */
     #[Test]
+    public function resolveWillDetectPhpSourceFromFileBasedClassmapEntries(): void
+    {
+        mkdir($this->workspace . '/legacy', recursive: true);
+        file_put_contents($this->workspace . '/legacy/LegacyClass.php', "<?php\n\nfinal class LegacyClass {}\n");
+
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([]);
+        $this->composer->getAutoload('psr-0')
+            ->willReturn([]);
+        $this->composer->getAutoload('classmap')
+            ->willReturn(['legacy/LegacyClass.php']);
+
+        $capabilities = $this->resolver->resolve();
+
+        self::assertTrue($capabilities->hasPhpSourceFiles());
+        self::assertTrue($capabilities->canRunTests());
+        self::assertFalse($capabilities->canGenerateApiDocumentation());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function resolveWillDetectPhpPackageCapabilities(): void
     {
         mkdir($this->workspace . '/src', recursive: true);

--- a/tests/Project/ProjectCapabilitiesResolverTest.php
+++ b/tests/Project/ProjectCapabilitiesResolverTest.php
@@ -37,7 +37,6 @@ use function Safe\chdir;
 use function Safe\file_put_contents;
 use function Safe\getcwd;
 use function Safe\mkdir;
-use function Safe\realpath;
 
 #[CoversClass(ProjectCapabilitiesResolver::class)]
 #[UsesClass(Filesystem::class)]
@@ -149,7 +148,7 @@ final class ProjectCapabilitiesResolverTest extends TestCase
         self::assertTrue($capabilities->canRunTests());
         self::assertTrue($capabilities->canGenerateMetrics());
         self::assertTrue($capabilities->canGenerateWiki());
-        self::assertSame([realpath($this->workspace . '/src')], $capabilities->getApiDirectories());
+        self::assertSame(['src/'], $capabilities->getApiDirectories());
         self::assertSame('App', $capabilities->getDefaultPackageName());
     }
 }

--- a/tests/Project/ProjectCapabilitiesResolverTest.php
+++ b/tests/Project/ProjectCapabilitiesResolverTest.php
@@ -22,7 +22,6 @@ namespace FastForward\DevTools\Tests\Project;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\Filesystem;
 use FastForward\DevTools\Path\ManagedWorkspace;
-use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use FastForward\DevTools\Project\ProjectCapabilities;
 use FastForward\DevTools\Project\ProjectCapabilitiesResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -42,7 +41,6 @@ use function Safe\mkdir;
 #[UsesClass(Filesystem::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesClass(ProjectCapabilities::class)]
-#[UsesClass(WorkingProjectPathResolver::class)]
 final class ProjectCapabilitiesResolverTest extends TestCase
 {
     use ProphecyTrait;
@@ -107,10 +105,32 @@ final class ProjectCapabilitiesResolverTest extends TestCase
         self::assertFalse($capabilities->canGenerateApiDocumentation());
         self::assertTrue($capabilities->canGenerateDocs());
         self::assertFalse($capabilities->canRunTests());
-        self::assertFalse($capabilities->canGenerateMetrics());
+        self::assertTrue($capabilities->canGenerateMetrics());
         self::assertFalse($capabilities->canGenerateWiki());
         self::assertSame([], $capabilities->getApiDirectories());
         self::assertNull($capabilities->getDefaultPackageName());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function resolveWillIgnoreToolingPhpFilesWhenDetectingTestablePhpSource(): void
+    {
+        file_put_contents($this->workspace . '/ecs.php', "<?php\n\nreturn [];\n");
+
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([]);
+        $this->composer->getAutoload('psr-0')
+            ->willReturn([]);
+        $this->composer->getAutoload('classmap')
+            ->willReturn([]);
+
+        $capabilities = $this->resolver->resolve();
+
+        self::assertFalse($capabilities->hasPhpSourceFiles());
+        self::assertFalse($capabilities->canRunTests());
+        self::assertTrue($capabilities->canGenerateMetrics());
     }
 
     /**


### PR DESCRIPTION
## Summary
- add repository capability detection so `wiki`, `docs`, `tests`, `metrics`, and `reports` can skip unsupported PHP-code workflows with controlled warnings in guide-only repositories
- keep wiki-related workflows from failing when `.github/wiki` is absent and prevent docs/wiki generation from inventing PHP API output when no project autoload surface exists
- make reports preview comments, deployment verification, and workflow summaries mention only docs, coverage, and metrics artifacts that were actually generated
- keep `docs` failing fast when a custom `--source` path is explicitly provided but does not exist, while preserving the new default `docs` behavior for guide-only repositories

## Testing
- `composer dev-tools`
- `composer dev-tools changelog:check -- --file=CHANGELOG.md --against=origin/main`
- `vendor/bin/yaml-lint .github/workflows/wiki-preview.yml .github/workflows/wiki-maintenance.yml .github/workflows/reports.yml`

Closes #325