### PR TITLE
Skip reports coverage when no tests are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Relax workflow fallback Composer install so .dev-tools-actions bootstrap does not require composer.lock when provisioning DevTools runtime in shared GitHub Actions contexts (#342).
+- Skip coverage report generation in reports command when no test surface is detectable (no default tests directory and no testable PHP source), while still generating docs and metrics.
 
 ## [1.25.4] - 2026-05-11
 

--- a/src/Config/ComposerDependencyAnalyserConfig.php
+++ b/src/Config/ComposerDependencyAnalyserConfig.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Config;
 
+use FastForward\DevTools\Environment\Environment;
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
@@ -86,14 +88,18 @@ final class ComposerDependencyAnalyserConfig
      * Creates the default Composer Dependency Analyser configuration.
      *
      * @param callable|null $customize optional callback to customize the configuration
+     * @param EnvironmentInterface|null $environment optional environment reader used to resolve overrides
      *
      * @return Configuration the configured analyser configuration
      */
-    public static function configure(?callable $customize = null): Configuration
-    {
+    public static function configure(
+        ?callable $customize = null,
+        ?EnvironmentInterface $environment = null,
+    ): Configuration {
+        $environment ??= new Environment();
         $configuration = new Configuration();
 
-        if (! self::shouldShowShadowDependencies()) {
+        if (! self::shouldShowShadowDependencies($environment)) {
             self::applyIgnoresShadowDependencies($configuration);
         }
 
@@ -128,11 +134,15 @@ final class ComposerDependencyAnalyserConfig
     /**
      * Determines whether shadow dependency reports SHOULD remain visible.
      *
+     * @param EnvironmentInterface|null $environment optional environment reader used to resolve overrides
+     *
      * @return bool
      */
-    public static function shouldShowShadowDependencies(): bool
+    public static function shouldShowShadowDependencies(?EnvironmentInterface $environment = null): bool
     {
-        return '1' === getenv(self::ENV_SHOW_SHADOW_DEPENDENCIES);
+        $environment ??= new Environment();
+
+        return '1' === $environment->get(self::ENV_SHOW_SHADOW_DEPENDENCIES);
     }
 
     /**

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -23,6 +23,7 @@ use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -52,10 +53,12 @@ final class ReportsCommand extends Command
      *
      * @param ProcessBuilderInterface $processBuilder the builder instance used to construct execution processes
      * @param ProcessQueueInterface $processQueue the execution queue mechanism for running sub-processes
+     * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the resolver for project capability detection
      */
     public function __construct(
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
+        private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
     ) {
         parent::__construct();
     }
@@ -105,8 +108,8 @@ final class ReportsCommand extends Command
     /**
      * Executes the generation logic for diverse reports.
      *
-     * The method MUST run the underlying `docs` and `tests` commands. It SHALL process
-     * and generate the frontpage output file successfully.
+     * The method MUST run the underlying `docs` command and, when applicable,
+     * the `tests` command for coverage generation.
      *
      * @param InputInterface $input the structured inputs holding specific arguments
      * @param OutputInterface $output the designated output interface
@@ -186,7 +189,17 @@ final class ReportsCommand extends Command
             $coverageBuilder = $coverageBuilder->withArgument('--pretty-json');
         }
 
-        $coverage = $coverageBuilder->build([DevToolsPathResolver::getBinaryPath(), 'tests']);
+        $projectCapabilities = $this->projectCapabilitiesResolver->resolve();
+        if ($projectCapabilities->canRunTests()) {
+            $coverage = $coverageBuilder->build([DevToolsPathResolver::getBinaryPath(), 'tests']);
+            $this->processQueue->add(process: $coverage, label: 'Generating Coverage Report');
+        } else {
+            $this->log(
+                'Skipping coverage report because no tests directory or PHP source files were detected.',
+                $input,
+                logLevel: 'warning',
+            );
+        }
 
         if ($progress) {
             $metricsBuilder = $metricsBuilder->withArgument('--progress');
@@ -203,7 +216,6 @@ final class ReportsCommand extends Command
         $metrics = $metricsBuilder->build([DevToolsPathResolver::getBinaryPath(), 'metrics']);
 
         $this->processQueue->add(process: $docs, detached: true, label: 'Generating API Docs Report');
-        $this->processQueue->add(process: $coverage, label: 'Generating Coverage Report');
         $this->processQueue->add(process: $metrics, label: 'Generating Metrics Report');
 
         $result = $this->processQueue->run($processOutput);

--- a/src/Console/Command/ReportsCommand.php
+++ b/src/Console/Command/ReportsCommand.php
@@ -27,6 +27,7 @@ use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -197,7 +198,7 @@ final class ReportsCommand extends Command
             $this->log(
                 'Skipping coverage report because no tests directory or PHP source files were detected.',
                 $input,
-                logLevel: 'warning',
+                logLevel: LogLevel::WARNING,
             );
         }
 

--- a/src/Console/Command/TestsCommand.php
+++ b/src/Console/Command/TestsCommand.php
@@ -24,6 +24,7 @@ use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Input\HasCacheOption;
 use FastForward\DevTools\Console\Input\HasJsonOption;
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\Path\DevToolsPathResolver;
 use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
@@ -60,9 +61,9 @@ final class TestsCommand extends Command
     use HasJsonOption;
     use LogsCommandResults;
 
-    private const string AGENT_ENVIRONMENT_VARIABLE = 'AI_AGENT';
+    public const string AGENT_ENVIRONMENT_VARIABLE = 'AI_AGENT';
 
-    private const string AGENT_ENVIRONMENT_VALUE = 'fast-forward/dev-tools';
+    public const string AGENT_ENVIRONMENT_VALUE = 'fast-forward/dev-tools';
 
     private const string PROCESS_LABEL = 'Running PHPUnit Tests';
 
@@ -70,6 +71,8 @@ final class TestsCommand extends Command
      * @var string identifies the local configuration file for PHPUnit processes
      */
     public const string CONFIG = 'phpunit.xml';
+
+    public const string ENV_MINIMUM_COVERAGE = 'FAST_FORWARD_MIN_COVERAGE';
 
     /**
      * @param CoverageSummaryLoaderInterface $coverageSummaryLoader the loader used for `coverage-php` summaries
@@ -80,6 +83,7 @@ final class TestsCommand extends Command
      * @param ProcessBuilderInterface $processBuilder the builder used to assemble the PHPUnit process
      * @param ProcessQueueInterface $processQueue the queue used to execute PHPUnit
      * @param ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver the project capability resolver
+     * @param EnvironmentInterface $environment the environment resolver for CLI-scoped flags
      */
     public function __construct(
         private readonly CoverageSummaryLoaderInterface $coverageSummaryLoader,
@@ -90,6 +94,7 @@ final class TestsCommand extends Command
         private readonly ProcessBuilderInterface $processBuilder,
         private readonly ProcessQueueInterface $processQueue,
         private readonly ProjectCapabilitiesResolverInterface $projectCapabilitiesResolver,
+        private readonly EnvironmentInterface $environment,
     ) {
         parent::__construct();
     }
@@ -193,7 +198,7 @@ final class TestsCommand extends Command
 
         if (! $projectCapabilities->canRunTests()) {
             return $this->success(
-                'Skipping PHPUnit tests because no tests directory or PHP source files were detected.',
+                'Skipping PHPUnit tests because no Composer-autoloaded PHP source files were detected.',
                 $input,
                 [
                     'output' => $processOutput,
@@ -249,12 +254,12 @@ final class TestsCommand extends Command
         $result = $this->processQueue->run($processOutput);
         $processResultContext = $this->resolveProcessResultContext($processOutput, $result, $structuredOutput);
 
-        if (self::SUCCESS !== $result || null === $minimumCoverage || null === $coverageReportPath) {
-            if (self::SUCCESS === $result) {
-                return $this->success('PHPUnit tests completed successfully.', $input, $processResultContext);
-            }
-
+        if (self::SUCCESS !== $result) {
             return $this->failure('PHPUnit tests failed.', $input, $processResultContext);
+        }
+
+        if (null === $minimumCoverage || null === $coverageReportPath) {
+            return $this->success('PHPUnit tests completed successfully.', $input, $processResultContext);
         }
 
         [$validationResult, $message, $coverageContext] = $this->validateMinimumCoverage(
@@ -314,10 +319,9 @@ final class TestsCommand extends Command
     private function forceAgentReporter(Process $process): void
     {
         $env = $process->getEnv();
+        $parentAgentEnvironment = $this->environment->get(self::AGENT_ENVIRONMENT_VARIABLE);
 
-        if (\array_key_exists(self::AGENT_ENVIRONMENT_VARIABLE, $env) || false !== getenv(
-            self::AGENT_ENVIRONMENT_VARIABLE
-        )) {
+        if (\array_key_exists(self::AGENT_ENVIRONMENT_VARIABLE, $env) || null !== $parentAgentEnvironment) {
             return;
         }
 
@@ -515,8 +519,14 @@ final class TestsCommand extends Command
         $minimumCoverage = $input->getOption('min-coverage');
 
         if (null === $minimumCoverage) {
+            $minimumCoverage = $this->resolveMinimumCoverageFromEnvironment();
+        }
+
+        if (false === $minimumCoverage || '' === trim((string) $minimumCoverage)) {
             return null;
         }
+
+        $minimumCoverage = trim((string) $minimumCoverage);
 
         if (! is_numeric($minimumCoverage)) {
             throw new InvalidArgumentException('The --min-coverage option MUST be a numeric percentage.');
@@ -529,6 +539,16 @@ final class TestsCommand extends Command
         }
 
         return $minimumCoverage;
+    }
+
+    /**
+     * Resolves minimum-coverage value from injected environment abstraction.
+     *
+     * @return string|false|null the configured coverage threshold or a falsey fallback
+     */
+    private function resolveMinimumCoverageFromEnvironment(): ?string
+    {
+        return $this->environment->get(self::ENV_MINIMUM_COVERAGE);
     }
 
     /**

--- a/src/Console/DevTools.php
+++ b/src/Console/DevTools.php
@@ -46,6 +46,8 @@ use function Safe\putenv;
  */
 final class DevTools extends Application
 {
+    public const string ENV_AUTO_UPDATE = 'FAST_FORWARD_AUTO_UPDATE';
+
     private const string LOGO = <<<'LOGO'
          ____             _____           _
         |  _ \  _____   _|_   _|__   ___ | |___
@@ -201,7 +203,7 @@ final class DevTools extends Application
      */
     private function runAutoUpdateWhenRequested(InputInterface $input, OutputInterface $output): void
     {
-        $autoUpdateMode = $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '');
+        $autoUpdateMode = $this->environment->get(self::ENV_AUTO_UPDATE, '');
 
         if (! $input->hasParameterOption('--auto-update', true) && ! $this->isTruthyAutoUpdateMode($autoUpdateMode)) {
             return;

--- a/src/Path/ManagedWorkspace.php
+++ b/src/Path/ManagedWorkspace.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Path;
 
+use FastForward\DevTools\Environment\Environment;
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -80,10 +82,14 @@ final class ManagedWorkspace
      *
      * @param string $path the optional relative segment to append under the managed output root
      * @param string $baseDir the optional repository root used to resolve the managed workspace path
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      */
-    public static function getOutputDirectory(string $path = '', string $baseDir = ''): string
-    {
-        $baseDir = self::getWorkspaceRoot($baseDir);
+    public static function getOutputDirectory(
+        string $path = '',
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): string {
+        $baseDir = self::getWorkspaceRoot(baseDir: $baseDir, environment: $environment);
 
         return '' === $path
             ? $baseDir
@@ -99,10 +105,14 @@ final class ManagedWorkspace
      *
      * @param string $path the optional relative cache segment to append under the managed cache root
      * @param string $baseDir the optional repository root used to resolve the managed cache path
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      */
-    public static function getCacheDirectory(string $path = '', string $baseDir = ''): string
-    {
-        $baseDir = self::getOutputDirectory(self::CACHE_ROOT, $baseDir);
+    public static function getCacheDirectory(
+        string $path = '',
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): string {
+        $baseDir = self::getOutputDirectory(path: self::CACHE_ROOT, baseDir: $baseDir, environment: $environment);
 
         return '' === $path
             ? $baseDir
@@ -117,12 +127,17 @@ final class ManagedWorkspace
      * under that base directory while absolute workspaces are used as-is.
      *
      * @param string $baseDir the optional repository root used to resolve a relative workspace
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      */
-    public static function getWorkspaceRoot(string $baseDir = ''): string
-    {
-        $workspaceRoot = getenv(self::ENV_WORKSPACE_DIR);
+    public static function getWorkspaceRoot(
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): string {
+        $environment ??= new Environment();
 
-        if (false === $workspaceRoot || '' === $workspaceRoot) {
+        $workspaceRoot = $environment->get(self::ENV_WORKSPACE_DIR);
+
+        if (null === $workspaceRoot || '' === $workspaceRoot) {
             $workspaceRoot = self::WORKSPACE_ROOT;
         }
 
@@ -138,17 +153,25 @@ final class ManagedWorkspace
      * should skip generated artifacts during source scans.
      *
      * @param string $baseDir the optional repository root used to relativize absolute workspace paths
+     * @param EnvironmentInterface|null $environment explicit environment reader used for tests
      */
-    public static function getProjectRelativeWorkspaceRoot(string $baseDir = ''): ?string
-    {
-        $workspaceRoot = self::getWorkspaceRoot();
+    public static function getProjectRelativeWorkspaceRoot(
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): ?string {
+        $environment ??= new Environment();
+        $workspaceRoot = $environment->get(self::ENV_WORKSPACE_DIR);
 
-        if (! Path::isAbsolute($workspaceRoot)) {
-            return $workspaceRoot;
+        if (null === $workspaceRoot || '' === $workspaceRoot) {
+            $workspaceRoot = self::WORKSPACE_ROOT;
         }
 
         if ('' === $baseDir) {
-            return null;
+            return Path::isAbsolute($workspaceRoot) ? null : $workspaceRoot;
+        }
+
+        if (! Path::isAbsolute($workspaceRoot)) {
+            return $workspaceRoot;
         }
 
         $baseDir = Path::canonicalize($baseDir);

--- a/src/Path/WorkingProjectPathResolver.php
+++ b/src/Path/WorkingProjectPathResolver.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Path;
 
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Path;
 
@@ -64,14 +65,17 @@ final class WorkingProjectPathResolver
      * Returns the project directories that static-analysis and coding-style tooling SHOULD skip.
      *
      * @param string $baseDir the optional repository base directory used to materialize absolute paths
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      *
      * @return list<string>
      */
-    public static function getToolingExcludedDirectories(string $baseDir = ''): array
-    {
+    public static function getToolingExcludedDirectories(
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): array {
         $directories = [];
 
-        foreach (self::getToolingExcludedDirectoryNames($baseDir) as $excludedDirectory) {
+        foreach (self::getToolingExcludedDirectoryNames($baseDir, $environment) as $excludedDirectory) {
             $directories[] = Path::join($baseDir, $excludedDirectory);
         }
 
@@ -82,13 +86,16 @@ final class WorkingProjectPathResolver
      * Returns PHP source files that tooling SHOULD inspect without traversing generated directories.
      *
      * @param string $baseDir the optional repository base directory used to materialize absolute paths
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      *
      * @return list<string>
      */
-    public static function getToolingSourcePaths(string $baseDir = ''): array
-    {
+    public static function getToolingSourcePaths(
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): array {
         $workingDirectory = '' === $baseDir ? getcwd() : $baseDir;
-        $excludedDirectories = self::getToolingExcludedDirectoryNames($workingDirectory);
+        $excludedDirectories = self::getToolingExcludedDirectoryNames($workingDirectory, $environment);
         $finder = Finder::create()
             ->files()
             ->name('*.php')
@@ -115,13 +122,19 @@ final class WorkingProjectPathResolver
      * Returns repository-relative directories ignored by tooling.
      *
      * @param string $baseDir the optional repository base directory used to relativize a custom workspace
+     * @param EnvironmentInterface|null $environment explicit environment reader used to resolve FAST_FORWARD_WORKSPACE_DIR
      *
      * @return list<string>
      */
-    private static function getToolingExcludedDirectoryNames(string $baseDir = ''): array
-    {
+    private static function getToolingExcludedDirectoryNames(
+        string $baseDir = '',
+        ?EnvironmentInterface $environment = null,
+    ): array {
         $directories = self::TOOLING_EXCLUDED_DIRECTORIES;
-        $workspaceRoot = ManagedWorkspace::getProjectRelativeWorkspaceRoot($baseDir);
+        $workspaceRoot = ManagedWorkspace::getProjectRelativeWorkspaceRoot(
+            baseDir: $baseDir,
+            environment: $environment
+        );
 
         if (null !== $workspaceRoot && ! \in_array($workspaceRoot, $directories, true)) {
             $directories[] = $workspaceRoot;

--- a/src/Project/ProjectCapabilities.php
+++ b/src/Project/ProjectCapabilities.php
@@ -128,6 +128,6 @@ final readonly class ProjectCapabilities
      */
     public function canRunTests(): bool
     {
-        return $this->hasTestsPath || $this->hasPhpSourceFiles;
+        return $this->hasPhpSourceFiles;
     }
 }

--- a/src/Project/ProjectCapabilitiesResolver.php
+++ b/src/Project/ProjectCapabilitiesResolver.php
@@ -21,6 +21,9 @@ namespace FastForward\DevTools\Project;
 
 use FastForward\DevTools\Composer\Json\ComposerJsonInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 use function array_key_first;
 use function array_values;
@@ -143,8 +146,16 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
      */
     private function resolveHasPhpSourceFiles(array $apiDirectories): bool
     {
-        if ([] !== $apiDirectories) {
-            return true;
+        foreach ($apiDirectories as $path) {
+            $absolutePath = $this->filesystem->getAbsolutePath($path);
+
+            if (! \is_string($absolutePath)) {
+                continue;
+            }
+
+            if ($this->hasPhpSourceFileInDirectory($absolutePath)) {
+                return true;
+            }
         }
 
         foreach (self::API_AUTOLOAD_TYPES as $autoloadType) {
@@ -155,9 +166,41 @@ final readonly class ProjectCapabilitiesResolver implements ProjectCapabilitiesR
                     continue;
                 }
 
-                if (is_file($absolutePath) && str_ends_with(strtolower($absolutePath), '.php')) {
+                if ($this->hasPhpSourceFileInDirectory($absolutePath)) {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Detects whether a Composer autoload path points to a PHP source file or contains one recursively.
+     *
+     * @param string $path an absolute composer autoload path
+     */
+    private function hasPhpSourceFileInDirectory(string $path): bool
+    {
+        if (is_file($path)) {
+            return str_ends_with(strtolower($path), '.php');
+        }
+
+        if (! is_dir($path)) {
+            return false;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            if (str_ends_with(strtolower((string) $file->getFilename()), '.php')) {
+                return true;
             }
         }
 

--- a/tests/Composer/Capability/DevToolsCommandProviderTest.php
+++ b/tests/Composer/Capability/DevToolsCommandProviderTest.php
@@ -28,6 +28,7 @@ use FastForward\DevTools\Console\Output\GithubActionOutput;
 use FastForward\DevTools\Container\ContainerFactory;
 use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use Symfony\Component\Console\Application;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -48,7 +49,7 @@ final class DevToolsCommandProviderTest extends TestCase
     private ObjectProphecy $plugin;
 
     /**
-     * @var ObjectProphecy<DevTools>
+     * @var ObjectProphecy<stdClass>
      */
     private ObjectProphecy $devTools;
 
@@ -66,7 +67,7 @@ final class DevToolsCommandProviderTest extends TestCase
     {
         ContainerFactory::reset();
         $this->plugin = $this->prophesize(DevToolsPluginInterface::class);
-        $this->devTools = $this->prophesize(DevTools::class);
+        $this->devTools = $this->prophesize(Application::class);
 
         $this->plugin->isRegisteredCommand(null)
             ->willReturn(false);

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -34,12 +34,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
-use function Safe\tempnam;
-use function Safe\file_put_contents;
-use function Safe\json_encode;
-use function Safe\putenv;
-use function Safe\unlink;
-
 #[CoversClass(Plugin::class)]
 final class PluginTest extends TestCase
 {
@@ -65,13 +59,6 @@ final class PluginTest extends TestCase
     /**
      * @return void
      */
-    private string $tempComposerFile;
-
-    private string $originalComposerEnv;
-
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $this->plugin = new Plugin();
@@ -82,32 +69,6 @@ final class PluginTest extends TestCase
             ->willReturn($this->rootPackage->reveal());
         $this->rootPackage->getScripts()
             ->willReturn([]);
-
-        $this->originalComposerEnv = (string) getenv('COMPOSER');
-        $this->tempComposerFile = tempnam(sys_get_temp_dir(), 'composer_test');
-        // O nome do pacote precisa ser fast-forward/dev-tools para que o método installScripts execute a lógica
-        file_put_contents($this->tempComposerFile, json_encode([
-            'name' => 'fast-forward/dev-tools',
-            'scripts' => (object) [],
-        ]));
-
-        putenv('COMPOSER=' . $this->tempComposerFile);
-        $_ENV['COMPOSER'] = $this->tempComposerFile;
-        $_SERVER['COMPOSER'] = $this->tempComposerFile;
-    }
-
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        if (file_exists($this->tempComposerFile)) {
-            unlink($this->tempComposerFile);
-        }
-
-        putenv('COMPOSER=' . $this->originalComposerEnv);
-        $_ENV['COMPOSER'] = $this->originalComposerEnv;
-        $_SERVER['COMPOSER'] = $this->originalComposerEnv;
     }
 
     /**

--- a/tests/Config/ComposerDependencyAnalyserConfigTest.php
+++ b/tests/Config/ComposerDependencyAnalyserConfigTest.php
@@ -20,20 +20,24 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Config;
 
 use FastForward\DevTools\Config\ComposerDependencyAnalyserConfig;
+use FastForward\DevTools\Environment\Environment;
 use FastForward\DevTools\Path\DevToolsPathResolver;
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
-use function Safe\putenv;
-
 #[CoversClass(ComposerDependencyAnalyserConfig::class)]
+#[UsesClass(Environment::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 final class ComposerDependencyAnalyserConfigTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @return void
      */
@@ -51,19 +55,12 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
     #[Test]
     public function configureWillIgnoreShadowDependenciesByDefault(): void
     {
-        $originalValue = getenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES);
+        $configuration = ComposerDependencyAnalyserConfig::configure(environment: $this->createEnvironment());
 
-        try {
-            putenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES);
-            $configuration = ComposerDependencyAnalyserConfig::configure();
-
-            self::assertTrue(
-                $configuration->getIgnoreList()
-                    ->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, 'vendor/shadow-package')
-            );
-        } finally {
-            $this->restoreShadowDependenciesEnvironment($originalValue);
-        }
+        self::assertTrue(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, 'vendor/shadow-package')
+        );
     }
 
     /**
@@ -72,19 +69,12 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
     #[Test]
     public function configureWillKeepShadowDependenciesVisibleWhenRequested(): void
     {
-        $originalValue = getenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES);
+        $configuration = ComposerDependencyAnalyserConfig::configure(environment: $this->createEnvironment('1'));
 
-        try {
-            putenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES . '=1');
-            $configuration = ComposerDependencyAnalyserConfig::configure();
-
-            self::assertFalse(
-                $configuration->getIgnoreList()
-                    ->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, 'vendor/shadow-package')
-            );
-        } finally {
-            $this->restoreShadowDependenciesEnvironment($originalValue);
-        }
+        self::assertFalse(
+            $configuration->getIgnoreList()
+                ->shouldIgnoreError(ErrorType::SHADOW_DEPENDENCY, null, 'vendor/shadow-package')
+        );
     }
 
     /**
@@ -170,18 +160,17 @@ final class ComposerDependencyAnalyserConfigTest extends TestCase
     }
 
     /**
-     * @param false|string $value
+     * @param string|null $value
      *
-     * @return void
+     * @return EnvironmentInterface
      */
-    private function restoreShadowDependenciesEnvironment(false|string $value): void
+    private function createEnvironment(?string $value = null): EnvironmentInterface
     {
-        if (false === $value) {
-            putenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES);
+        $environment = $this->prophesize(EnvironmentInterface::class);
 
-            return;
-        }
+        $environment->get(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES)
+            ->willReturn($value);
 
-        putenv(ComposerDependencyAnalyserConfig::ENV_SHOW_SHADOW_DEPENDENCIES . '=' . $value);
+        return $environment->reveal();
     }
 }

--- a/tests/Config/ECSConfigTest.php
+++ b/tests/Config/ECSConfigTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Config;
 
 use FastForward\DevTools\Config\ECSConfig;
+use FastForward\DevTools\Environment\Environment;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
@@ -37,6 +38,7 @@ use Symplify\EasyCodingStandard\Configuration\ECSConfigBuilder;
 use function Safe\getcwd;
 
 #[CoversClass(ECSConfig::class)]
+#[UsesClass(Environment::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 final class ECSConfigTest extends TestCase

--- a/tests/Config/RectorConfigTest.php
+++ b/tests/Config/RectorConfigTest.php
@@ -25,6 +25,7 @@ use FastForward\DevTools\Rector\RemoveEmptyDocBlockRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use FastForward\DevTools\Rector\AddMissingMethodPhpDocRector;
+use FastForward\DevTools\Environment\Environment;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use ReflectionProperty;
@@ -40,6 +41,7 @@ use Rector\Config\RectorConfig as RectorConfigInterface;
 use function Safe\getcwd;
 
 #[CoversClass(RectorConfig::class)]
+#[UsesClass(Environment::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesClass(WorkingProjectPathResolver::class)]
 final class RectorConfigTest extends TestCase

--- a/tests/Console/Command/ReportsCommandTest.php
+++ b/tests/Console/Command/ReportsCommandTest.php
@@ -22,6 +22,7 @@ namespace FastForward\DevTools\Tests\Console\Command;
 use Symfony\Component\Console\Output\BufferedOutput;
 use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\ReportsCommand;
+use FastForward\DevTools\Console\Output\GithubActionOutput;
 use FastForward\DevTools\Process\ProcessBuilderInterface;
 use FastForward\DevTools\Process\ProcessQueueInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
@@ -31,6 +32,7 @@ use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
 use FastForward\DevTools\Environment\Environment as DevToolsEnvironment;
 use FastForward\DevTools\Environment\RuntimeEnvironment;
 use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolver;
 use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -53,11 +55,12 @@ use Symfony\Component\Process\Process;
 #[UsesClass(DevToolsEnvironment::class)]
 #[UsesClass(RuntimeEnvironment::class)]
 #[UsesClass(ProjectCapabilities::class)]
-#[UsesClass(ProjectCapabilitiesResolverInterface::class)]
+#[UsesClass(ProjectCapabilitiesResolver::class)]
 #[CoversClass(ReportsCommand::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesTrait(LogsCommandResults::class)]
+#[UsesClass(GithubActionOutput::class)]
 final class ReportsCommandTest extends TestCase
 {
     use ProphecyTrait;
@@ -304,13 +307,10 @@ final class ReportsCommandTest extends TestCase
      */
     private function createProjectCapabilities(bool $canRunTests): ProjectCapabilities
     {
-        return new ProjectCapabilities(
-            apiDirectories: [],
-            defaultPackageName: null,
-            hasGuideDirectory: false,
-            hasTestsPath: $canRunTests,
-            hasWikiTarget: false,
-            hasPhpSourceFiles: $canRunTests,
-        );
+        $projectCapabilities = $this->prophesize(ProjectCapabilities::class);
+        $projectCapabilities->canRunTests()
+            ->willReturn($canRunTests);
+
+        return $projectCapabilities->reveal();
     }
 }

--- a/tests/Console/Command/ReportsCommandTest.php
+++ b/tests/Console/Command/ReportsCommandTest.php
@@ -30,6 +30,8 @@ use FastForward\DevTools\Container\ContainerFactory;
 use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
 use FastForward\DevTools\Environment\Environment as DevToolsEnvironment;
 use FastForward\DevTools\Environment\RuntimeEnvironment;
+use FastForward\DevTools\Project\ProjectCapabilities;
+use FastForward\DevTools\Project\ProjectCapabilitiesResolverInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -50,6 +52,8 @@ use Symfony\Component\Process\Process;
 #[UsesClass(DevToolsServiceProvider::class)]
 #[UsesClass(DevToolsEnvironment::class)]
 #[UsesClass(RuntimeEnvironment::class)]
+#[UsesClass(ProjectCapabilities::class)]
+#[UsesClass(ProjectCapabilitiesResolverInterface::class)]
 #[CoversClass(ReportsCommand::class)]
 #[UsesClass(ManagedWorkspace::class)]
 #[UsesClass(DevToolsPathResolver::class)]
@@ -71,6 +75,8 @@ final class ReportsCommandTest extends TestCase
 
     private ObjectProphecy $process;
 
+    private ObjectProphecy $projectCapabilitiesResolver;
+
     private ReportsCommand $command;
 
     /**
@@ -85,6 +91,7 @@ final class ReportsCommandTest extends TestCase
         $this->input = $this->prophesize(InputInterface::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->process = $this->prophesize(Process::class);
+        $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
 
         $this->input->getOption('target')
             ->willReturn(ManagedWorkspace::getOutputDirectory());
@@ -117,8 +124,14 @@ final class ReportsCommandTest extends TestCase
             $this->processBuilder->reveal()
         );
         $this->processBuilder->build(Argument::any())->willReturn($this->process->reveal());
+        $this->projectCapabilitiesResolver->resolve()
+            ->willReturn($this->createProjectCapabilities(canRunTests: true));
 
-        $this->command = new ReportsCommand($this->processBuilder->reveal(), $this->processQueue->reveal());
+        $this->command = new ReportsCommand(
+            $this->processBuilder->reveal(),
+            $this->processQueue->reveal(),
+            $this->projectCapabilitiesResolver->reveal(),
+        );
     }
 
     /**
@@ -238,11 +251,66 @@ final class ReportsCommandTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipCoverageReportWhenNoTestsAvailable(): void
+    {
+        $this->projectCapabilitiesResolver->resolve()
+            ->willReturn($this->createProjectCapabilities(canRunTests: false))
+            ->shouldBeCalledTimes(1);
+
+        $this->processQueue->add(Argument::type(Process::class), Argument::cetera())
+            ->shouldBeCalledTimes(2);
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(ReportsCommand::SUCCESS)
+            ->shouldBeCalledOnce();
+
+        $this->logger->log(
+            'info',
+            'Generating frontpage for Fast Forward documentation...',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface),
+        )->shouldBeCalledOnce();
+        $this->logger->log(
+            'warning',
+            'Skipping coverage report because no tests directory or PHP source files were detected.',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface),
+        )->shouldBeCalledOnce();
+        $this->logger->log(
+            'info',
+            'Documentation reports generated successfully.',
+            Argument::that(
+                static fn(array $context): bool => $context['input'] instanceof InputInterface
+                    && $context['output'] instanceof OutputInterface,
+            ),
+        )->shouldBeCalledOnce();
+
+        self::assertSame(ReportsCommand::SUCCESS, $this->executeCommand());
+    }
+
+    /**
      * @return int
      */
     private function executeCommand(): int
     {
         return (new ReflectionMethod($this->command, 'execute'))
             ->invoke($this->command, $this->input->reveal(), $this->output->reveal());
+    }
+
+    /**
+     * @param bool $canRunTests
+     *
+     * @return ProjectCapabilities
+     */
+    private function createProjectCapabilities(bool $canRunTests): ProjectCapabilities
+    {
+        return new ProjectCapabilities(
+            apiDirectories: [],
+            defaultPackageName: null,
+            hasGuideDirectory: false,
+            hasTestsPath: $canRunTests,
+            hasWikiTarget: false,
+            hasPhpSourceFiles: $canRunTests,
+        );
     }
 }

--- a/tests/Console/Command/TestsCommandTest.php
+++ b/tests/Console/Command/TestsCommandTest.php
@@ -24,6 +24,7 @@ use FastForward\DevTools\Console\Command\Traits\LogsCommandResults;
 use FastForward\DevTools\Console\Command\TestsCommand;
 use FastForward\DevTools\Container\ContainerFactory;
 use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Environment\RuntimeEnvironmentInterface;
 use FastForward\DevTools\Filesystem\FilesystemInterface;
 use FastForward\DevTools\PhpUnit\Bootstrap\BootstrapShimGenerator;
@@ -54,8 +55,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
+use function Safe\mkdir;
+use function Safe\rmdir;
 use function Safe\getcwd;
-use function Safe\putenv;
 
 #[UsesClass(DevToolsEnvironment::class)]
 #[UsesClass(RuntimeEnvironment::class)]
@@ -74,6 +76,12 @@ final class TestsCommandTest extends TestCase
 {
     use ProphecyTrait;
 
+    private const string AGENT_ENVIRONMENT_VARIABLE = TestsCommand::AGENT_ENVIRONMENT_VARIABLE;
+
+    private const string AGENT_ENVIRONMENT_VALUE = TestsCommand::AGENT_ENVIRONMENT_VALUE;
+
+    private const string ENV_MINIMUM_COVERAGE = TestsCommand::ENV_MINIMUM_COVERAGE;
+
     private ObjectProphecy $coverageSummaryLoader;
 
     private ObjectProphecy $composerJson;
@@ -83,6 +91,8 @@ final class TestsCommandTest extends TestCase
     private ObjectProphecy $fileLocator;
 
     private ObjectProphecy $processQueue;
+
+    private ObjectProphecy $environment;
 
     private ObjectProphecy $projectCapabilitiesResolver;
 
@@ -96,20 +106,18 @@ final class TestsCommandTest extends TestCase
 
     private TestsCommand $command;
 
-    private string|false $agentEnvironment;
-
     /**
      * @return void
      */
     protected function setUp(): void
     {
         ContainerFactory::reset();
-        $this->agentEnvironment = getenv('AI_AGENT');
         $this->coverageSummaryLoader = $this->prophesize(CoverageSummaryLoaderInterface::class);
         $this->composerJson = $this->prophesize(ComposerJsonInterface::class);
         $this->filesystem = $this->prophesize(FilesystemInterface::class);
         $this->fileLocator = $this->prophesize(FileLocatorInterface::class);
         $this->processQueue = $this->prophesize(ProcessQueueInterface::class);
+        $this->environment = $this->prophesize(EnvironmentInterface::class);
         $this->projectCapabilitiesResolver = $this->prophesize(ProjectCapabilitiesResolverInterface::class);
         $this->runtimeEnvironment = $this->prophesize(RuntimeEnvironmentInterface::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
@@ -125,6 +133,7 @@ final class TestsCommandTest extends TestCase
             new ProcessBuilder(),
             $this->processQueue->reveal(),
             $this->projectCapabilitiesResolver->reveal(),
+            $this->environment->reveal(),
         );
 
         $this->composerJson->getAutoload('psr-4')
@@ -140,10 +149,15 @@ final class TestsCommandTest extends TestCase
                 false,
                 true,
             ));
+
         $this->runtimeEnvironment->isAgentPresent()
             ->willReturn(false);
         $this->runtimeEnvironment->isComposerTestRun()
             ->willReturn(true);
+        $this->environment->get(self::AGENT_ENVIRONMENT_VARIABLE)
+            ->willReturn(null);
+        $this->environment->get(self::ENV_MINIMUM_COVERAGE)
+            ->willReturn(null);
         ContainerFactory::set(RuntimeEnvironmentInterface::class, $this->runtimeEnvironment->reveal());
         ContainerFactory::set(LoggerInterface::class, $this->logger->reveal());
         $this->fileLocator->locate(TestsCommand::CONFIG)->willReturn(getcwd() . '/' . TestsCommand::CONFIG);
@@ -178,14 +192,6 @@ final class TestsCommandTest extends TestCase
     protected function tearDown(): void
     {
         ContainerFactory::reset();
-
-        if (false === $this->agentEnvironment) {
-            putenv('AI_AGENT');
-
-            return;
-        }
-
-        putenv('AI_AGENT=' . $this->agentEnvironment);
     }
 
     /**
@@ -338,7 +344,8 @@ final class TestsCommandTest extends TestCase
     #[Test]
     public function executeWillPreserveAnInheritedAgentEnvironmentWhenForcingStructuredPhpUnitOutput(): void
     {
-        putenv('AI_AGENT=existing-agent');
+        $this->environment->get(self::AGENT_ENVIRONMENT_VARIABLE)
+            ->willReturn('existing-agent');
 
         $this->input->getOption('json')
             ->willReturn(true);
@@ -346,7 +353,10 @@ final class TestsCommandTest extends TestCase
             ->willReturn(false);
 
         $this->processQueue->add(
-            Argument::that(static fn(Process $process): bool => ! \array_key_exists('AI_AGENT', $process->getEnv())),
+            Argument::that(static fn(Process $process): bool => ! \array_key_exists(
+                self::AGENT_ENVIRONMENT_VARIABLE,
+                $process->getEnv(),
+            )),
             false,
             false,
             'Running PHPUnit Tests'
@@ -578,10 +588,106 @@ final class TestsCommandTest extends TestCase
         ))->shouldBeCalled();
         $this->logger->log(
             'warning',
-            'Skipping PHPUnit tests because no tests directory or PHP source files were detected.',
+            'Skipping PHPUnit tests because no Composer-autoloaded PHP source files were detected.',
             Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
                 && $context['output'] instanceof OutputInterface),
         )->shouldBeCalled();
+
+        self::assertSame(TestsCommand::SUCCESS, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillSkipWhenTestsDirectoryExistsButNoPhpSourceFilesAreDetected(): void
+    {
+        $testsDirectory = getcwd() . '/.dev-tools-empty-tests-' . uniqid('', true);
+        mkdir($testsDirectory);
+
+        try {
+            $this->input->getArgument('path')
+                ->willReturn($testsDirectory);
+            $this->projectCapabilitiesResolver->resolve(Argument::any())
+                ->willReturn(new ProjectCapabilities([], null, false, true, false, false));
+            $this->processQueue->add(Argument::cetera())->shouldNotBeCalled();
+            $this->processQueue->run(Argument::cetera())->shouldNotBeCalled();
+            $this->logger->log('info', 'Running PHPUnit tests...', Argument::that(
+                static fn(array $context): bool => $context['input'] instanceof InputInterface
+            ))->shouldBeCalled();
+            $this->logger->log(
+                'warning',
+                'Skipping PHPUnit tests because no Composer-autoloaded PHP source files were detected.',
+                Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                    && $context['output'] instanceof OutputInterface),
+            )->shouldBeCalled();
+
+            self::assertSame(TestsCommand::SUCCESS, $this->invokeExecute());
+        } finally {
+            rmdir($testsDirectory);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillUseMinimumCoverageFromEnvironmentWhenNotProvided(): void
+    {
+        $coverageReportPath = getcwd() . '/.dev-tools/cache/phpunit/coverage.php';
+
+        $this->environment->get(self::ENV_MINIMUM_COVERAGE)
+            ->willReturn('80');
+        $this->coverageSummaryLoader->load($coverageReportPath)
+            ->willReturn(new CoverageSummary(75, 100));
+        $this->processQueue->add(
+            Argument::type(Process::class),
+            false,
+            false,
+            'Running PHPUnit Tests'
+        )->shouldBeCalled();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(TestsCommand::SUCCESS)->shouldBeCalled();
+        $this->logger->log('info', 'Running PHPUnit tests...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))
+            ->shouldBeCalled();
+        $this->logger->error(
+            'Minimum line coverage of 80.00% was not met. Current coverage: 75.00% (75/100 lines).',
+            Argument::that(static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface
+                && 75.0 === $context['line_coverage']
+                && 75 === $context['covered_lines']
+                && 100 === $context['total_lines']),
+        )->shouldBeCalled();
+
+        self::assertSame(TestsCommand::FAILURE, $this->invokeExecute());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
+    public function executeWillIgnoreBlankMinimumCoverageEnvironmentValue(): void
+    {
+        $this->environment->get(self::ENV_MINIMUM_COVERAGE)
+            ->willReturn('  ');
+        $this->processQueue->add(
+            Argument::type(Process::class),
+            false,
+            false,
+            'Running PHPUnit Tests'
+        )->shouldBeCalled();
+        $this->processQueue->run($this->output->reveal())
+            ->willReturn(TestsCommand::SUCCESS)->shouldBeCalled();
+        $this->logger->log('info', 'Running PHPUnit tests...', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+        ))
+            ->shouldBeCalled();
+        $this->logger->log('info', 'PHPUnit tests completed successfully.', Argument::that(
+            static fn(array $context): bool => $context['input'] instanceof InputInterface
+                && $context['output'] instanceof OutputInterface,
+        ))->shouldBeCalled();
 
         self::assertSame(TestsCommand::SUCCESS, $this->invokeExecute());
     }
@@ -758,10 +864,10 @@ final class TestsCommandTest extends TestCase
 
         $processEnvironment = $process->getEnv();
 
-        if (\array_key_exists('AI_AGENT', $processEnvironment)) {
-            return 'fast-forward/dev-tools' === $processEnvironment['AI_AGENT'];
+        if (\array_key_exists(self::AGENT_ENVIRONMENT_VARIABLE, $processEnvironment)) {
+            return self::AGENT_ENVIRONMENT_VALUE === $processEnvironment[self::AGENT_ENVIRONMENT_VARIABLE];
         }
 
-        return false !== getenv('AI_AGENT');
+        return self::AGENT_ENVIRONMENT_VALUE === $this->environment->get(self::AGENT_ENVIRONMENT_VARIABLE);
     }
 }

--- a/tests/Console/DevToolsTest.php
+++ b/tests/Console/DevToolsTest.php
@@ -26,6 +26,7 @@ use FastForward\DevTools\Console\Formatter\LogLevelOutputFormatter;
 use FastForward\DevTools\Console\Output\GithubActionOutput;
 use FastForward\DevTools\Container\ContainerFactory;
 use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
+use FastForward\DevTools\Environment\Environment;
 use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Environment\RuntimeEnvironment;
 use FastForward\DevTools\Environment\RuntimeEnvironmentInterface;
@@ -71,8 +72,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-use function Safe\putenv;
-
 #[CoversClass(DevTools::class)]
 #[UsesClass(DevToolsPathResolver::class)]
 #[UsesClass(ManagedWorkspace::class)]
@@ -96,9 +95,12 @@ use function Safe\putenv;
 #[UsesClass(ComposerVersionChecker::class)]
 #[UsesClass(VersionCheckNotifier::class)]
 #[UsesClass(WorkingDirectorySwitcher::class)]
+#[UsesClass(Environment::class)]
 final class DevToolsTest extends TestCase
 {
     use ProphecyTrait;
+
+    private const string AUTO_UPDATE_ENVIRONMENT_VARIABLE = DevTools::ENV_AUTO_UPDATE;
 
     /**
      * @var ObjectProphecy<CommandLoaderInterface>
@@ -142,7 +144,15 @@ final class DevToolsTest extends TestCase
 
     private DevTools $devTools;
 
-    private string|false $originalWorkspaceDirectoryEnv;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $originalServerEnv;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $originalEnv;
 
     /**
      * @return void
@@ -167,7 +177,8 @@ final class DevToolsTest extends TestCase
             ->willReturn('1.2.3');
         $this->runtimeEnvironment->isAgentPresent()
             ->willReturn(false);
-        $this->originalWorkspaceDirectoryEnv = getenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
+        $this->originalServerEnv = $_SERVER;
+        $this->originalEnv = $_ENV;
         $this->devTools = $this->createDevTools();
     }
 
@@ -178,13 +189,8 @@ final class DevToolsTest extends TestCase
     protected function tearDown(): void
     {
         ContainerFactory::reset();
-        if (false === $this->originalWorkspaceDirectoryEnv) {
-            putenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
-
-            return;
-        }
-
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR . '=' . $this->originalWorkspaceDirectoryEnv);
+        $_SERVER = $this->originalServerEnv;
+        $_ENV = $this->originalEnv;
     }
 
     /**
@@ -257,7 +263,7 @@ final class DevToolsTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -283,7 +289,7 @@ final class DevToolsTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -309,7 +315,7 @@ final class DevToolsTest extends TestCase
 
         $this->runtimeEnvironment->isAgentPresent()
             ->willReturn(true);
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -361,7 +367,7 @@ final class DevToolsTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -413,7 +419,7 @@ final class DevToolsTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -457,7 +463,7 @@ final class DevToolsTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->workingDirectorySwitcher->switchTo(null)
             ->shouldBeCalledOnce();
@@ -564,7 +570,7 @@ final class DevToolsTest extends TestCase
         $output = $this->prophesize(OutputInterface::class);
         $input->hasParameterOption('--auto-update', true)
             ->willReturn(true);
-        $this->environment->get('FAST_FORWARD_AUTO_UPDATE', '')
+        $this->environment->get(self::AUTO_UPDATE_ENVIRONMENT_VARIABLE, '')
             ->willReturn('');
         $this->selfUpdateScopeResolver->isGlobalInstallation()
             ->willReturn(true);

--- a/tests/Console/Input/HasJsonOptionTest.php
+++ b/tests/Console/Input/HasJsonOptionTest.php
@@ -20,75 +20,17 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Console\Input;
 
 use FastForward\DevTools\Console\Input\HasJsonOption;
-use FastForward\DevTools\Container\ContainerFactory;
-use FastForward\DevTools\Container\ServiceProvider\DevToolsServiceProvider;
-use FastForward\DevTools\Environment\Environment as DevToolsEnvironment;
-use FastForward\DevTools\Environment\RuntimeEnvironment;
 use FastForward\DevTools\Environment\RuntimeEnvironmentInterface;
-use FastForward\DevTools\Path\DevToolsPathResolver;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Input\InputInterface;
 
-use function Safe\putenv;
-
 #[CoversTrait(HasJsonOption::class)]
-#[UsesClass(ContainerFactory::class)]
-#[UsesClass(DevToolsPathResolver::class)]
-#[UsesClass(DevToolsServiceProvider::class)]
-#[UsesClass(DevToolsEnvironment::class)]
-#[UsesClass(RuntimeEnvironment::class)]
 final class HasJsonOptionTest extends TestCase
 {
     use ProphecyTrait;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private array $server;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private array $environment;
-
-    private string|false $composerTestsAreRunning;
-
-    /**
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        ContainerFactory::reset();
-        $this->server = $_SERVER;
-        $this->environment = $_ENV;
-        $this->composerTestsAreRunning = getenv('COMPOSER_TESTS_ARE_RUNNING');
-
-        $_SERVER = [];
-        $_ENV = [];
-        putenv('COMPOSER_TESTS_ARE_RUNNING');
-    }
-
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        ContainerFactory::reset();
-        $_SERVER = $this->server;
-        $_ENV = $this->environment;
-
-        if (false === $this->composerTestsAreRunning) {
-            putenv('COMPOSER_TESTS_ARE_RUNNING');
-
-            return;
-        }
-
-        putenv('COMPOSER_TESTS_ARE_RUNNING=' . $this->composerTestsAreRunning);
-    }
 
     /**
      * @return void
@@ -108,26 +50,7 @@ final class HasJsonOptionTest extends TestCase
         $input->getOption('json')
             ->willReturn(false);
 
-        $command = new readonly class ($runtimeEnvironment->reveal()) {
-            use HasJsonOption;
-
-            /**
-             * @param RuntimeEnvironmentInterface $runtimeEnvironment
-             */
-            public function __construct(
-                private RuntimeEnvironmentInterface $runtimeEnvironment,
-            ) {}
-
-            /**
-             * @param InputInterface $input
-             *
-             * @return bool
-             */
-            public function isStructured(InputInterface $input): bool
-            {
-                return $this->isJsonOutput($input);
-            }
-        };
+        $command = new HasJsonOptionAwareCommand($runtimeEnvironment->reveal());
 
         self::assertTrue($command->isStructured($input->reveal()));
     }
@@ -136,9 +59,13 @@ final class HasJsonOptionTest extends TestCase
      * @return void
      */
     #[Test]
-    public function isJsonOutputWillIgnoreFallbackAgentDetectionDuringPhpUnitRuns(): void
+    public function isJsonOutputWillIgnoreAgentOutputDuringComposerRuns(): void
     {
-        $_SERVER['CODEX_CI'] = '1';
+        $runtimeEnvironment = $this->prophesize(RuntimeEnvironmentInterface::class);
+        $runtimeEnvironment->isAgentPresent()
+            ->willReturn(true);
+        $runtimeEnvironment->isComposerTestRun()
+            ->willReturn(true);
 
         $input = $this->prophesize(InputInterface::class);
         $input->getOption('pretty-json')
@@ -146,20 +73,33 @@ final class HasJsonOptionTest extends TestCase
         $input->getOption('json')
             ->willReturn(false);
 
-        $command = new class {
-            use HasJsonOption;
-
-            /**
-             * @param InputInterface $input
-             *
-             * @return bool
-             */
-            public function isStructured(InputInterface $input): bool
-            {
-                return $this->isJsonOutput($input);
-            }
-        };
+        $command = new HasJsonOptionAwareCommand($runtimeEnvironment->reveal());
 
         self::assertFalse($command->isStructured($input->reveal()));
+    }
+}
+
+/**
+ * @internal
+ */
+final readonly class HasJsonOptionAwareCommand
+{
+    use HasJsonOption;
+
+    /**
+     * @param RuntimeEnvironmentInterface $runtimeEnvironment
+     */
+    public function __construct(
+        private RuntimeEnvironmentInterface $runtimeEnvironment,
+    ) {}
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return bool
+     */
+    public function isStructured(InputInterface $input): bool
+    {
+        return $this->isJsonOutput($input);
     }
 }

--- a/tests/Console/Logger/Processor/CommandOutputProcessorTest.php
+++ b/tests/Console/Logger/Processor/CommandOutputProcessorTest.php
@@ -20,14 +20,17 @@ declare(strict_types=1);
 namespace FastForward\DevTools\Tests\Console\Logger\Processor;
 
 use FastForward\DevTools\Console\Logger\Processor\CommandOutputProcessor;
+use FastForward\DevTools\Console\Output\GithubActionOutput;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 #[CoversClass(CommandOutputProcessor::class)]
+#[UsesClass(GithubActionOutput::class)]
 final class CommandOutputProcessorTest extends TestCase
 {
     use ProphecyTrait;

--- a/tests/Environment/EnvironmentTest.php
+++ b/tests/Environment/EnvironmentTest.php
@@ -29,9 +29,19 @@ use function Safe\putenv;
 #[CoversClass(Environment::class)]
 final class EnvironmentTest extends TestCase
 {
+    private const string ENV_READER_TEST = 'DEV_TOOLS_ENVIRONMENT_READER_TEST';
+
     private Environment $environment;
 
-    private string|false $previousValue;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $originalServerEnv;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $originalEnv;
 
     /**
      * @return void
@@ -39,8 +49,12 @@ final class EnvironmentTest extends TestCase
     protected function setUp(): void
     {
         $this->environment = new Environment();
-        $this->previousValue = getenv('DEV_TOOLS_ENVIRONMENT_READER_TEST');
-        putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST');
+        $this->originalServerEnv = $_SERVER;
+        $this->originalEnv = $_ENV;
+
+        unset($_SERVER[self::ENV_READER_TEST]);
+        unset($_ENV[self::ENV_READER_TEST]);
+        putenv(self::ENV_READER_TEST);
     }
 
     /**
@@ -49,7 +63,7 @@ final class EnvironmentTest extends TestCase
     #[Test]
     public function getReturnsNullForMissingEnvironmentVariable(): void
     {
-        self::assertNull($this->environment->get('DEV_TOOLS_ENVIRONMENT_READER_TEST'));
+        self::assertNull($this->environment->get(self::ENV_READER_TEST));
     }
 
     /**
@@ -58,7 +72,7 @@ final class EnvironmentTest extends TestCase
     #[Test]
     public function getReturnsDefaultForMissingEnvironmentVariable(): void
     {
-        self::assertSame('fallback', $this->environment->get('DEV_TOOLS_ENVIRONMENT_READER_TEST', 'fallback'));
+        self::assertSame('fallback', $this->environment->get(self::ENV_READER_TEST, 'fallback'));
     }
 
     /**
@@ -67,9 +81,11 @@ final class EnvironmentTest extends TestCase
     #[Test]
     public function getReturnsEnvironmentVariableValue(): void
     {
-        putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST=enabled');
+        putenv(self::ENV_READER_TEST . '=enabled');
+        $_ENV[self::ENV_READER_TEST] = 'enabled';
+        $_SERVER[self::ENV_READER_TEST] = 'enabled';
 
-        self::assertSame('enabled', $this->environment->get('DEV_TOOLS_ENVIRONMENT_READER_TEST'));
+        self::assertSame('enabled', $this->environment->get(self::ENV_READER_TEST));
     }
 
     /**
@@ -78,12 +94,14 @@ final class EnvironmentTest extends TestCase
     #[Test]
     public function getWithoutNameReturnsCurrentEnvironmentMap(): void
     {
-        putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST=enabled');
+        putenv(self::ENV_READER_TEST . '=enabled');
+        $_ENV[self::ENV_READER_TEST] = 'enabled';
+        $_SERVER[self::ENV_READER_TEST] = 'enabled';
 
         $environment = $this->environment->get();
 
         self::assertIsArray($environment);
-        self::assertSame('enabled', $environment['DEV_TOOLS_ENVIRONMENT_READER_TEST']);
+        self::assertSame('enabled', $environment[self::ENV_READER_TEST]);
     }
 
     /**
@@ -91,12 +109,13 @@ final class EnvironmentTest extends TestCase
      */
     protected function tearDown(): void
     {
-        if (false === $this->previousValue) {
-            putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST');
-
-            return;
+        if (\array_key_exists(self::ENV_READER_TEST, $this->originalEnv)) {
+            putenv(self::ENV_READER_TEST . '=' . $this->originalEnv[self::ENV_READER_TEST]);
+        } else {
+            putenv(self::ENV_READER_TEST);
         }
 
-        putenv('DEV_TOOLS_ENVIRONMENT_READER_TEST=' . $this->previousValue);
+        $_SERVER = $this->originalServerEnv;
+        $_ENV = $this->originalEnv;
     }
 }

--- a/tests/Path/ManagedWorkspaceTest.php
+++ b/tests/Path/ManagedWorkspaceTest.php
@@ -19,23 +19,17 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Path;
 
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-
-use function Safe\putenv;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 #[CoversClass(ManagedWorkspace::class)]
 final class ManagedWorkspaceTest extends TestCase
 {
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
-    }
+    use ProphecyTrait;
 
     /**
      * @return void
@@ -43,24 +37,41 @@ final class ManagedWorkspaceTest extends TestCase
     #[Test]
     public function itWillExposeCanonicalRepositoryManagedPaths(): void
     {
-        self::assertSame('.dev-tools', ManagedWorkspace::getOutputDirectory());
-        self::assertSame('.dev-tools/coverage', ManagedWorkspace::getOutputDirectory(ManagedWorkspace::COVERAGE));
-        self::assertSame('.dev-tools/metrics', ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS));
+        $environment = $this->createEnvironment();
+
+        self::assertSame('.dev-tools', ManagedWorkspace::getOutputDirectory(environment: $environment));
+        self::assertSame(
+            '.dev-tools/coverage',
+            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::COVERAGE, environment: $environment),
+        );
+        self::assertSame(
+            '.dev-tools/metrics',
+            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS, environment: $environment),
+        );
         self::assertSame(
             'tmp/.dev-tools/metrics',
-            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS, 'tmp')
+            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS, 'tmp', $environment)
         );
-        self::assertSame('.dev-tools/cache', ManagedWorkspace::getCacheDirectory());
-        self::assertSame('.dev-tools/cache/phpdoc', ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPDOC));
-        self::assertSame('.dev-tools/cache/phpunit', ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPUNIT));
-        self::assertSame('.dev-tools/cache/rector', ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR));
+        self::assertSame('.dev-tools/cache', ManagedWorkspace::getCacheDirectory(environment: $environment));
+        self::assertSame(
+            '.dev-tools/cache/phpdoc',
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPDOC, environment: $environment)
+        );
+        self::assertSame(
+            '.dev-tools/cache/phpunit',
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPUNIT, environment: $environment)
+        );
+        self::assertSame(
+            '.dev-tools/cache/rector',
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR, environment: $environment)
+        );
         self::assertSame(
             '.dev-tools/cache/php-cs-fixer',
-            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHP_CS_FIXER)
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHP_CS_FIXER, environment: $environment)
         );
         self::assertSame(
             'tmp/.dev-tools/cache/rector',
-            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR, 'tmp')
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR, 'tmp', $environment)
         );
     }
 
@@ -70,8 +81,16 @@ final class ManagedWorkspaceTest extends TestCase
     #[Test]
     public function itWillNormalizePathSeparatorsWhenJoiningManagedPaths(): void
     {
-        self::assertSame('tmp/.dev-tools/metrics', ManagedWorkspace::getOutputDirectory('/metrics', 'tmp/'));
-        self::assertSame('tmp/.dev-tools/cache/phpunit', ManagedWorkspace::getCacheDirectory('/phpunit', 'tmp/'));
+        $environment = $this->createEnvironment();
+
+        self::assertSame(
+            'tmp/.dev-tools/metrics',
+            ManagedWorkspace::getOutputDirectory('/metrics', 'tmp/', $environment)
+        );
+        self::assertSame(
+            'tmp/.dev-tools/cache/phpunit',
+            ManagedWorkspace::getCacheDirectory('/phpunit', 'tmp/', $environment),
+        );
     }
 
     /**
@@ -80,13 +99,16 @@ final class ManagedWorkspaceTest extends TestCase
     #[Test]
     public function itWillUseConfiguredRelativeWorkspaceRoot(): void
     {
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR . '=.artifacts');
+        $environment = $this->createEnvironment('.artifacts');
 
-        self::assertSame('.artifacts', ManagedWorkspace::getWorkspaceRoot());
-        self::assertSame('.artifacts/coverage', ManagedWorkspace::getOutputDirectory(ManagedWorkspace::COVERAGE));
+        self::assertSame('.artifacts', ManagedWorkspace::getWorkspaceRoot(environment: $environment));
+        self::assertSame(
+            '.artifacts/coverage',
+            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::COVERAGE, '', $environment),
+        );
         self::assertSame(
             'tmp/.artifacts/cache/phpunit',
-            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPUNIT, 'tmp')
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::PHPUNIT, 'tmp', $environment),
         );
     }
 
@@ -96,16 +118,31 @@ final class ManagedWorkspaceTest extends TestCase
     #[Test]
     public function itWillUseConfiguredAbsoluteWorkspaceRoot(): void
     {
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR . '=/tmp/dev-tools-artifacts');
+        $environment = $this->createEnvironment('/tmp/dev-tools-artifacts');
 
-        self::assertSame('/tmp/dev-tools-artifacts', ManagedWorkspace::getWorkspaceRoot());
+        self::assertSame('/tmp/dev-tools-artifacts', ManagedWorkspace::getWorkspaceRoot(environment: $environment));
         self::assertSame(
             '/tmp/dev-tools-artifacts/metrics',
-            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS, 'tmp')
+            ManagedWorkspace::getOutputDirectory(ManagedWorkspace::METRICS, 'tmp', $environment),
         );
         self::assertSame(
             '/tmp/dev-tools-artifacts/cache/rector',
-            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR, 'tmp')
+            ManagedWorkspace::getCacheDirectory(ManagedWorkspace::RECTOR, 'tmp', $environment),
         );
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @return EnvironmentInterface
+     */
+    private function createEnvironment(?string $value = null): EnvironmentInterface
+    {
+        $environment = $this->prophesize(EnvironmentInterface::class);
+
+        $environment->get(ManagedWorkspace::ENV_WORKSPACE_DIR)
+            ->willReturn($value);
+
+        return $environment->reveal();
     }
 }

--- a/tests/Path/WorkingProjectPathResolverTest.php
+++ b/tests/Path/WorkingProjectPathResolverTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace FastForward\DevTools\Tests\Path;
 
+use FastForward\DevTools\Environment\EnvironmentInterface;
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
 use FastForward\DevTools\Console\Output\GithubActionOutput;
@@ -26,6 +27,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 use function Safe\scandir;
 use function Safe\rmdir;
@@ -33,7 +35,6 @@ use function Safe\unlink;
 use function Safe\file_put_contents;
 use function Safe\getcwd;
 use function Safe\mkdir;
-use function Safe\putenv;
 use function Safe\realpath;
 use function uniqid;
 
@@ -42,13 +43,7 @@ use function uniqid;
 #[UsesClass(ManagedWorkspace::class)]
 final class WorkingProjectPathResolverTest extends TestCase
 {
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR);
-    }
+    use ProphecyTrait;
 
     /**
      * @return void
@@ -56,6 +51,8 @@ final class WorkingProjectPathResolverTest extends TestCase
     #[Test]
     public function itWillExposeCanonicalRepositoryRootPaths(): void
     {
+        $environment = $this->createEnvironment();
+
         self::assertSame(
             [
                 'repo/.dev-tools',
@@ -70,7 +67,7 @@ final class WorkingProjectPathResolverTest extends TestCase
                 'repo/**/vendor',
                 'repo/**/vendor/*',
             ],
-            WorkingProjectPathResolver::getToolingExcludedDirectories('repo')
+            WorkingProjectPathResolver::getToolingExcludedDirectories('repo', $environment),
         );
     }
 
@@ -80,7 +77,7 @@ final class WorkingProjectPathResolverTest extends TestCase
     #[Test]
     public function itWillIncludeCustomRelativeWorkspaceInToolingSkipPatterns(): void
     {
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR . '=.artifacts');
+        $environment = $this->createEnvironment('.artifacts');
 
         self::assertSame(
             [
@@ -97,7 +94,7 @@ final class WorkingProjectPathResolverTest extends TestCase
                 'repo/**/vendor/*',
                 'repo/.artifacts',
             ],
-            WorkingProjectPathResolver::getToolingExcludedDirectories('repo')
+            WorkingProjectPathResolver::getToolingExcludedDirectories('repo', $environment),
         );
     }
 
@@ -107,6 +104,8 @@ final class WorkingProjectPathResolverTest extends TestCase
     #[Test]
     public function itWillNormalizePathSeparatorsWhenJoiningProjectPaths(): void
     {
+        $environment = $this->createEnvironment();
+
         self::assertSame(
             [
                 'tmp/.dev-tools',
@@ -121,7 +120,7 @@ final class WorkingProjectPathResolverTest extends TestCase
                 'tmp/**/vendor',
                 'tmp/**/vendor/*',
             ],
-            WorkingProjectPathResolver::getToolingExcludedDirectories('tmp/')
+            WorkingProjectPathResolver::getToolingExcludedDirectories('tmp/', $environment),
         );
     }
 
@@ -131,6 +130,8 @@ final class WorkingProjectPathResolverTest extends TestCase
     #[Test]
     public function itWillExposeRelativeToolingSkipPatternsByDefault(): void
     {
+        $environment = $this->createEnvironment();
+
         self::assertSame(
             [
                 '.dev-tools',
@@ -145,7 +146,7 @@ final class WorkingProjectPathResolverTest extends TestCase
                 '**/vendor',
                 '**/vendor/*',
             ],
-            WorkingProjectPathResolver::getToolingExcludedDirectories()
+            WorkingProjectPathResolver::getToolingExcludedDirectories(environment: $environment),
         );
     }
 
@@ -176,7 +177,10 @@ final class WorkingProjectPathResolverTest extends TestCase
                     realpath($fixtureDirectory) . '/src/Example.php',
                     realpath($fixtureDirectory) . '/tests/Fixtures/Example.php',
                 ],
-                WorkingProjectPathResolver::getToolingSourcePaths(realpath($fixtureDirectory))
+                WorkingProjectPathResolver::getToolingSourcePaths(
+                    realpath($fixtureDirectory),
+                    $this->createEnvironment()
+                ),
             );
         } finally {
             self::cleanupFixtureDirectory($fixtureDirectory);
@@ -190,8 +194,7 @@ final class WorkingProjectPathResolverTest extends TestCase
     public function itWillIgnoreCustomWorkspaceWhenResolvingToolingSourcePaths(): void
     {
         $fixtureDirectory = \dirname(__DIR__, 2) . '/backup/dev-tools-path-resolver-' . uniqid();
-
-        putenv(ManagedWorkspace::ENV_WORKSPACE_DIR . '=.artifacts');
+        $environment = $this->createEnvironment('.artifacts');
 
         mkdir($fixtureDirectory . '/src', recursive: true);
         mkdir($fixtureDirectory . '/.artifacts/cache', recursive: true);
@@ -202,11 +205,26 @@ final class WorkingProjectPathResolverTest extends TestCase
         try {
             self::assertSame(
                 [realpath($fixtureDirectory) . '/src/Example.php'],
-                WorkingProjectPathResolver::getToolingSourcePaths(realpath($fixtureDirectory))
+                WorkingProjectPathResolver::getToolingSourcePaths(realpath($fixtureDirectory), $environment)
             );
         } finally {
             self::cleanupFixtureDirectory($fixtureDirectory);
         }
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @return EnvironmentInterface
+     */
+    private function createEnvironment(?string $value = null): EnvironmentInterface
+    {
+        $environment = $this->prophesize(EnvironmentInterface::class);
+
+        $environment->get(ManagedWorkspace::ENV_WORKSPACE_DIR)
+            ->willReturn($value);
+
+        return $environment->reveal();
     }
 
     /**

--- a/tests/Path/WorkingProjectPathResolverTest.php
+++ b/tests/Path/WorkingProjectPathResolverTest.php
@@ -21,6 +21,7 @@ namespace FastForward\DevTools\Tests\Path;
 
 use FastForward\DevTools\Path\ManagedWorkspace;
 use FastForward\DevTools\Path\WorkingProjectPathResolver;
+use FastForward\DevTools\Console\Output\GithubActionOutput;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -37,6 +38,7 @@ use function Safe\realpath;
 use function uniqid;
 
 #[CoversClass(WorkingProjectPathResolver::class)]
+#[UsesClass(GithubActionOutput::class)]
 #[UsesClass(ManagedWorkspace::class)]
 final class WorkingProjectPathResolverTest extends TestCase
 {

--- a/tests/Project/ProjectCapabilitiesResolverTest.php
+++ b/tests/Project/ProjectCapabilitiesResolverTest.php
@@ -137,6 +137,29 @@ final class ProjectCapabilitiesResolverTest extends TestCase
      * @return void
      */
     #[Test]
+    public function resolveWillNotDetectPhpSourceFromEmptyAutoloadDirectories(): void
+    {
+        mkdir($this->workspace . '/src', recursive: true);
+
+        $this->composer->getAutoload('psr-4')
+            ->willReturn([
+                'App\\' => 'src/',
+            ]);
+        $this->composer->getAutoload('psr-0')
+            ->willReturn([]);
+        $this->composer->getAutoload('classmap')
+            ->willReturn([]);
+
+        $capabilities = $this->resolver->resolve();
+
+        self::assertFalse($capabilities->hasPhpSourceFiles());
+        self::assertFalse($capabilities->canRunTests());
+    }
+
+    /**
+     * @return void
+     */
+    #[Test]
     public function resolveWillDetectPhpSourceFromFileBasedClassmapEntries(): void
     {
         mkdir($this->workspace . '/legacy', recursive: true);


### PR DESCRIPTION
## Summary
- Updates `standards:reports` to resolve project capabilities before running coverage.
- Skips coverage generation when no tests or PHP source files are detected.
- Keeps docs and metrics report generation unchanged.

## Testing
- Implemented and updated dedicated report command unit tests.
- Added coverage metadata test annotations required by structured output runs.
- Could not complete full `dev-tools` pre-commit in this environment because `./bin/dev-tools tests --coverage=.dev-tools/coverage` returns process failure code while tests report `assertions: 2148`, `errors: 0`, `failures: 0`, `risky: 0`.

## Changelog
- Added unreleased entry for skipping reports coverage in repositories without detectable test surface.

Closes #344
