### PR TITLE
Fix GitHub Actions setup-composer fallback lockfile handling (#342)

### DIFF
--- a/.github/actions/php/setup-composer/action.yml
+++ b/.github/actions/php/setup-composer/action.yml
@@ -106,7 +106,7 @@ runs:
       with:
         working-directory: ${{ inputs.dev-tools-source-directory }}
         composer-options: --prefer-dist --no-plugins --no-scripts
-        require-lock-file: 'true'
+        require-lock-file: 'false'
         custom-cache-suffix: dev-tools-runtime
 
     - name: Expose DevTools runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Relax workflow fallback Composer install so .dev-tools-actions bootstrap does not require composer.lock when provisioning DevTools runtime in shared GitHub Actions contexts (#342).
+
 ## [1.25.4] - 2026-05-11
 
 ### Fixed
 
 - Show DevTools version metadata in CLI application output so `list` and `--version` expose the installed package version from `Application` metadata (#339).
-- Relax workflow fallback Composer install so `.dev-tools-actions` bootstrap does not require `composer.lock` when provisioning DevTools runtime in shared GitHub Actions contexts (#342).
 
 ## [1.25.3] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Show DevTools version metadata in CLI application output so `list` and `--version` expose the installed package version from `Application` metadata (#339).
+- Relax workflow fallback Composer install so `.dev-tools-actions` bootstrap does not require `composer.lock` when provisioning DevTools runtime in shared GitHub Actions contexts (#342).
 
 ## [1.25.3] - 2026-05-11
 

--- a/tests/GitHubActions/SetupComposerActionTest.php
+++ b/tests/GitHubActions/SetupComposerActionTest.php
@@ -107,6 +107,19 @@ final class SetupComposerActionTest extends TestCase
      * @return void
      */
     #[Test]
+    public function fallbackInstallShouldNotRequireComposerLockFile(): void
+    {
+        $actionFile = self::ACTION_PATH . '/action.yml';
+        $actionContents = file_get_contents($actionFile);
+
+        self::assertStringContainsString("require-lock-file: 'false'", $actionContents);
+        self::assertStringNotContainsString("require-lock-file: 'true'", $actionContents);
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function detectRuntimeWillFallbackToTheWorkflowSourceWhenTheConsumerDoesNotInstallDevTools(): void
     {
         $this->createRepositoryRuntimeFiles($this->workspace . '/.dev-tools-actions');


### PR DESCRIPTION
## Summary

- Set `require-lock-file` to `false` when `setup-composer` installs the fallback DevTools runtime in `.github/actions/php/setup-composer/action.yml`.
- Add regression coverage in `tests/GitHubActions/SetupComposerActionTest.php` asserting fallback install no longer requires a lock file.
- Add an `Unreleased` changelog entry for this workflow reliability fix.

## Verification

- Pre-commit hooks executed during commit:
  - `composer`
  - `phplint`
  - `jsonlint`
  - `yamllint`

Closes #342
