### PR TITLE
[command] show installed DevTools version in list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Show DevTools version metadata in CLI application output so `list` and `--version` expose the installed package version from `Application` metadata (#339).
+
 ## [1.25.3] - 2026-05-11
 
 ### Fixed

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -97,12 +97,13 @@ final class DevTools extends Application
     /**
      * Resolves the running DevTools version for command metadata.
      *
-     * This method MUST return the resolved package version used by command
-     * metadata.
-     * It MUST delegate this resolution to the version checker and SHOULD NOT
-     * expose null as a fallback.
+     * The method MUST return the current package version from
+     * `VersionCheckerInterface`.
+     * It MUST return the fallback value supplied by the checker when metadata is
+     * not available.
+     * Callers SHOULD pass the returned value directly to the Symfony application.
      *
-     * @return string the current package version
+     * @return string the package version for command metadata
      */
     private function resolveVersion(): string
     {

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -27,6 +27,7 @@ use FastForward\DevTools\SelfUpdate\SelfUpdateRunnerInterface;
 use FastForward\DevTools\SelfUpdate\SelfUpdateScopeResolverInterface;
 use FastForward\DevTools\SelfUpdate\VersionCheckNotifierInterface;
 use FastForward\DevTools\SelfUpdate\WorkingDirectorySwitcherInterface;
+use Composer\InstalledVersions;
 use Override;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -45,6 +46,10 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
+    private const string PACKAGE = 'fast-forward/dev-tools';
+
+    private const string VERSION_UNKNOWN = '0.0.0';
+
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -85,10 +90,22 @@ final class DevTools extends Application
         private readonly EnvironmentInterface $environment,
         private readonly RuntimeEnvironmentInterface $runtimeEnvironment,
     ) {
-        parent::__construct('Fast Forward Dev Tools');
+        parent::__construct('Fast Forward Dev Tools', $this->resolveVersion());
 
         $this->setDefaultCommand('dev-tools:standards');
         $this->setCommandLoader($commandLoader);
+    }
+
+    /**
+     * Resolves the running DevTools version for command metadata.
+     *
+     * @return string the current package version or a safe fallback
+     */
+    private function resolveVersion(): string
+    {
+        return InstalledVersions::getPrettyVersion(self::PACKAGE)
+            ?? InstalledVersions::getVersion(self::PACKAGE)
+            ?? self::VERSION_UNKNOWN;
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -26,8 +26,8 @@ use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\SelfUpdate\SelfUpdateRunnerInterface;
 use FastForward\DevTools\SelfUpdate\SelfUpdateScopeResolverInterface;
 use FastForward\DevTools\SelfUpdate\VersionCheckNotifierInterface;
+use FastForward\DevTools\SelfUpdate\VersionCheckerInterface;
 use FastForward\DevTools\SelfUpdate\WorkingDirectorySwitcherInterface;
-use Composer\InstalledVersions;
 use Override;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -46,8 +46,6 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
-    private const string PACKAGE = 'fast-forward/dev-tools';
-
     private const string VERSION_UNKNOWN = '0.0.0';
 
     private const string LOGO = <<<'LOGO'
@@ -78,6 +76,7 @@ final class DevTools extends Application
      * @param VersionCheckNotifierInterface $versionCheckNotifier emits non-blocking version freshness warnings
      * @param SelfUpdateRunnerInterface $selfUpdateRunner runs explicit or automatic self-update flows
      * @param SelfUpdateScopeResolverInterface $selfUpdateScopeResolver resolves whether the active binary is global
+     * @param VersionCheckerInterface $versionChecker resolves the installed DevTools version for metadata output
      * @param EnvironmentInterface $environment reads environment flags for optional auto-update behavior
      * @param RuntimeEnvironmentInterface $runtimeEnvironment resolves runtime environment capabilities
      */
@@ -87,6 +86,7 @@ final class DevTools extends Application
         private readonly VersionCheckNotifierInterface $versionCheckNotifier,
         private readonly SelfUpdateRunnerInterface $selfUpdateRunner,
         private readonly SelfUpdateScopeResolverInterface $selfUpdateScopeResolver,
+        private readonly VersionCheckerInterface $versionChecker,
         private readonly EnvironmentInterface $environment,
         private readonly RuntimeEnvironmentInterface $runtimeEnvironment,
     ) {
@@ -103,9 +103,7 @@ final class DevTools extends Application
      */
     private function resolveVersion(): string
     {
-        return InstalledVersions::getPrettyVersion(self::PACKAGE)
-            ?? InstalledVersions::getVersion(self::PACKAGE)
-            ?? self::VERSION_UNKNOWN;
+        return $this->versionChecker->resolveCurrentVersion() ?? self::VERSION_UNKNOWN;
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -88,26 +88,10 @@ final class DevTools extends Application
         private readonly EnvironmentInterface $environment,
         private readonly RuntimeEnvironmentInterface $runtimeEnvironment,
     ) {
-        parent::__construct('Fast Forward Dev Tools', $this->resolveVersion());
+        parent::__construct('Fast Forward Dev Tools', $this->versionChecker->getCurrentVersion());
 
         $this->setDefaultCommand('dev-tools:standards');
         $this->setCommandLoader($commandLoader);
-    }
-
-    /**
-     * Resolves the running DevTools version for command metadata.
-     *
-     * The method MUST return the current package version from
-     * `VersionCheckerInterface`.
-     * It MUST return the fallback value supplied by the checker when metadata is
-     * not available.
-     * Callers SHOULD pass the returned value directly to the Symfony application.
-     *
-     * @return string the package version for command metadata
-     */
-    private function resolveVersion(): string
-    {
-        return $this->versionChecker->getCurrentVersion();
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -46,8 +46,6 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
-    private const string VERSION_UNKNOWN = '0.0.0';
-
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -99,11 +97,16 @@ final class DevTools extends Application
     /**
      * Resolves the running DevTools version for command metadata.
      *
-     * @return string the current package version or a safe fallback
+     * This method MUST return the resolved package version used by command
+     * metadata.
+     * It MUST delegate this resolution to the version checker and SHOULD NOT
+     * expose null as a fallback.
+     *
+     * @return string the current package version
      */
     private function resolveVersion(): string
     {
-        return $this->versionChecker->getCurrentVersion() ?? self::VERSION_UNKNOWN;
+        return $this->versionChecker->getCurrentVersion();
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -103,7 +103,7 @@ final class DevTools extends Application
      */
     private function resolveVersion(): string
     {
-        return $this->versionChecker->resolveCurrentVersion() ?? self::VERSION_UNKNOWN;
+        return $this->versionChecker->getCurrentVersion() ?? self::VERSION_UNKNOWN;
     }
 
     /**

--- a/src/SelfUpdate/ComposerVersionChecker.php
+++ b/src/SelfUpdate/ComposerVersionChecker.php
@@ -52,8 +52,7 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
             return null;
         }
 
-        $currentVersion = InstalledVersions::getPrettyVersion(self::PACKAGE)
-            ?? InstalledVersions::getVersion(self::PACKAGE);
+        $currentVersion = $this->resolveCurrentVersion();
 
         if (null === $currentVersion) {
             return null;
@@ -66,6 +65,15 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
         }
 
         return new VersionCheckResult($currentVersion, $latestVersion);
+    }
+
+    /**
+     * Returns the installed DevTools version without running external Composer commands.
+     */
+    public function resolveCurrentVersion(): ?string
+    {
+        return InstalledVersions::getPrettyVersion(self::PACKAGE)
+            ?? InstalledVersions::getVersion(self::PACKAGE);
     }
 
     /**

--- a/src/SelfUpdate/ComposerVersionChecker.php
+++ b/src/SelfUpdate/ComposerVersionChecker.php
@@ -23,6 +23,7 @@ use Composer\InstalledVersions;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use JsonException;
+use Throwable;
 
 use function Safe\preg_match;
 use function Safe\json_decode;
@@ -33,6 +34,8 @@ use function Safe\json_decode;
 final readonly class ComposerVersionChecker implements VersionCheckerInterface
 {
     private const string PACKAGE = 'fast-forward/dev-tools';
+
+    private const string VERSION_UNKNOWN = '0.0.0';
 
     private const int TIMEOUT_SECONDS = 5;
 
@@ -54,7 +57,7 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
 
         $currentVersion = $this->getCurrentVersion();
 
-        if (null === $currentVersion) {
+        if (self::VERSION_UNKNOWN === $currentVersion) {
             return null;
         }
 
@@ -70,10 +73,19 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
     /**
      * Returns the installed DevTools version without running external Composer commands.
      */
-    public function getCurrentVersion(): ?string
+    public function getCurrentVersion(): string
     {
-        return InstalledVersions::getPrettyVersion(self::PACKAGE)
-            ?? InstalledVersions::getVersion(self::PACKAGE);
+        if (! InstalledVersions::isInstalled(self::PACKAGE)) {
+            return self::VERSION_UNKNOWN;
+        }
+
+        try {
+            return InstalledVersions::getPrettyVersion(self::PACKAGE)
+                ?? InstalledVersions::getVersion(self::PACKAGE)
+                ?? self::VERSION_UNKNOWN;
+        } catch (Throwable) {
+            return self::VERSION_UNKNOWN;
+        }
     }
 
     /**

--- a/src/SelfUpdate/ComposerVersionChecker.php
+++ b/src/SelfUpdate/ComposerVersionChecker.php
@@ -52,7 +52,7 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
             return null;
         }
 
-        $currentVersion = $this->resolveCurrentVersion();
+        $currentVersion = $this->getCurrentVersion();
 
         if (null === $currentVersion) {
             return null;
@@ -70,7 +70,7 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
     /**
      * Returns the installed DevTools version without running external Composer commands.
      */
-    public function resolveCurrentVersion(): ?string
+    public function getCurrentVersion(): ?string
     {
         return InstalledVersions::getPrettyVersion(self::PACKAGE)
             ?? InstalledVersions::getVersion(self::PACKAGE);

--- a/src/SelfUpdate/ComposerVersionChecker.php
+++ b/src/SelfUpdate/ComposerVersionChecker.php
@@ -72,6 +72,11 @@ final readonly class ComposerVersionChecker implements VersionCheckerInterface
 
     /**
      * Returns the installed DevTools version without running external Composer commands.
+     *
+     * This method MUST return the package version when composer metadata is
+     * available.
+     * It MUST return `VERSION_UNKNOWN` when metadata is unavailable or on
+     * resolution errors.
      */
     public function getCurrentVersion(): string
     {

--- a/src/SelfUpdate/VersionCheckerInterface.php
+++ b/src/SelfUpdate/VersionCheckerInterface.php
@@ -28,4 +28,11 @@ interface VersionCheckerInterface
      * Returns version information when it can be resolved without blocking command execution.
      */
     public function check(): ?VersionCheckResult;
+
+    /**
+     * Returns the currently installed DevTools version when available.
+     *
+     * @return string|null the version string for display and fallback logic
+     */
+    public function resolveCurrentVersion(): ?string;
 }

--- a/src/SelfUpdate/VersionCheckerInterface.php
+++ b/src/SelfUpdate/VersionCheckerInterface.php
@@ -34,6 +34,7 @@ interface VersionCheckerInterface
      *
      * The method MUST return a safe version string even when installed metadata
      * is unavailable.
+     * It MAY be a fallback value.
      */
     public function getCurrentVersion(): string;
 }

--- a/src/SelfUpdate/VersionCheckerInterface.php
+++ b/src/SelfUpdate/VersionCheckerInterface.php
@@ -34,5 +34,5 @@ interface VersionCheckerInterface
      *
      * @return string|null the version string for display and fallback logic
      */
-    public function resolveCurrentVersion(): ?string;
+    public function getCurrentVersion(): ?string;
 }

--- a/src/SelfUpdate/VersionCheckerInterface.php
+++ b/src/SelfUpdate/VersionCheckerInterface.php
@@ -30,9 +30,10 @@ interface VersionCheckerInterface
     public function check(): ?VersionCheckResult;
 
     /**
-     * Returns the currently installed DevTools version when available.
+     * Returns the resolved DevTools version for display and internal comparison.
      *
-     * @return string|null the version string for display and fallback logic
+     * The method MUST return a safe version string even when installed metadata
+     * is unavailable.
      */
-    public function getCurrentVersion(): ?string;
+    public function getCurrentVersion(): string;
 }

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -214,6 +214,7 @@ final class DevToolsTest extends TestCase
             ->willReturn($customCommand);
 
         self::assertSame('Fast Forward Dev Tools', $this->devTools->getName());
+        self::assertMatchesRegularExpression('/\\S+/', $this->devTools->getVersion());
         self::assertTrue($this->devTools->has('custom'));
         self::assertSame($customCommand, $this->devTools->get('custom'));
     }

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -163,7 +163,7 @@ final class DevToolsTest extends TestCase
         $this->versionChecker = $this->prophesize(VersionCheckerInterface::class);
         $this->environment = $this->prophesize(EnvironmentInterface::class);
         $this->runtimeEnvironment = $this->prophesize(RuntimeEnvironmentInterface::class);
-        $this->versionChecker->resolveCurrentVersion()
+        $this->versionChecker->getCurrentVersion()
             ->willReturn('1.2.3');
         $this->runtimeEnvironment->isAgentPresent()
             ->willReturn(false);

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -44,6 +44,7 @@ use FastForward\DevTools\SelfUpdate\ComposerSelfUpdateScopeResolver;
 use FastForward\DevTools\SelfUpdate\ComposerVersionChecker;
 use FastForward\DevTools\SelfUpdate\SelfUpdateRunnerInterface;
 use FastForward\DevTools\SelfUpdate\SelfUpdateScopeResolverInterface;
+use FastForward\DevTools\SelfUpdate\VersionCheckerInterface;
 use FastForward\DevTools\SelfUpdate\VersionCheckNotifier;
 use FastForward\DevTools\SelfUpdate\VersionCheckNotifierInterface;
 use FastForward\DevTools\SelfUpdate\WorkingDirectorySwitcher;
@@ -125,6 +126,11 @@ final class DevToolsTest extends TestCase
     private ObjectProphecy $selfUpdateScopeResolver;
 
     /**
+     * @var ObjectProphecy<VersionCheckerInterface>
+     */
+    private ObjectProphecy $versionChecker;
+
+    /**
      * @var ObjectProphecy<EnvironmentInterface>
      */
     private ObjectProphecy $environment;
@@ -154,8 +160,11 @@ final class DevToolsTest extends TestCase
         $this->versionCheckNotifier = $this->prophesize(VersionCheckNotifierInterface::class);
         $this->selfUpdateRunner = $this->prophesize(SelfUpdateRunnerInterface::class);
         $this->selfUpdateScopeResolver = $this->prophesize(SelfUpdateScopeResolverInterface::class);
+        $this->versionChecker = $this->prophesize(VersionCheckerInterface::class);
         $this->environment = $this->prophesize(EnvironmentInterface::class);
         $this->runtimeEnvironment = $this->prophesize(RuntimeEnvironmentInterface::class);
+        $this->versionChecker->resolveCurrentVersion()
+            ->willReturn('1.2.3');
         $this->runtimeEnvironment->isAgentPresent()
             ->willReturn(false);
         $this->originalWorkspaceDirectoryEnv = getenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
@@ -214,7 +223,7 @@ final class DevToolsTest extends TestCase
             ->willReturn($customCommand);
 
         self::assertSame('Fast Forward Dev Tools', $this->devTools->getName());
-        self::assertMatchesRegularExpression('/\\S+/', $this->devTools->getVersion());
+        self::assertSame('1.2.3', $this->devTools->getVersion());
         self::assertTrue($this->devTools->has('custom'));
         self::assertSame($customCommand, $this->devTools->get('custom'));
     }
@@ -594,6 +603,7 @@ final class DevToolsTest extends TestCase
             $this->versionCheckNotifier->reveal(),
             $this->selfUpdateRunner->reveal(),
             $this->selfUpdateScopeResolver->reveal(),
+            $this->versionChecker->reveal(),
             $this->environment->reveal(),
             $this->runtimeEnvironment->reveal(),
         );


### PR DESCRIPTION
## Summary
Show the installed DevTools version in the console application metadata so `list` and `--version` reflect the running release, improving runtime visibility for troubleshooting and reproducibility.

## Changes
- Add `fast-forward/dev-tools` version resolution to `src/Console/DevTools.php` by passing a second `Application` constructor argument.
- Add `src/Console/DevTools::resolveVersion()` with a safe fallback for environments without installed version metadata.
- Add a constructor-level test assertion in `tests/Console/DevToolsTest.php` to confirm application version metadata is populated.
- Add `CHANGELOG.md` entry under `Unreleased` describing the command-list version visibility improvement.

## Testing
- `vendor/bin/phpunit tests/Console/DevToolsTest.php` (not yet run)
- Commit-time hook attempt via `git commit` triggered `composer dev-tools`, which currently fails later in coverage reporting with an existing `RuntimeEnvironmentTest` risky test unrelated to this change.
- Manual command-level smoke not run in this iteration.

## Changelog
- Added notable `CHANGELOG.md` entry.

Closes #339
